### PR TITLE
refactor: XPを user_stats テーブルに分離（placement_results との混在を解消）

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1399,7 +1399,7 @@ app.post('/api/fermi/question', fermiLimiter, async (req, res) => {
 
 app.post('/api/placement/submit', async (req, res) => {
   try {
-    const { guestId, nickname, deviation, correctCount, totalCount, xp } = req.body || {}
+    const { guestId, nickname, deviation, correctCount, totalCount } = req.body || {}
     if (!guestId || typeof deviation !== 'number') {
       return res.status(400).json({ error: 'guestId and deviation required' })
     }
@@ -1409,22 +1409,17 @@ app.post('/api/placement/submit', async (req, res) => {
       return res.status(503).json({ error: 'Supabase not configured' })
     }
 
-    const basePayload = {
-      guest_id: guestId,
-      nickname: (nickname || 'ゲスト').slice(0, 20),
-      deviation,
-      correct_count: correctCount || 0,
-      total_count: totalCount || 0,
-      completed_at: new Date().toISOString(),
-    }
-    const fullPayload = { ...basePayload, xp: typeof xp === 'number' && xp >= 0 ? xp : 0 }
-
-    let { error } = await supabase.from('placement_results').upsert(fullPayload, { onConflict: 'guest_id' })
-    // Migration 008 未適用環境では xp 列が無いためエラーになる。基本ペイロードで再試行。
-    if (error && /xp/i.test(error.message)) {
-      const retry = await supabase.from('placement_results').upsert(basePayload, { onConflict: 'guest_id' })
-      error = retry.error
-    }
+    const { error } = await supabase.from('placement_results').upsert(
+      {
+        guest_id: guestId,
+        nickname: (nickname || 'ゲスト').slice(0, 20),
+        deviation,
+        correct_count: correctCount || 0,
+        total_count: totalCount || 0,
+        completed_at: new Date().toISOString(),
+      },
+      { onConflict: 'guest_id' }
+    )
 
     if (error) {
       console.error('[placement/submit] Supabase error:', error.message)
@@ -1437,12 +1432,11 @@ app.post('/api/placement/submit', async (req, res) => {
   }
 })
 
-// Sync XP only — used by the ranking screen on mount so other users see
-// the latest XP without requiring a fresh placement submission.
-// No-op if the user hasn't yet taken the placement test.
-app.post('/api/placement/sync-xp', async (req, res) => {
+// XP・ニックネームの正準ストアを upsert（user_stats）。
+// プレースメント未受験のユーザーでも呼べる。
+app.post('/api/profile/sync-xp', async (req, res) => {
   try {
-    const { guestId, xp } = req.body || {}
+    const { guestId, nickname, xp } = req.body || {}
     if (!guestId || typeof xp !== 'number' || xp < 0) {
       return res.status(400).json({ error: 'guestId and non-negative xp required' })
     }
@@ -1451,13 +1445,18 @@ app.post('/api/placement/sync-xp', async (req, res) => {
       return res.status(503).json({ error: 'Supabase not configured' })
     }
 
-    const { error } = await supabase
-      .from('placement_results')
-      .update({ xp })
-      .eq('guest_id', guestId)
+    const { error } = await supabase.from('user_stats').upsert(
+      {
+        guest_id: guestId,
+        nickname: (nickname || 'ゲスト').slice(0, 20),
+        xp,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'guest_id' }
+    )
 
     if (error) {
-      console.error('[placement/sync-xp] Supabase error:', error.message)
+      console.error('[profile/sync-xp] Supabase error:', error.message)
       return res.status(500).json({ error: error.message })
     }
 
@@ -1500,35 +1499,43 @@ app.get('/api/placement/ranking', async (req, res) => {
       return res.status(503).json({ error: 'Supabase not configured' })
     }
 
-    let { data, error } = await supabase
+    const placementsRes = await supabase
       .from('placement_results')
-      .select('guest_id, nickname, deviation, correct_count, total_count, xp')
+      .select('guest_id, nickname, deviation, correct_count, total_count')
       .gt('total_count', 0)  // スキップユーザー除外
       .order('deviation', { ascending: false })
 
-    // Migration 008 未適用環境では xp 列が無い。フォールバックで再取得。
-    if (error && /xp/i.test(error.message)) {
-      const retry = await supabase
-        .from('placement_results')
-        .select('guest_id, nickname, deviation, correct_count, total_count')
-        .gt('total_count', 0)
-        .order('deviation', { ascending: false })
-      data = retry.data
-      error = retry.error
+    if (placementsRes.error) {
+      console.error('[placement/ranking] Supabase error:', placementsRes.error.message)
+      return res.status(500).json({ error: placementsRes.error.message })
     }
 
-    if (error) {
-      console.error('[placement/ranking] Supabase error:', error.message)
-      return res.status(500).json({ error: error.message })
+    const placements = placementsRes.data || []
+    const total = placements.length
+    const top50 = placements.slice(0, 50)
+
+    // user_stats から XP を取得して結合（Migration 009 未適用環境ではフォールバック）
+    const xpMap = new Map<string, number>()
+    if (top50.length > 0) {
+      const ids = top50.map((e: any) => e.guest_id)
+      const xpRes = await supabase
+        .from('user_stats')
+        .select('guest_id, xp')
+        .in('guest_id', ids)
+      if (xpRes.error) {
+        console.warn('[placement/ranking] user_stats join failed (migration 009 未適用?):', xpRes.error.message)
+      } else {
+        for (const row of (xpRes.data || []) as any[]) {
+          xpMap.set(row.guest_id, row.xp || 0)
+        }
+      }
     }
 
-    const entries = data || []
-    const total = entries.length
-    const top = entries.slice(0, 50).map((e: any, i: number) => ({
+    const top = top50.map((e: any, i: number) => ({
       rank: i + 1,
       nickname: e.nickname,
       deviation: e.deviation,
-      xp: typeof e.xp === 'number' ? e.xp : 0,
+      xp: xpMap.get(e.guest_id) || 0,
       isYou: e.guest_id === guestId,
     }))
 
@@ -1536,11 +1543,22 @@ app.get('/api/placement/ranking', async (req, res) => {
     let yourDeviation = -1
     let yourXp = 0
     if (guestId) {
-      const idx = entries.findIndex((e: any) => e.guest_id === guestId)
+      const idx = placements.findIndex((e: any) => e.guest_id === guestId)
       if (idx >= 0) {
         yourRank = idx + 1
-        yourDeviation = (entries[idx] as any).deviation
-        yourXp = (entries[idx] as any).xp || 0
+        yourDeviation = (placements[idx] as any).deviation
+        // top50 外でも自分の XP は別途取得
+        yourXp = xpMap.get(guestId) ?? 0
+        if (!xpMap.has(guestId)) {
+          const yourXpRes = await supabase
+            .from('user_stats')
+            .select('xp')
+            .eq('guest_id', guestId)
+            .maybeSingle()
+          if (!yourXpRes.error && yourXpRes.data) {
+            yourXp = (yourXpRes.data as any).xp || 0
+          }
+        }
       }
     }
 

--- a/src/PlacementTest.tsx
+++ b/src/PlacementTest.tsx
@@ -9,7 +9,6 @@ import {
 } from './placementData'
 import { getGuestId, getNickname, setNickname, defaultNickname } from './guestId'
 import { t } from './i18n'
-import { getXp } from './stats'
 import './PlacementTest.css'
 
 import { API_BASE } from './apiBase'
@@ -25,7 +24,6 @@ async function submitPlacement(deviation: number, correctCount: number, totalCou
         deviation,
         correctCount,
         totalCount,
-        xp: getXp(),
       }),
     })
   } catch { /* silent */ }

--- a/src/screens/PlacementTestScreen.tsx
+++ b/src/screens/PlacementTestScreen.tsx
@@ -12,7 +12,6 @@ import { ArrowLeftIcon, ArrowRightIcon, CheckIcon } from '../icons'
 import { Button } from '../components/Button'
 import { IconButton } from '../components/IconButton'
 import { API_BASE } from './apiBase'
-import { getXp } from '../stats'
 
 interface PlacementTestScreenProps {
   onComplete: () => void
@@ -25,7 +24,7 @@ async function submitPlacement(deviation: number, correctCount: number, totalCou
     await fetch(`${API_BASE}/api/placement/submit`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ guestId: getGuestId(), nickname, deviation, correctCount, totalCount, xp: getXp() }),
+      body: JSON.stringify({ guestId: getGuestId(), nickname, deviation, correctCount, totalCount }),
     })
   } catch { /* silent */ }
 }

--- a/src/screens/RankingScreen.tsx
+++ b/src/screens/RankingScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo } from 'react'
-import { getGuestId } from '../guestId'
+import { getGuestId, getNickname } from '../guestId'
 import { hasCompletedPlacement, loadPlacementResult } from '../placementData'
 import { API_BASE } from './apiBase'
 import { getStreak, getStudyDates, getCompletedLessons, getXp } from '../stats'
@@ -46,13 +46,14 @@ export function RankingScreen({ onTakeTest }: RankingScreenProps) {
   useEffect(() => {
     let cancelled = false
     const guestId = getGuestId()
-    // 自分の最新XPをサーバに同期してからランキングを取得（サーバ未対応時は無視して続行）
+    const nickname = getNickname()
+    // 自分の最新XP/ニックネームを user_stats に upsert してからランキング取得
     const syncThenFetch = async () => {
       try {
-        await fetch(`${API_BASE}/api/placement/sync-xp`, {
+        await fetch(`${API_BASE}/api/profile/sync-xp`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ guestId, xp }),
+          body: JSON.stringify({ guestId, nickname, xp }),
         })
       } catch { /* オフライン・未対応サーバは無視 */ }
       try {

--- a/supabase/migrations/009_user_stats.sql
+++ b/supabase/migrations/009_user_stats.sql
@@ -1,0 +1,36 @@
+-- Migration 009: user_stats — XP・ニックネームの正準ストア
+-- ─────────────────────────────────────────────────────────────────
+-- placement_results は本来「プレースメントテストの結果」のテーブル。
+-- 008 で xp 列を相乗りさせていたが、プレースメント未受験ユーザーの
+-- XP が乗らない／概念が混在する問題があったため、専用テーブルへ分離。
+--
+-- placement_results.xp は当面残す（ロールバック余地）。
+-- 将来削除する場合は別 migration で `ALTER TABLE ... DROP COLUMN xp;`
+
+CREATE TABLE IF NOT EXISTS user_stats (
+  guest_id   TEXT PRIMARY KEY,
+  nickname   TEXT NOT NULL DEFAULT 'ゲスト',
+  xp         INTEGER NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- XP 順ソート用
+CREATE INDEX IF NOT EXISTS idx_user_stats_xp
+  ON user_stats (xp DESC);
+
+-- 008 適用済み環境からの backfill（xp 列が無ければスキップ）
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'placement_results' AND column_name = 'xp'
+  ) THEN
+    INSERT INTO user_stats (guest_id, nickname, xp)
+    SELECT guest_id, nickname, xp
+    FROM placement_results
+    WHERE xp > 0
+    ON CONFLICT (guest_id) DO UPDATE
+      SET xp = GREATEST(user_stats.xp, EXCLUDED.xp),
+          updated_at = now();
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

PR #26 で XP を `placement_results` に相乗りさせていたが、概念混在＋プレースメント未受験ユーザーがランキングから抜ける問題があった。XP・ニックネームの正準ストアとして `user_stats` を切り出して整理。

## 変更点

### 1. Migration 009 (`009_user_stats.sql`)
```sql
CREATE TABLE IF NOT EXISTS user_stats (
  guest_id   TEXT PRIMARY KEY,
  nickname   TEXT NOT NULL DEFAULT 'ゲスト',
  xp         INTEGER NOT NULL DEFAULT 0,
  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
);
CREATE INDEX IF NOT EXISTS idx_user_stats_xp ON user_stats (xp DESC);
```
+ 008 が適用済みなら `placement_results.xp` から **条件付き backfill**（`DO $$ ... IF EXISTS ... END $$`）。

`placement_results.xp` 列はロールバック余地のため当面残します（将来削除する場合は別 migration で）。

### 2. サーバ
- `POST /api/profile/sync-xp` **新設** — `user_stats` に upsert（プレースメント未受験ユーザーでもOK）
- `POST /api/placement/sync-xp` **削除**（旧 placement_results 相乗り版）
- `POST /api/placement/submit` から `xp` 引数を除去（placement_results は本来の責務に）
- `GET /api/placement/ranking` — `placement_results` 取得後、`user_stats` を `in` クエリで結合し XP を合流。Migration 009 未適用環境では join 失敗を warn ログにとどめ `xp=0` で続行

### 3. クライアント
- `RankingScreen` — sync URL を `/api/profile/sync-xp` に変更、`nickname` も同梱
- `PlacementTestScreen` / `PlacementTest.tsx` — submit ボディから `xp` を削除（user_stats が責務を持つので不要）

## ⚠️ デプロイ手順
1. **Supabase で `009_user_stats.sql` を適用** — Dashboard SQL Editor 推奨
2. main にマージ → Render 自動デプロイ

未適用でも:
- `placement/ranking` はランキング自体は返る（XP は全員 0）
- `profile/sync-xp` は 500 を返すがクライアントは catch で握り潰し

## Test plan
- [x] `npx tsc -p tsconfig.app.json --noEmit` → エラーなし
- [x] `npm run build` → 成功
- [ ] migration 009 適用後、ランキング画面で XP が表示される
- [ ] プレースメント未受験のユーザーが `profile/sync-xp` を呼んでも `user_stats` に行が作られる
- [ ] 既存の placement 提出が xp 抜きでも 200 を返す

https://claude.ai/code/session_01ATsR64Zh4SGiXxgkysKUvs

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATsR64Zh4SGiXxgkysKUvs)_