### PR TITLE
feat: ランキングに各ユーザーのXPを表示（Supabase migration 含む）

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1399,7 +1399,7 @@ app.post('/api/fermi/question', fermiLimiter, async (req, res) => {
 
 app.post('/api/placement/submit', async (req, res) => {
   try {
-    const { guestId, nickname, deviation, correctCount, totalCount } = req.body || {}
+    const { guestId, nickname, deviation, correctCount, totalCount, xp } = req.body || {}
     if (!guestId || typeof deviation !== 'number') {
       return res.status(400).json({ error: 'guestId and deviation required' })
     }
@@ -1416,6 +1416,7 @@ app.post('/api/placement/submit', async (req, res) => {
         deviation,
         correct_count: correctCount || 0,
         total_count: totalCount || 0,
+        xp: typeof xp === 'number' && xp >= 0 ? xp : 0,
         completed_at: new Date().toISOString(),
       },
       { onConflict: 'guest_id' }
@@ -1423,6 +1424,36 @@ app.post('/api/placement/submit', async (req, res) => {
 
     if (error) {
       console.error('[placement/submit] Supabase error:', error.message)
+      return res.status(500).json({ error: error.message })
+    }
+
+    res.json({ ok: true })
+  } catch (e: unknown) {
+    res.status(500).json({ error: e instanceof Error ? e.message : String(e) })
+  }
+})
+
+// Sync XP only — used by the ranking screen on mount so other users see
+// the latest XP without requiring a fresh placement submission.
+// No-op if the user hasn't yet taken the placement test.
+app.post('/api/placement/sync-xp', async (req, res) => {
+  try {
+    const { guestId, xp } = req.body || {}
+    if (!guestId || typeof xp !== 'number' || xp < 0) {
+      return res.status(400).json({ error: 'guestId and non-negative xp required' })
+    }
+
+    if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+      return res.status(503).json({ error: 'Supabase not configured' })
+    }
+
+    const { error } = await supabase
+      .from('placement_results')
+      .update({ xp })
+      .eq('guest_id', guestId)
+
+    if (error) {
+      console.error('[placement/sync-xp] Supabase error:', error.message)
       return res.status(500).json({ error: error.message })
     }
 
@@ -1467,7 +1498,7 @@ app.get('/api/placement/ranking', async (req, res) => {
 
     const { data, error } = await supabase
       .from('placement_results')
-      .select('guest_id, nickname, deviation, correct_count, total_count')
+      .select('guest_id, nickname, deviation, correct_count, total_count, xp')
       .gt('total_count', 0)  // スキップユーザー除外
       .order('deviation', { ascending: false })
 
@@ -1482,20 +1513,23 @@ app.get('/api/placement/ranking', async (req, res) => {
       rank: i + 1,
       nickname: e.nickname,
       deviation: e.deviation,
+      xp: typeof e.xp === 'number' ? e.xp : 0,
       isYou: e.guest_id === guestId,
     }))
 
     let yourRank = -1
     let yourDeviation = -1
+    let yourXp = 0
     if (guestId) {
       const idx = entries.findIndex((e: any) => e.guest_id === guestId)
       if (idx >= 0) {
         yourRank = idx + 1
         yourDeviation = (entries[idx] as any).deviation
+        yourXp = (entries[idx] as any).xp || 0
       }
     }
 
-    res.json({ total, top, yourRank, yourDeviation })
+    res.json({ total, top, yourRank, yourDeviation, yourXp })
   } catch (e: unknown) {
     res.status(500).json({ error: e instanceof Error ? e.message : String(e) })
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -1409,18 +1409,22 @@ app.post('/api/placement/submit', async (req, res) => {
       return res.status(503).json({ error: 'Supabase not configured' })
     }
 
-    const { error } = await supabase.from('placement_results').upsert(
-      {
-        guest_id: guestId,
-        nickname: (nickname || 'ゲスト').slice(0, 20),
-        deviation,
-        correct_count: correctCount || 0,
-        total_count: totalCount || 0,
-        xp: typeof xp === 'number' && xp >= 0 ? xp : 0,
-        completed_at: new Date().toISOString(),
-      },
-      { onConflict: 'guest_id' }
-    )
+    const basePayload = {
+      guest_id: guestId,
+      nickname: (nickname || 'ゲスト').slice(0, 20),
+      deviation,
+      correct_count: correctCount || 0,
+      total_count: totalCount || 0,
+      completed_at: new Date().toISOString(),
+    }
+    const fullPayload = { ...basePayload, xp: typeof xp === 'number' && xp >= 0 ? xp : 0 }
+
+    let { error } = await supabase.from('placement_results').upsert(fullPayload, { onConflict: 'guest_id' })
+    // Migration 008 未適用環境では xp 列が無いためエラーになる。基本ペイロードで再試行。
+    if (error && /xp/i.test(error.message)) {
+      const retry = await supabase.from('placement_results').upsert(basePayload, { onConflict: 'guest_id' })
+      error = retry.error
+    }
 
     if (error) {
       console.error('[placement/submit] Supabase error:', error.message)
@@ -1496,11 +1500,22 @@ app.get('/api/placement/ranking', async (req, res) => {
       return res.status(503).json({ error: 'Supabase not configured' })
     }
 
-    const { data, error } = await supabase
+    let { data, error } = await supabase
       .from('placement_results')
       .select('guest_id, nickname, deviation, correct_count, total_count, xp')
       .gt('total_count', 0)  // スキップユーザー除外
       .order('deviation', { ascending: false })
+
+    // Migration 008 未適用環境では xp 列が無い。フォールバックで再取得。
+    if (error && /xp/i.test(error.message)) {
+      const retry = await supabase
+        .from('placement_results')
+        .select('guest_id, nickname, deviation, correct_count, total_count')
+        .gt('total_count', 0)
+        .order('deviation', { ascending: false })
+      data = retry.data
+      error = retry.error
+    }
 
     if (error) {
       console.error('[placement/ranking] Supabase error:', error.message)

--- a/src/PlacementTest.tsx
+++ b/src/PlacementTest.tsx
@@ -9,6 +9,7 @@ import {
 } from './placementData'
 import { getGuestId, getNickname, setNickname, defaultNickname } from './guestId'
 import { t } from './i18n'
+import { getXp } from './stats'
 import './PlacementTest.css'
 
 import { API_BASE } from './apiBase'
@@ -24,6 +25,7 @@ async function submitPlacement(deviation: number, correctCount: number, totalCou
         deviation,
         correctCount,
         totalCount,
+        xp: getXp(),
       }),
     })
   } catch { /* silent */ }

--- a/src/screens/PlacementTestScreen.tsx
+++ b/src/screens/PlacementTestScreen.tsx
@@ -12,6 +12,7 @@ import { ArrowLeftIcon, ArrowRightIcon, CheckIcon } from '../icons'
 import { Button } from '../components/Button'
 import { IconButton } from '../components/IconButton'
 import { API_BASE } from './apiBase'
+import { getXp } from '../stats'
 
 interface PlacementTestScreenProps {
   onComplete: () => void
@@ -24,7 +25,7 @@ async function submitPlacement(deviation: number, correctCount: number, totalCou
     await fetch(`${API_BASE}/api/placement/submit`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ guestId: getGuestId(), nickname, deviation, correctCount, totalCount }),
+      body: JSON.stringify({ guestId: getGuestId(), nickname, deviation, correctCount, totalCount, xp: getXp() }),
     })
   } catch { /* silent */ }
 }

--- a/src/screens/RankingScreen.tsx
+++ b/src/screens/RankingScreen.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useMemo } from 'react'
 import { getGuestId } from '../guestId'
 import { hasCompletedPlacement, loadPlacementResult } from '../placementData'
 import { API_BASE } from './apiBase'
-import { getStreak, getStudyDates, getCompletedLessons } from '../stats'
+import { getStreak, getStudyDates, getCompletedLessons, getXp } from '../stats'
 import { getPoints } from './homeHelpers'
 
 
@@ -11,8 +11,8 @@ interface RankingScreenProps {
   onTakeTest: () => void
 }
 
-type RankEntry = { rank: number; nickname: string; deviation: number; isYou: boolean }
-type RankingData = { total: number; top: RankEntry[]; yourRank: number; yourDeviation: number }
+type RankEntry = { rank: number; nickname: string; deviation: number; xp: number; isYou: boolean }
+type RankingData = { total: number; top: RankEntry[]; yourRank: number; yourDeviation: number; yourXp: number }
 
 export function RankingScreen({ onTakeTest }: RankingScreenProps) {
   const [rankData, setRankData] = useState<RankingData | null>(null)
@@ -21,6 +21,7 @@ export function RankingScreen({ onTakeTest }: RankingScreenProps) {
 
   const streak = getStreak()
   const points = getPoints()
+  const xp = getXp()
   const placement = loadPlacementResult()
   const deviation = placement?.deviation ?? null
   const completed = hasCompletedPlacement() && (placement?.totalCount ?? 0) > 0
@@ -44,12 +45,27 @@ export function RankingScreen({ onTakeTest }: RankingScreenProps) {
 
   useEffect(() => {
     let cancelled = false
-    fetch(`${API_BASE}/api/placement/ranking?guestId=${encodeURIComponent(getGuestId())}`)
-      .then((r) => r.json())
-      .then((d) => { if (!cancelled) { setRankData(d); setLoading(false) } })
-      .catch(() => { if (!cancelled) setLoading(false) })
+    const guestId = getGuestId()
+    // 自分の最新XPをサーバに同期してからランキングを取得（サーバ未対応時は無視して続行）
+    const syncThenFetch = async () => {
+      try {
+        await fetch(`${API_BASE}/api/placement/sync-xp`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ guestId, xp }),
+        })
+      } catch { /* オフライン・未対応サーバは無視 */ }
+      try {
+        const r = await fetch(`${API_BASE}/api/placement/ranking?guestId=${encodeURIComponent(guestId)}`)
+        const d = await r.json()
+        if (!cancelled) { setRankData(d); setLoading(false) }
+      } catch {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    syncThenFetch()
     return () => { cancelled = true }
-  }, [])
+  }, [xp])
 
   // 最近の活動 — 実データから生成
   const recentActivity = useMemo(() => {
@@ -104,20 +120,25 @@ export function RankingScreen({ onTakeTest }: RankingScreenProps) {
         {/* スコアヒーロー */}
         <div style={{ background: '#3B5BDB', borderRadius: 28, padding: '24px 20px', position: 'relative', overflow: 'hidden' }}>
           <div style={{ position: 'absolute', right: -40, top: -40, width: 160, height: 160, borderRadius: '50%', background: 'rgba(255,255,255,.06)', pointerEvents: 'none' }} />
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1px 1fr 1px 1fr' }}>
-            <div style={{ textAlign: 'center', padding: '0 4px' }}>
-              <div style={{ fontFamily: "'Inter Tight', sans-serif", fontSize: 32, fontWeight: 900, color: '#fff', letterSpacing: '-.04em', lineHeight: 1 }}>{streak}</div>
-              <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '.1em', textTransform: 'uppercase', color: 'rgba(255,255,255,.5)', marginTop: 5 }}>連続学習</div>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1px 1fr 1px 1fr 1px 1fr' }}>
+            <div style={{ textAlign: 'center', padding: '0 2px' }}>
+              <div style={{ fontFamily: "'Inter Tight', sans-serif", fontSize: 28, fontWeight: 900, color: '#fff', letterSpacing: '-.04em', lineHeight: 1 }}>{streak}</div>
+              <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', color: 'rgba(255,255,255,.5)', marginTop: 5 }}>連続</div>
             </div>
             <div style={{ background: 'rgba(255,255,255,.15)', margin: '4px 0' }} />
-            <div style={{ textAlign: 'center', padding: '0 4px' }}>
-              <div style={{ fontFamily: "'Inter Tight', sans-serif", fontSize: 32, fontWeight: 900, color: '#fff', letterSpacing: '-.04em', lineHeight: 1 }}>{points}</div>
-              <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '.1em', textTransform: 'uppercase', color: 'rgba(255,255,255,.5)', marginTop: 5 }}>ポイント</div>
+            <div style={{ textAlign: 'center', padding: '0 2px' }}>
+              <div style={{ fontFamily: "'Inter Tight', sans-serif", fontSize: 28, fontWeight: 900, color: '#fff', letterSpacing: '-.04em', lineHeight: 1 }}>{xp}</div>
+              <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', color: 'rgba(255,255,255,.5)', marginTop: 5 }}>XP</div>
             </div>
             <div style={{ background: 'rgba(255,255,255,.15)', margin: '4px 0' }} />
-            <div style={{ textAlign: 'center', padding: '0 4px' }}>
-              <div style={{ fontFamily: "'Inter Tight', sans-serif", fontSize: 26, fontWeight: 900, color: '#fff', letterSpacing: '-.04em', lineHeight: 1 }}>{deviation != null ? Math.round(deviation) : '—'}</div>
-              <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '.1em', textTransform: 'uppercase', color: 'rgba(255,255,255,.5)', marginTop: 5 }}>偏差値</div>
+            <div style={{ textAlign: 'center', padding: '0 2px' }}>
+              <div style={{ fontFamily: "'Inter Tight', sans-serif", fontSize: 28, fontWeight: 900, color: '#fff', letterSpacing: '-.04em', lineHeight: 1 }}>{points}</div>
+              <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', color: 'rgba(255,255,255,.5)', marginTop: 5 }}>ポイント</div>
+            </div>
+            <div style={{ background: 'rgba(255,255,255,.15)', margin: '4px 0' }} />
+            <div style={{ textAlign: 'center', padding: '0 2px' }}>
+              <div style={{ fontFamily: "'Inter Tight', sans-serif", fontSize: 24, fontWeight: 900, color: '#fff', letterSpacing: '-.04em', lineHeight: 1 }}>{deviation != null ? Math.round(deviation) : '—'}</div>
+              <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', color: 'rgba(255,255,255,.5)', marginTop: 5 }}>偏差値</div>
             </div>
           </div>
         </div>
@@ -177,11 +198,21 @@ export function RankingScreen({ onTakeTest }: RankingScreenProps) {
                   <div key={`${e.rank}-${e.nickname}`} style={{ background: e.isYou ? '#EEF2FF' : '#fff', border: `1px solid ${e.isYou ? '#DBE4FF' : '#E2E8FF'}`, borderRadius: 14, padding: '12px 16px', display: 'flex', alignItems: 'center', gap: 12, boxShadow: '0 1px 2px rgba(15,21,35,.06)' }}>
                     <div style={{ fontFamily: "'Inter Tight', sans-serif", fontSize: 18, fontWeight: 900, color: posColor, width: 24, textAlign: 'center', flexShrink: 0 }}>{e.rank}</div>
                     <div style={{ width: 36, height: 36, borderRadius: '50%', background: 'linear-gradient(135deg, #3B5BDB, #748FFC)', flexShrink: 0, boxShadow: e.isYou ? '0 0 0 2px #3B5BDB' : 'none' }} />
-                    <div style={{ flex: 1, fontSize: 16, fontWeight: 600, color: '#0F1523' }}>
-                      {e.nickname}
-                      {e.isYou && <span style={{ fontSize: 13, fontWeight: 700, color: '#3B5BDB', background: '#EEF2FF', borderRadius: 4, padding: '1px 5px', marginLeft: 6 }}>あなた</span>}
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontSize: 16, fontWeight: 600, color: '#0F1523', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                        {e.nickname}
+                        {e.isYou && <span style={{ fontSize: 13, fontWeight: 700, color: '#3B5BDB', background: '#EEF2FF', borderRadius: 4, padding: '1px 5px', marginLeft: 6 }}>あなた</span>}
+                      </div>
+                      <div style={{ fontSize: 12, color: '#7A849E', marginTop: 2, display: 'flex', alignItems: 'center', gap: 4 }}>
+                        <svg width="11" height="11" viewBox="0 0 24 24" fill="#FBBF24"><path d="M12 2L15 8.5l7 1-5 4.7 1.5 7L12 17.8 5.5 21.2 7 14.2 2 9.5l7-1z"/></svg>
+                        <span style={{ fontFamily: "'Inter Tight', sans-serif", fontWeight: 700 }}>{e.xp.toLocaleString()}</span>
+                        <span>XP</span>
+                      </div>
                     </div>
-                    <div style={{ fontFamily: "'Inter Tight', sans-serif", fontSize: 18, fontWeight: 900, color: '#3B5BDB' }}>{e.deviation}</div>
+                    <div style={{ textAlign: 'right', flexShrink: 0 }}>
+                      <div style={{ fontFamily: "'Inter Tight', sans-serif", fontSize: 18, fontWeight: 900, color: '#3B5BDB', lineHeight: 1 }}>{e.deviation}</div>
+                      <div style={{ fontSize: 10, color: '#7A849E', fontWeight: 700, letterSpacing: '.06em', marginTop: 3 }}>偏差値</div>
+                    </div>
                   </div>
                 )
               })}

--- a/supabase/migrations/008_placement_xp.sql
+++ b/supabase/migrations/008_placement_xp.sql
@@ -1,0 +1,13 @@
+-- Migration 008: Add XP column to placement_results for ranking display
+-- ─────────────────────────────────────────────────────────────────
+-- Adds an `xp` column so the ranking endpoint can show each user's
+-- cumulative XP alongside their deviation score.
+-- Existing rows default to 0; clients sync their localStorage XP up
+-- via /api/placement/sync-xp on ranking screen mount.
+
+ALTER TABLE placement_results
+  ADD COLUMN IF NOT EXISTS xp INTEGER NOT NULL DEFAULT 0;
+
+-- Index for potential XP-based sorting in the future.
+CREATE INDEX IF NOT EXISTS idx_placement_results_xp
+  ON placement_results (xp DESC);


### PR DESCRIPTION
## Summary

ランキング画面で各ユーザーのXPを表示できるように、Supabase + サーバ + クライアント を一気に拡張。

## 変更点

### 1. Supabase migration（要適用）
`supabase/migrations/008_placement_xp.sql` を新規作成:
```sql
ALTER TABLE placement_results
  ADD COLUMN IF NOT EXISTS xp INTEGER NOT NULL DEFAULT 0;

CREATE INDEX IF NOT EXISTS idx_placement_results_xp
  ON placement_results (xp DESC);
```
既存行は `xp = 0` で初期化、将来 XP 順ソート用にインデックスも貼っておきます。

### 2. サーバ (`server/index.ts`)
- **`POST /api/placement/submit`** — `xp` パラメータを受理してテーブルに保存
- **`POST /api/placement/sync-xp`**（新規）— 既存行の `xp` のみを更新。プレースメント未受験ユーザーには noop
- **`GET /api/placement/ranking`** — 各エントリに `xp` を含める。`yourXp` も追加返却

### 3. クライアント
- **`screens/RankingScreen.tsx`**
  - マウント時に `sync-xp` で自分の最新ローカル XP をサーバへ送ってからランキングを取得
  - ヒーローカードを 3カラム → **4カラム（連続 / XP / ポイント / 偏差値）** に
  - 各ランキング行を 2 行レイアウトに改修。ニックネーム下に ⭐ + XP（カンマ区切り）、右側に偏差値 + 「偏差値」ラベル
- **`screens/PlacementTestScreen.tsx`、`PlacementTest.tsx`** — placement 提出時に `getXp()` を同梱

## デプロイ手順
1. **Supabase で migration 008 を適用**（管理コンソール / `supabase db push` 等）
2. main にマージ → Render が自動デプロイ
3. 既存ユーザーは初回 ランキング画面表示で XP がサーバに同期される

migration 未適用でも:
- API レスポンス側は `xp || 0` でガード済 → クライアントは安全に 0 表示で動作
- migration 適用後、自然に各ユーザーの XP が反映されていく

## Test plan
- [x] `npx tsc -p tsconfig.app.json --noEmit` → エラーなし（クライアント側）
- [x] `npm run build` → 成功
- [ ] migration 適用後、既存テスト受験者の行に XP 0 が表示
- [ ] 自分のローカル XP が同期されて自分の行に反映される
- [ ] ヒーローカードが 4 カラム（連続/XP/ポイント/偏差値）で正しく描画される
- [ ] プレースメント提出時に XP が server 側に保存される

## 既知の制約
- 並び順は引き続き「偏差値降順」。XP 順ソートに切り替えたい場合は別 PR で（インデックスは既に用意）
- プレースメント未受験ユーザーは引き続きランキングに出ない（XPだけ送っても表示対象外）

https://claude.ai/code/session_01ATsR64Zh4SGiXxgkysKUvs

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATsR64Zh4SGiXxgkysKUvs)_