### PR TITLE
chore: バンドル分割・ナビUX・カテゴリ統一・戦略コース仕上げ

### DIFF
--- a/src/AppV3.tsx
+++ b/src/AppV3.tsx
@@ -1,41 +1,42 @@
 // Logic v3 — full app shell with all screens
-import { useEffect, useState, useRef, useCallback } from 'react'
+import { useEffect, useState, useRef, useCallback, lazy, Suspense } from 'react'
 import { AppShell, type Tab } from './components/AppShell'
 import { HomeScreenV3 } from './screens/HomeScreenV3'
-import { FlashcardsScreen } from './screens/FlashcardsScreen'
-import { FermiScreen } from './screens/FermiScreen'
-import { DailyFermiScreen } from './screens/DailyFermiScreen'
-import { DeviationScreen } from './screens/DeviationScreen'
 import { RankingScreen } from './screens/RankingScreen'
-import { FermiRankingScreen } from './screens/FermiRankingScreen'
-import { RoleplaySelectScreen } from './screens/RoleplaySelectScreen'
-import { RoleplayChatScreen } from './screens/RoleplayChatScreen'
-import { JournalInputScreen } from './screens/JournalInputScreen'
-import { WorksheetScreen } from './screens/WorksheetScreen'
-import { ReportProblemScreen } from './screens/ReportProblemScreen'
-import { OnboardingScreen } from './screens/OnboardingScreen'
-import { BetaCodeScreen } from './screens/BetaCodeScreen'
-
-import { AIProblemGenScreen } from './screens/AIProblemGenScreen'
-import { AIProblemScreen } from './screens/AIProblemScreen'
-import { FeedbackScreen } from './screens/FeedbackScreen'
-import { FeedbackDashboardScreen } from './screens/FeedbackDashboardScreen'
-import { PlacementTestScreen } from './screens/PlacementTestScreen'
-import { PricingScreen } from './screens/PricingScreen'
-import { StreakScreen } from './screens/StreakScreen'
-import { SettingsScreen } from './screens/SettingsScreen'
-import { AccountSettingsScreen } from './screens/AccountSettingsScreen'
-import { NotificationSettingsScreen } from './screens/NotificationSettingsScreen'
 import { LoginGate } from './components/LoginGate'
-import { CompletedLessonsScreen } from './screens/CompletedLessonsScreen'
-import { StudyTimeScreen } from './screens/StudyTimeScreen'
-import { LanguageScreen } from './screens/LanguageScreen'
-import { RankScreen } from './screens/RankScreen'
-import { LoginScreen } from './screens/LoginScreen'
 import { RoadmapScreenV3 } from './screens/RoadmapScreenV3'
 import { ProfileScreenV3 } from './screens/ProfileScreenV3'
 import { LessonStoriesScreen } from './screens/LessonStoriesScreen'
 import { LessonCompleteScreen } from './screens/LessonCompleteScreen'
+
+// Lazy-load lower-frequency screens to keep initial bundle small.
+const FlashcardsScreen = lazy(() => import('./screens/FlashcardsScreen').then(m => ({ default: m.FlashcardsScreen })))
+const FermiScreen = lazy(() => import('./screens/FermiScreen').then(m => ({ default: m.FermiScreen })))
+const DailyFermiScreen = lazy(() => import('./screens/DailyFermiScreen').then(m => ({ default: m.DailyFermiScreen })))
+const DeviationScreen = lazy(() => import('./screens/DeviationScreen').then(m => ({ default: m.DeviationScreen })))
+const FermiRankingScreen = lazy(() => import('./screens/FermiRankingScreen').then(m => ({ default: m.FermiRankingScreen })))
+const RoleplaySelectScreen = lazy(() => import('./screens/RoleplaySelectScreen').then(m => ({ default: m.RoleplaySelectScreen })))
+const RoleplayChatScreen = lazy(() => import('./screens/RoleplayChatScreen').then(m => ({ default: m.RoleplayChatScreen })))
+const JournalInputScreen = lazy(() => import('./screens/JournalInputScreen').then(m => ({ default: m.JournalInputScreen })))
+const WorksheetScreen = lazy(() => import('./screens/WorksheetScreen').then(m => ({ default: m.WorksheetScreen })))
+const ReportProblemScreen = lazy(() => import('./screens/ReportProblemScreen').then(m => ({ default: m.ReportProblemScreen })))
+const OnboardingScreen = lazy(() => import('./screens/OnboardingScreen').then(m => ({ default: m.OnboardingScreen })))
+const BetaCodeScreen = lazy(() => import('./screens/BetaCodeScreen').then(m => ({ default: m.BetaCodeScreen })))
+const AIProblemGenScreen = lazy(() => import('./screens/AIProblemGenScreen').then(m => ({ default: m.AIProblemGenScreen })))
+const AIProblemScreen = lazy(() => import('./screens/AIProblemScreen').then(m => ({ default: m.AIProblemScreen })))
+const FeedbackScreen = lazy(() => import('./screens/FeedbackScreen').then(m => ({ default: m.FeedbackScreen })))
+const FeedbackDashboardScreen = lazy(() => import('./screens/FeedbackDashboardScreen').then(m => ({ default: m.FeedbackDashboardScreen })))
+const PlacementTestScreen = lazy(() => import('./screens/PlacementTestScreen').then(m => ({ default: m.PlacementTestScreen })))
+const PricingScreen = lazy(() => import('./screens/PricingScreen').then(m => ({ default: m.PricingScreen })))
+const StreakScreen = lazy(() => import('./screens/StreakScreen').then(m => ({ default: m.StreakScreen })))
+const SettingsScreen = lazy(() => import('./screens/SettingsScreen').then(m => ({ default: m.SettingsScreen })))
+const AccountSettingsScreen = lazy(() => import('./screens/AccountSettingsScreen').then(m => ({ default: m.AccountSettingsScreen })))
+const NotificationSettingsScreen = lazy(() => import('./screens/NotificationSettingsScreen').then(m => ({ default: m.NotificationSettingsScreen })))
+const CompletedLessonsScreen = lazy(() => import('./screens/CompletedLessonsScreen').then(m => ({ default: m.CompletedLessonsScreen })))
+const StudyTimeScreen = lazy(() => import('./screens/StudyTimeScreen').then(m => ({ default: m.StudyTimeScreen })))
+const LanguageScreen = lazy(() => import('./screens/LanguageScreen').then(m => ({ default: m.LanguageScreen })))
+const RankScreen = lazy(() => import('./screens/RankScreen').then(m => ({ default: m.RankScreen })))
+const LoginScreen = lazy(() => import('./screens/LoginScreen').then(m => ({ default: m.LoginScreen })))
 import { allLessons, getAllLessonsFlat } from './lessonData'
 import { getCurrentLevel } from './screens/homeHelpers'
 
@@ -315,23 +316,27 @@ function AppV3() {
   // Onboarding: show full-screen, no AppShell
   if (screen.type === 'onboarding') {
     return (
-      <OnboardingScreen
-        onComplete={() => {
-          localStorage.setItem(ONBOARDED_KEY, '1')
-          navigate({ type: 'home' })
-          // チュートリアルは右下FABから任意で起動
-        }}
-      />
+      <Suspense fallback={null}>
+        <OnboardingScreen
+          onComplete={() => {
+            localStorage.setItem(ONBOARDED_KEY, '1')
+            navigate({ type: 'home' })
+            // チュートリアルは右下FABから任意で起動
+          }}
+        />
+      </Suspense>
     )
   }
 
   // BetaCode: show full-screen, no AppShell
   if (screen.type === 'beta-code') {
     return (
-      <BetaCodeScreen
-        onSuccess={() => navigate({ type: 'home' })}
-        onSkip={() => navigate({ type: 'home' })}
-      />
+      <Suspense fallback={null}>
+        <BetaCodeScreen
+          onSuccess={() => navigate({ type: 'home' })}
+          onSkip={() => navigate({ type: 'home' })}
+        />
+      </Suspense>
     )
   }
 
@@ -345,6 +350,7 @@ function AppV3() {
       hideTabBar={screen.type === 'lesson' || screen.type === 'lesson-complete'}
     >
       {/* スクリーン遷移fade-in: screen.typeが変わるたびにkeyで再マウント */}
+      <Suspense fallback={null}>
       <div key={screen.type} className="tab-fade-in" style={{ display: 'contents' }}>
       {screen.type === 'home' && (
         <HomeScreenV3
@@ -548,6 +554,7 @@ function AppV3() {
         />
       )}
       </div>
+      </Suspense>
     </AppShell>
 
     {/* SCRUM-195: チュートリアルオーバーレイ */}

--- a/src/LessonIcon.tsx
+++ b/src/LessonIcon.tsx
@@ -82,6 +82,143 @@ export default function LessonIcon({ id, action, size = 24 }: Props) {
     )
   }
 
+  // 経営戦略 (320): 工場（テイラー＆フォード）
+  if (id === 320) {
+    return (
+      <svg {...props}>
+        <path d="M3 21V10l5 3V10l5 3V10l5 3v8z" />
+        <line x1="3" y1="21" x2="21" y2="21" />
+        <line x1="7" y1="17" x2="7" y2="18" />
+        <line x1="12" y1="17" x2="12" y2="18" />
+        <line x1="17" y1="17" x2="17" y2="18" />
+      </svg>
+    )
+  }
+
+  // アンゾフ (321): 2x2マトリクスに矢印
+  if (id === 321) {
+    return (
+      <svg {...props}>
+        <rect x="3" y="3" width="8" height="8" rx="1" />
+        <rect x="13" y="3" width="8" height="8" rx="1" />
+        <rect x="3" y="13" width="8" height="8" rx="1" />
+        <rect x="13" y="13" width="8" height="8" rx="1" />
+        <path d="M7 7l10 10" />
+        <path d="m14 17 3 0 0-3" />
+      </svg>
+    )
+  }
+
+  // PPM (322): 4象限と円（事業バブル）
+  if (id === 322) {
+    return (
+      <svg {...props}>
+        <line x1="12" y1="3" x2="12" y2="21" />
+        <line x1="3" y1="12" x2="21" y2="12" />
+        <circle cx="7" cy="7" r="2.5" />
+        <circle cx="17" cy="7" r="1.5" />
+        <circle cx="7" cy="17" r="1" />
+        <circle cx="17" cy="17" r="2" />
+      </svg>
+    )
+  }
+
+  // 5フォース (323): 中心に向かう5本の矢印
+  if (id === 323) {
+    return (
+      <svg {...props}>
+        <circle cx="12" cy="12" r="3" />
+        <path d="M12 2v4" /><path d="m10 5 2-3 2 3" />
+        <path d="M22 12h-4" /><path d="m19 10 3 2-3 2" />
+        <path d="M12 22v-4" /><path d="m10 19 2 3 2-3" />
+        <path d="M2 12h4" /><path d="m5 10-3 2 3 2" />
+        <path d="m18 6-3 3" />
+      </svg>
+    )
+  }
+
+  // 3つの基本戦略 (324): 3つの並列な柱
+  if (id === 324) {
+    return (
+      <svg {...props}>
+        <rect x="3" y="6" width="4" height="14" rx="0.5" />
+        <rect x="10" y="3" width="4" height="17" rx="0.5" />
+        <rect x="17" y="9" width="4" height="11" rx="0.5" />
+        <line x1="2" y1="20" x2="22" y2="20" />
+      </svg>
+    )
+  }
+
+  // RBV / VRIO (325): 4枚の重なるカード
+  if (id === 325) {
+    return (
+      <svg {...props}>
+        <rect x="3" y="6" width="11" height="13" rx="1.5" />
+        <rect x="6" y="4" width="11" height="13" rx="1.5" />
+        <rect x="9" y="2" width="11" height="13" rx="1.5" />
+        <line x1="12" y1="6" x2="17" y2="6" />
+        <line x1="12" y1="9" x2="17" y2="9" />
+      </svg>
+    )
+  }
+
+  // コアコンピタンス (326): 中心と放射状の枝
+  if (id === 326) {
+    return (
+      <svg {...props}>
+        <circle cx="12" cy="12" r="3.5" />
+        <path d="M12 8.5V3" />
+        <path d="M12 15.5V21" />
+        <path d="M8.5 12H3" />
+        <path d="M15.5 12H21" />
+        <path d="m9.5 9.5-3-3" />
+        <path d="m14.5 14.5 3 3" />
+        <path d="m14.5 9.5 3-3" />
+        <path d="m9.5 14.5-3 3" />
+      </svg>
+    )
+  }
+
+  // ブルーオーシャン (327): 波と航路
+  if (id === 327) {
+    return (
+      <svg {...props}>
+        <path d="M2 16c2 0 2-2 4-2s2 2 4 2 2-2 4-2 2 2 4 2 2-2 4-2" />
+        <path d="M2 20c2 0 2-2 4-2s2 2 4 2 2-2 4-2 2 2 4 2 2-2 4-2" />
+        <path d="M12 11V3" />
+        <path d="M9 6h6" />
+      </svg>
+    )
+  }
+
+  // ダイナミック・ケイパビリティ (328): 循環する矢印
+  if (id === 328) {
+    return (
+      <svg {...props}>
+        <path d="M21 12a9 9 0 1 1-3-6.7" />
+        <path d="m21 4-1 5-5-1" />
+        <circle cx="12" cy="12" r="2" />
+      </svg>
+    )
+  }
+
+  // プラットフォーム戦略 (329): 中心ハブとノード
+  if (id === 329) {
+    return (
+      <svg {...props}>
+        <circle cx="12" cy="12" r="3" />
+        <circle cx="4" cy="5" r="1.8" />
+        <circle cx="20" cy="5" r="1.8" />
+        <circle cx="4" cy="19" r="1.8" />
+        <circle cx="20" cy="19" r="1.8" />
+        <line x1="6" y1="6" x2="10" y2="10.5" />
+        <line x1="18" y1="6" x2="14" y2="10.5" />
+        <line x1="6" y1="18" x2="10" y2="13.5" />
+        <line x1="18" y1="18" x2="14" y2="13.5" />
+      </svg>
+    )
+  }
+
   // デフォルト: ブック
   return (
     <svg {...props}>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -132,7 +132,7 @@ export function AppShell({
                 style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4, padding: '8px 14px', background: 'none', border: 'none', cursor: 'pointer', minWidth: 60 }}
               >
                 {tab.icon(active, isV3)}
-                <div style={{ fontSize: 13, fontWeight: 600, color: active ? (isV3 ? '#6C8EF5' : '#3B5BDB') : (isV3 ? '#6B82A8' : '#7A849E') }}>{tab.label}</div>
+                <div className="app-nav-label" style={{ fontSize: 13, fontWeight: 600, color: active ? (isV3 ? '#6C8EF5' : '#3B5BDB') : (isV3 ? '#6B82A8' : '#7A849E') }}>{tab.label}</div>
                 {active && <div style={{ width: 4, height: 4, borderRadius: '50%', background: isV3 ? '#6C8EF5' : '#3B5BDB', marginTop: -2 }} />}
               </button>
             )

--- a/src/index.css
+++ b/src/index.css
@@ -360,6 +360,13 @@ input, textarea, select { -webkit-tap-highlight-color: transparent; }
   animation: fade-in-up 0.32s ease-out both;
 }
 
+/* ===== Small phones: hide bottom nav text labels (icon-only) ===== */
+@media (max-width: 360px) {
+  .app-nav-label {
+    display: none;
+  }
+}
+
 /* ===== Tablet (768px+) ===== */
 @media (min-width: 768px) {
   :root {

--- a/src/lessonSlides.ts
+++ b/src/lessonSlides.ts
@@ -149,6 +149,7 @@ function getHeroImage(category: string, lessonId?: number): string {
   if (c.includes('ラテラル')) return '/images/v3/lesson-lateral-thinking.webp'
   if (c.includes('アナロジー') || c.includes('analogy')) return '/images/v3/lesson-analogy.webp'
   if (c.includes('システム')) return '/images/v3/lesson-systems-thinking.webp'
+  if (c.includes('経営戦略') || c === 'strategy') return '/images/v3/course-business.webp'
   if (c.includes('思考法') || c.includes('thinking')) return '/images/v3/course-thinking.webp'
   if (c.includes('coffee') || c.includes('コーヒー')) return '/images/v3/home-daily-question.webp'
   return '/images/v3/hero-deduction.webp'

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,6 @@
-import { StrictMode } from 'react'
+import { StrictMode, lazy, Suspense } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
-import AppV3 from './AppV3.tsx'
 import { initSentry } from './sentry'
 
 initSentry()
@@ -24,8 +22,13 @@ if (params.get('v') === '3') {
 }
 const useV3 = localStorage.getItem('logic-v3-preview') !== '0'
 
+const App = lazy(() => import('./App'))
+const AppV3 = lazy(() => import('./AppV3'))
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    {useV3 ? <AppV3 /> : <App />}
+    <Suspense fallback={null}>
+      {useV3 ? <AppV3 /> : <App />}
+    </Suspense>
   </StrictMode>,
 )

--- a/src/philosophyLessons.ts
+++ b/src/philosophyLessons.ts
@@ -4,7 +4,7 @@ export const philosophyLessonMap: Record<number, LessonData> = {
   77: {
     id: 77,
     title: 'ソクラテスの問答法',
-    category: 'philosophy',
+    category: '哲学・思考の原理',
     steps: [
       {
         type: 'explain',
@@ -48,7 +48,7 @@ export const philosophyLessonMap: Record<number, LessonData> = {
   78: {
     id: 78,
     title: '反証可能性 — 科学と疑似科学の境界',
-    category: 'philosophy',
+    category: '哲学・思考の原理',
     steps: [
       {
         type: 'explain',
@@ -80,7 +80,7 @@ export const philosophyLessonMap: Record<number, LessonData> = {
   79: {
     id: 79,
     title: '功利主義と義務論 — 倫理的判断の2つの軸',
-    category: 'philosophy',
+    category: '哲学・思考の原理',
     steps: [
       {
         type: 'explain',
@@ -112,7 +112,7 @@ export const philosophyLessonMap: Record<number, LessonData> = {
   80: {
     id: 80,
     title: '認識論入門 — 私たちはどこまで知れるか',
-    category: 'philosophy',
+    category: '哲学・思考の原理',
     steps: [
       {
         type: 'explain',
@@ -144,7 +144,7 @@ export const philosophyLessonMap: Record<number, LessonData> = {
   81: {
     id: 81,
     title: '思考実験 — 哲学の実験室',
-    category: 'philosophy',
+    category: '哲学・思考の原理',
     steps: [
       {
         type: 'explain',

--- a/src/screens/DailyFermiScreen.tsx
+++ b/src/screens/DailyFermiScreen.tsx
@@ -8,6 +8,7 @@ import { t, getLocale } from '../i18n'
 import { getGuestId } from '../guestId'
 import { useDailyGuide, GuideLabel, GuideStyle } from '../tutorial/dailyGuide'
 import { isStandardPlan, isPremiumPlan } from '../subscription'
+import { getDisplayName } from '../stats'
 
 // ── プラン別デイリー制限 ──────────────────────────────────────
 const TODAY = new Date().toISOString().slice(0, 10)
@@ -368,7 +369,6 @@ export function DailyFermiScreen({ onBack, onReport }: DailyFermiScreenProps) {
       setSubmitPhase('done')
       // スコアをランキングに記録
       if (data.score != null) {
-        const { getDisplayName } = await import('../stats')
         fetch(`${API_BASE}/api/fermi/record-score`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { loginWithGoogle, loginWithEmail, signupWithEmail, isSupabaseConfigured } from '../supabase'
+import { startBetaCampaignCheckout, startCheckout } from '../subscription'
 
 interface OnboardingScreenProps {
   onComplete: () => void
@@ -350,7 +351,6 @@ function OnboardingPricingView({ onNext, onSelectPlan }: { onNext: () => void; o
   const handleCampaignTap = async () => {
     setLoading(true)
     try {
-      const { startBetaCampaignCheckout } = await import('../subscription')
       await startBetaCampaignCheckout()
     } catch {
       // エラー無視（非ネイティブ環境）
@@ -649,7 +649,6 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
 
   const handleBillingSelect = async (planId: 'standard_monthly' | 'standard_yearly' | 'premium_monthly' | 'premium_yearly') => {
     try {
-      const { startCheckout } = await import('../subscription')
       await startCheckout(planId)
     } catch { /* ignore on web */ }
     setPhase('register')

--- a/src/strategyLessons.ts
+++ b/src/strategyLessons.ts
@@ -7,7 +7,7 @@ export const strategyLessonMap: Record<number, LessonData> = {
   320: {
     id: 320,
     title: '戦略の起源 — テイラーとフォード',
-    category: 'strategy',
+    category: '経営戦略',
     steps: [
       {
         type: 'explain',
@@ -51,7 +51,7 @@ export const strategyLessonMap: Record<number, LessonData> = {
   321: {
     id: 321,
     title: 'アンゾフのマトリクス — 成長の方向を決める',
-    category: 'strategy',
+    category: '経営戦略',
     steps: [
       {
         type: 'explain',
@@ -95,7 +95,7 @@ export const strategyLessonMap: Record<number, LessonData> = {
   322: {
     id: 322,
     title: 'PPM — 事業ポートフォリオを管理する',
-    category: 'strategy',
+    category: '経営戦略',
     steps: [
       {
         type: 'explain',
@@ -139,7 +139,7 @@ export const strategyLessonMap: Record<number, LessonData> = {
   323: {
     id: 323,
     title: 'ポーターの5フォース — 業界構造を読み解く',
-    category: 'strategy',
+    category: '経営戦略',
     steps: [
       {
         type: 'explain',
@@ -183,7 +183,7 @@ export const strategyLessonMap: Record<number, LessonData> = {
   324: {
     id: 324,
     title: '3つの基本戦略 — どこで勝つかを決める',
-    category: 'strategy',
+    category: '経営戦略',
     steps: [
       {
         type: 'explain',
@@ -227,7 +227,7 @@ export const strategyLessonMap: Record<number, LessonData> = {
   325: {
     id: 325,
     title: 'RBV と VRIO — 内部資源で競争優位を説明する',
-    category: 'strategy',
+    category: '経営戦略',
     steps: [
       {
         type: 'explain',
@@ -240,6 +240,18 @@ export const strategyLessonMap: Record<number, LessonData> = {
         title: 'VRIO — 4つの問いで資源を診断する',
         content:
           'バーニーは資源が競争優位を生むかを4つの問いでチェックした。これが VRIO だ。\n\nV (Valuable) その資源は顧客価値を生むか？\nR (Rare) 競合が持っていない希少な資源か？\nI (Inimitable) 真似されにくいか？（歴史的経緯・社会的複雑さ・因果の不明さ）\nO (Organized) その資源を活かす組織体制があるか？\n\n4つすべてYesなら「持続的競争優位」を生む。1つでも欠けると、価値はあっても長続きしない。\n\n例: スターバックスのバリスタの接客ノウハウは、価値あり・他チェーンに少ない・組織文化に埋め込まれて模倣困難・店舗運営に組織化されている → 持続的優位。',
+      },
+      {
+        type: 'think',
+        question: 'あなたの会社（または身近な企業）の「強み」を一つ挙げ、VRIOの4つの問いで診断してみよう。どこが弱点で、どう補強できるか？',
+        hint: 'V→R→I→O の順に「Yes/No」で答え、最初に「No」が出た要素が補強ポイント。例: 技術はあるが知名度がない（Rが弱い）、組織がそれを活かせていない（Oが弱い）など。',
+        modelAnswer:
+          '例（地方の老舗和菓子店）:\n\nV（価値）: Yes — 「地元で100年の信頼」は顧客に価値を提供している。\nR（希少性）: Yes — 同じ歴史を持つ店は地域に少ない。\nI（模倣困難）: Yes — 歴史的経緯・地元コミュニティとの関係は新規参入では再現不能。\nO（組織）: No — 職人技をマニュアル化・後継者育成できておらず、活かしきれていない。\n\n補強策: 製法の言語化＋若手育成プログラム、ECチャネル整備で「Oで止まっている価値」を顧客まで届ける。',
+        points: [
+          'VRIO は順番が大事 — Vでない資源はそもそも資源ではない',
+          '日本企業はI（模倣困難性）が高くてもO（組織）で詰まっていることが多い',
+          '「弱点はどこか」を診断する道具として使うと実用性が上がる',
+        ],
       },
       {
         type: 'quiz',
@@ -271,7 +283,7 @@ export const strategyLessonMap: Record<number, LessonData> = {
   326: {
     id: 326,
     title: 'コアコンピタンス — 組織能力を競争源泉に',
-    category: 'strategy',
+    category: '経営戦略',
     steps: [
       {
         type: 'explain',
@@ -315,7 +327,7 @@ export const strategyLessonMap: Record<number, LessonData> = {
   327: {
     id: 327,
     title: 'ブルーオーシャン戦略 — 競争のない市場を創る',
-    category: 'strategy',
+    category: '経営戦略',
     steps: [
       {
         type: 'explain',
@@ -359,7 +371,7 @@ export const strategyLessonMap: Record<number, LessonData> = {
   328: {
     id: 328,
     title: 'ダイナミック・ケイパビリティ — 変化に適応する組織力',
-    category: 'strategy',
+    category: '経営戦略',
     steps: [
       {
         type: 'explain',
@@ -372,6 +384,18 @@ export const strategyLessonMap: Record<number, LessonData> = {
         title: 'Sense・Seize・Transform',
         content:
           'ティースはダイナミック・ケイパビリティを3つの組織能力に分けた。\n\nSense（感知）: 環境変化・新しい機会と脅威を察知する力。市場・技術・競合を読み続ける。\nSeize（捕捉）: 察知した機会に資源を投入し、新しいビジネスモデルを設計・実行する力。\nTransform（変革）: 既存の組織・資産を組み替え、新しい姿に進化させる力。古い成功体験を捨てる勇気も含む。\n\n例: 富士フイルムは写真フィルム市場の崩壊を Sense し、化粧品・医薬品へ Seize、研究開発と組織を Transform した。これに失敗したコダックとの差はここにあった。',
+      },
+      {
+        type: 'think',
+        question: 'あなたが知っている「環境変化に適応できなかった会社」を1つ挙げ、Sense / Seize / Transform のどこで詰まったかを言語化してみよう。',
+        hint: '「気づけなかった（Sense）」「気づいたが動けなかった（Seize）」「動いたが古い組織を捨てきれなかった（Transform）」のどこで止まったか、を考える。',
+        modelAnswer:
+          '例（コダック）:\n\nSense: ◯ デジタルカメラ自体は世界初で社内発明していた。変化は感知していた。\nSeize: △ デジタル事業に投資はしたが、本業のフィルムを食う意思決定を遅らせた。\nTransform: ✕ フィルム製造設備・流通・人材を組み替える決断ができず、旧事業を温存し続けた。\n\n結論: コダックは「感知」したが「変革」できなかった典型。富士フイルムは同じ感知から、化粧品（コラーゲン技術）・医薬品へ大胆に組み替えた。差は Transform の能力だった。',
+        points: [
+          '「気づき」と「動き」と「捨てる」は別の能力 — 1つでも欠けると失敗する',
+          '日本企業の多くは Sense は強いが、Transform で旧事業を捨てる勇気が足りない',
+          '危機が来てから動いても遅い。平時から「組み替えの筋肉」を鍛えるのが本質',
+        ],
       },
       {
         type: 'quiz',
@@ -403,7 +427,7 @@ export const strategyLessonMap: Record<number, LessonData> = {
   329: {
     id: 329,
     title: 'プラットフォーム戦略 — エコシステムと共進化',
-    category: 'strategy',
+    category: '経営戦略',
     steps: [
       {
         type: 'explain',


### PR DESCRIPTION
## Summary

4つの改善を一気に。

### 1. バンドル分割（最大の効き目）
- `main.tsx` で `App` / `AppV3` を `React.lazy` 化（条件付きロード対象を分離）
- `AppV3` 内の低頻度スクリーン25個を `React.lazy` + `Suspense` で動的読み込みに
- `stats.ts` / `subscription.ts` の ineffective dynamic import 警告を static 化で解消

**結果（gzip）**:
- 初回エントリ: `index-*.js` **365 kB → 61 kB**（約65%減）
- v3 ユーザーが必要とする初回 = `index + AppV3 + 共通` でも ~100 kB 程度
- 各スクリーンは独立したチャンクになり、操作時に都度ロード

### 2. 小型スマホでボトムナビのラベル非表示（アイコンのみ）
- `≤360px` で `.app-nav-label` を `display: none` に
- iPhone SE 等の極小幅でナビが折り返さないよう改善

### 3. レッスン `category` の表記揺れを統一
- `'philosophy'` → `'哲学・思考の原理'`
- `'strategy'` → `'経営戦略'`
- 他のカテゴリ（`'ロジカルシンキング'` 等）はもともと日本語。UI に表示される `<span className="lesson-category">{lesson.category}</span>` での表記が揃う
- `lessonSlides.ts` の `getHeroImage` に経営戦略のフォールバック画像 (`course-business.webp`) を追加

### 4. 戦略コース仕上げ
- L325 (RBV/VRIO) に `think` ステップ追加 — 自社の強みを VRIO で診断する自由記述
- L328 (動的能力) に `think` ステップ追加 — 環境変化に適応できなかった会社を Sense/Seize/Transform で言語化
- L320–L329 に専用カスタム SVG アイコンを追加（工場、2x2、4象限、5フォース、3本柱、カード、ハブ、波、循環、ノードグラフ）

## 触ったファイル（10）
- `src/main.tsx` — App/AppV3 の lazy 化
- `src/AppV3.tsx` — 25画面の lazy 化 + Suspense
- `src/screens/DailyFermiScreen.tsx`, `src/screens/OnboardingScreen.tsx` — dynamic import を static に
- `src/components/AppShell.tsx` — ナビラベルに className 付与
- `src/index.css` — `@media (max-width: 360px)` でラベル非表示
- `src/philosophyLessons.ts`, `src/strategyLessons.ts` — category 統一
- `src/lessonSlides.ts` — 経営戦略の hero image マッピング
- `src/strategyLessons.ts` — L325/L328 に think ステップ
- `src/LessonIcon.tsx` — L320–329 用 10 個の SVG アイコン

## Test plan
- [x] `npx tsc -p tsconfig.app.json --noEmit` → エラーなし
- [x] `npm run build` → 成功、chunk size 警告なくなる
- [ ] デプロイ後、初回ロード時間が短縮されている
- [ ] 小型スマホでナビにアイコンのみ表示
- [ ] 哲学コース・経営戦略コースのレッスン詳細で正しいカテゴリ表記
- [ ] L325/L328 で think ステップが表示・解答できる
- [ ] L320–329 のロードマップ／一覧でカスタムアイコンが表示される
- [ ] 各画面の遅延ロードで一瞬の白画面が許容範囲（fallback null）

https://claude.ai/code/session_01ATsR64Zh4SGiXxgkysKUvs

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATsR64Zh4SGiXxgkysKUvs)_