### PR TITLE
fix(ci): Android ビルドの「Cannot invoke method call() on null object」を修正

### DIFF
--- a/.github/workflows/android-deploy.yml
+++ b/.github/workflows/android-deploy.yml
@@ -77,48 +77,32 @@ jobs:
           key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: gradle-
 
-      # ── 11. キーストアをファイルに展開 ───────────────────
-      - name: Decode keystore
+      # ── 11. キーストアをファイルに展開 + key.properties を生成 ───
+      #     PR #28 で build.gradle が key.properties から署名情報を読む方式に
+      #     変わったので、CI 側で key.properties を生成する。
+      - name: Decode keystore and write key.properties
         run: |
           echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > android/app/logic.keystore
-
-      # ── 12. 署名設定を build.gradle に注入 ───────────────
-      - name: Configure signing
-        working-directory: android
-        run: |
-          cat >> app/build.gradle << 'EOF'
-
-          android {
-              signingConfigs {
-                  release {
-                      storeFile file("logic.keystore")
-                      storePassword System.getenv("KEYSTORE_PASSWORD")
-                      keyAlias System.getenv("KEY_ALIAS")
-                      keyPassword System.getenv("KEY_PASSWORD")
-                  }
-              }
-              buildTypes {
-                  release {
-                      signingConfig signingConfigs.release
-                  }
-              }
-          }
+          cat > android/key.properties << EOF
+          LOGIC_KEYSTORE_FILE=logic.keystore
+          LOGIC_KEYSTORE_PASSWORD=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          LOGIC_KEY_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}
+          LOGIC_KEY_PASSWORD=${{ secrets.ANDROID_KEY_PASSWORD }}
           EOF
-        env:
-          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          # 値が空でないか軽くチェック（base64 デコード後のバイト数）
+          KSIZE=$(wc -c < android/app/logic.keystore)
+          echo "logic.keystore size: $KSIZE bytes"
+          if [ "$KSIZE" -lt 100 ]; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 secret may be empty or invalid"
+            exit 1
+          fi
 
-      # ── 13. AAB ビルド ────────────────────────────────────
+      # ── 12. AAB ビルド ────────────────────────────────────
       - name: Build release AAB
         working-directory: android
-        run: ./gradlew bundleRelease
-        env:
-          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: ./gradlew bundleRelease --stacktrace
 
-      # ── 14. AAB を成果物として保存 ───────────────────────
+      # ── 13. AAB を成果物として保存 ───────────────────────
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v4
         with:
@@ -126,7 +110,7 @@ jobs:
           path: android/app/build/outputs/bundle/release/app-release.aab
           retention-days: 30
 
-      # ── 15. Play Console 内部テストに配信 ────────────────
+      # ── 14. Play Console 内部テストに配信 ────────────────
       - name: Deploy to Play Console (Internal Test)
         uses: r0adkll/upload-google-play@v1
         with:

--- a/android/key.properties.example
+++ b/android/key.properties.example
@@ -4,8 +4,11 @@
 #
 # キーストアファイル本体（logic-release.keystore）は keystores/ にあるが、
 # パス・パスワード等のシークレットはここに分離する。
+#
+# 注: LOGIC_KEYSTORE_FILE は android/app/build.gradle 起点の相対パス。
+#     <repo>/keystores/logic-release.keystore を指すには ../../keystores/...
 
-LOGIC_KEYSTORE_FILE=../keystores/logic-release.keystore
+LOGIC_KEYSTORE_FILE=../../keystores/logic-release.keystore
 LOGIC_KEYSTORE_PASSWORD=YOUR_KEYSTORE_PASSWORD
 LOGIC_KEY_ALIAS=logic
 LOGIC_KEY_PASSWORD=YOUR_KEY_PASSWORD


### PR DESCRIPTION
## エラー内容
```
> Configure project :app
[***] key.properties が無いため release は debug 鍵で署名されます
WARNING: Using flatDir should be avoided ...

FAILURE: Build failed with an exception.
* Where: Build file '.../android/app/build.gradle' line: 92
* What went wrong:
A problem occurred evaluating project ':app'.
> Cannot invoke method call() on null object
```

## 原因
PR #28 で `build.gradle` を「`key.properties` から署名情報を読む」方式に変えたが、`android-deploy.yml` は依然として **build.gradle 末尾に signingConfigs ブロックを追記する** 旧方式のままだった。

その結果:
1. CI には `key.properties` が無い → 私の `hasReleaseSigning` が false → `signingConfigs.release` 未定義
2. 末尾に追記された `buildTypes { release { signingConfig signingConfigs.release } }` が null 参照で爆発

## 修正
### `.github/workflows/android-deploy.yml`
- 旧 step 11（Decode keystore）と 12（Configure signing）を **1つに統合**
- keystore を decode した後、既存の secrets を `android/key.properties` に書き出すだけ
- これで `build.gradle` の既存ロジックが自然に署名処理を行う
- keystore サイズが 100 bytes 未満の場合は secret 未設定とみなし即エラー
- `bundleRelease` に `--stacktrace` を追加（次回失敗時に原因が見やすい）

### `android/key.properties.example`
`LOGIC_KEYSTORE_FILE` のパスを `../keystores/...` → **`../../keystores/...`** に修正。`app/build.gradle` 起点の相対解決は 2 階層上が正解。

## 必要な GitHub Secrets（既存のはずだがリスト化）
- `ANDROID_KEYSTORE_BASE64` — keystore を `base64 -i logic-release.keystore` した文字列
- `ANDROID_KEYSTORE_PASSWORD`
- `ANDROID_KEY_ALIAS`
- `ANDROID_KEY_PASSWORD`
- `VITE_API_BASE`
- `PLAY_STORE_SERVICE_ACCOUNT_JSON`

## Test plan
マージ後 main プッシュで CI が走ります。期待される結果:
- [ ] `Decode keystore and write key.properties` ステップ成功（keystore size > 100 bytes）
- [ ] `Build release AAB` ステップで signingConfig が読み込まれて成功
- [ ] `Upload AAB artifact` で成果物が添付される
- [ ] `Deploy to Play Console (Internal Test)` で内部テストへ自動配信

もしまた失敗したら `--stacktrace` で詳しいエラーが出るので、ログ貼ってもらえれば追加修正します。

https://claude.ai/code/session_01ATsR64Zh4SGiXxgkysKUvs

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATsR64Zh4SGiXxgkysKUvs)_