### PR TITLE
fix(android): Groovy 変数名衝突で signingConfigs が壊れる問題

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -2,16 +2,18 @@ apply plugin: 'com.android.application'
 
 // 署名情報は android/key.properties から読み込む（コミット禁止・gitignore済）。
 // CI 等で key.properties が無い場合は環境変数からのフォールバックを試す。
+// 注: ローカル変数名は signingConfig DSL のメソッド名（keyAlias / keyPassword）と
+//     衝突するため、`release_*` プレフィクスを付けている。
 def keystoreProperties = new Properties()
 def keystorePropertiesFile = rootProject.file('key.properties')
 if (keystorePropertiesFile.exists()) {
     keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 }
-def keystoreFilePath = keystoreProperties['LOGIC_KEYSTORE_FILE'] ?: System.getenv('LOGIC_KEYSTORE_FILE')
-def keystorePassword = keystoreProperties['LOGIC_KEYSTORE_PASSWORD'] ?: System.getenv('LOGIC_KEYSTORE_PASSWORD')
-def keyAlias           = keystoreProperties['LOGIC_KEY_ALIAS']         ?: System.getenv('LOGIC_KEY_ALIAS')
-def keyPassword        = keystoreProperties['LOGIC_KEY_PASSWORD']      ?: System.getenv('LOGIC_KEY_PASSWORD')
-def hasReleaseSigning  = keystoreFilePath && keystorePassword && keyAlias && keyPassword
+def releaseKeystoreFile     = keystoreProperties['LOGIC_KEYSTORE_FILE']     ?: System.getenv('LOGIC_KEYSTORE_FILE')
+def releaseKeystorePassword = keystoreProperties['LOGIC_KEYSTORE_PASSWORD'] ?: System.getenv('LOGIC_KEYSTORE_PASSWORD')
+def releaseKeyAlias         = keystoreProperties['LOGIC_KEY_ALIAS']         ?: System.getenv('LOGIC_KEY_ALIAS')
+def releaseKeyPassword      = keystoreProperties['LOGIC_KEY_PASSWORD']      ?: System.getenv('LOGIC_KEY_PASSWORD')
+def hasReleaseSigning       = releaseKeystoreFile && releaseKeystorePassword && releaseKeyAlias && releaseKeyPassword
 
 android {
     namespace "io.logic.app"
@@ -32,10 +34,10 @@ android {
     if (hasReleaseSigning) {
         signingConfigs {
             release {
-                storeFile file(keystoreFilePath)
-                storePassword keystorePassword
-                keyAlias keyAlias
-                keyPassword keyPassword
+                storeFile file(releaseKeystoreFile)
+                storePassword releaseKeystorePassword
+                keyAlias releaseKeyAlias
+                keyPassword releaseKeyPassword
             }
         }
     }


### PR DESCRIPTION
## エラー
```
Caused by: groovy.lang.MissingMethodException:
  No signature of method: java.lang.String.call() is applicable for argument types: (String)
  at /home/runner/.../android/app/build.gradle:37
```

## 原因
PR #28 で書いた build.gradle のローカル変数名 `keyAlias` / `keyPassword` が、Android signingConfigs DSL のメソッド名と **同一** 。

```groovy
def keyAlias = ...   // ← ローカル変数

signingConfigs {
    release {
        keyAlias keyAlias  // ← Groovy は "keyAlias" 文字列の .call(keyAlias) と誤解釈
    }
}
```

そのため `String.call()` を呼ぶ羽目になり、メソッド未定義エラーで死亡。

## 修正
ローカル変数を `release_*` プレフィクス付きに改名:

| Before | After |
|---|---|
| `keystoreFilePath` | `releaseKeystoreFile` |
| `keystorePassword` | `releaseKeystorePassword` |
| `keyAlias` ❌衝突 | `releaseKeyAlias` |
| `keyPassword` ❌衝突 | `releaseKeyPassword` |

これで DSL メソッド側（`keyAlias` / `keyPassword`）と区別される。

## Test plan
- マージ後、CI が走り `Build release AAB` ステップが進むはず
- 期待: `BUILD SUCCESSFUL`、AAB が `Upload AAB artifact` で添付
- ダメだったらまた `--stacktrace` のログを貼ってもらえれば対応します

https://claude.ai/code/session_01ATsR64Zh4SGiXxgkysKUvs

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATsR64Zh4SGiXxgkysKUvs)_