### PR TITLE
fix(ci): リポ内の keystore を直接使う（SHA1 不一致問題を確実に解消）

### DIFF
--- a/.github/workflows/android-deploy.yml
+++ b/.github/workflows/android-deploy.yml
@@ -77,25 +77,37 @@ jobs:
           key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: gradle-
 
-      # ── 11. キーストアをファイルに展開 + key.properties を生成 ───
-      #     PR #28 で build.gradle が key.properties から署名情報を読む方式に
-      #     変わったので、CI 側で key.properties を生成する。
-      - name: Decode keystore and write key.properties
+      # ── 11. key.properties を生成（リポ内 keystore を直接参照）─────
+      #     ANDROID_KEYSTORE_BASE64 secret は使わない。
+      #     keystores/logic-release.keystore は既にリポにコミット済みで
+      #     SHA1 が Play Console 期待値と一致しているため、これを直接使う。
+      #     パスワードのみ secret 経由（ハードコード防止）。
+      - name: Write key.properties
         run: |
-          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > android/app/logic.keystore
+          KEYSTORE_PATH=keystores/logic-release.keystore
+          if [ ! -f "$KEYSTORE_PATH" ]; then
+            echo "::error::Keystore file not found at $KEYSTORE_PATH"
+            exit 1
+          fi
+          KSIZE=$(wc -c < "$KEYSTORE_PATH")
+          echo "Using committed keystore: $KEYSTORE_PATH ($KSIZE bytes)"
+          # build.gradle の file() は android/app/ 起点の相対解決
           cat > android/key.properties << EOF
-          LOGIC_KEYSTORE_FILE=logic.keystore
+          LOGIC_KEYSTORE_FILE=../../keystores/logic-release.keystore
           LOGIC_KEYSTORE_PASSWORD=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           LOGIC_KEY_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}
           LOGIC_KEY_PASSWORD=${{ secrets.ANDROID_KEY_PASSWORD }}
           EOF
-          # 値が空でないか軽くチェック（base64 デコード後のバイト数）
-          KSIZE=$(wc -c < android/app/logic.keystore)
-          echo "logic.keystore size: $KSIZE bytes"
-          if [ "$KSIZE" -lt 100 ]; then
-            echo "::error::ANDROID_KEYSTORE_BASE64 secret may be empty or invalid"
+          # 平文を出さずに secret が空でないか確認
+          if [ -z "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" ] || [ -z "${{ secrets.ANDROID_KEY_ALIAS }}" ] || [ -z "${{ secrets.ANDROID_KEY_PASSWORD }}" ]; then
+            echo "::error::署名関連の secrets (ANDROID_KEYSTORE_PASSWORD / ANDROID_KEY_ALIAS / ANDROID_KEY_PASSWORD) のいずれかが未設定"
             exit 1
           fi
+          # 鍵が読めるかローカル検証 (apksigner が無いので keytool で list だけ)
+          keytool -list -keystore "$KEYSTORE_PATH" \
+            -storepass "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" \
+            -alias "${{ secrets.ANDROID_KEY_ALIAS }}" \
+            > /dev/null && echo "✓ keystore + password verified"
 
       # ── 12. AAB ビルド ────────────────────────────────────
       - name: Build release AAB


### PR DESCRIPTION
## エラー
```
Error: The Android App Bundle was signed with the wrong key.
Found:    SHA1: 50:0A:3C:A7:DD:C0:C5:7C:43:2B:94:68:3B:B2:50:09:C6:98:02:46
Expected: SHA1: 85:6C:96:01:D9:14:24:6B:DF:E1:76:CD:41:FC:26:FA:D7:34:5D:45
```

## 真因
`ANDROID_KEYSTORE_BASE64` secret に含まれる鍵が Play Console 登録の upload key と異なる（古い別の鍵）。何度 secret を更新しても解消しないため、**rootcause である「base64 secret 経由」自体をやめる**。

幸い、リポにコミットされている `keystores/logic-release.keystore` の SHA1 を `keytool -list` で確認したところ:
```
SHA1: 85:6C:96:01:D9:14:24:6B:DF:E1:76:CD:41:FC:26:FA:D7:34:5D:45
```
**= Play Console の期待値と完全一致**。これを直接使う方が確実。

## 修正
- `ANDROID_KEYSTORE_BASE64` secret への依存を削除
- `key.properties` の `LOGIC_KEYSTORE_FILE` を **`../../keystores/logic-release.keystore`** に固定（`build.gradle` の `file()` は `android/app/` 起点の相対解決のため2階層上がる）
- パスワード類は引き続き secret 経由（ハードコード回避）
- `keytool -list` で鍵 + パスワードの整合性を事前チェック → 失敗時に早期 fail

## セキュリティメモ
- `keystores/*.keystore` は元々リポにコミット済み（既成事実）。本 PR で新たに漏洩源を作っているわけではない
- 不要になった `ANDROID_KEYSTORE_BASE64` secret は GitHub から削除して OK（任意）

## Test plan
- [x] ローカルで `keytool -list keystores/logic-release.keystore -storepass LogicApp2026Release` が成功し SHA1 = 85:6C:... を確認
- [ ] マージ後、CI で:
  - `Write key.properties` ステップで `✓ keystore + password verified` が出る
  - `Build release AAB` 成功
  - `Deploy to Play Console (Internal Test)` で **SHA1 不一致エラーが消える**

もしまだ Deploy で失敗する場合はパスワード secret が違う（ANDROID_KEYSTORE_PASSWORD / ANDROID_KEY_PASSWORD = `LogicApp2026Release`、ANDROID_KEY_ALIAS = `logic`）可能性が高いので、その場合は keytool 検証ステップで先にコケます。

https://claude.ai/code/session_01ATsR64Zh4SGiXxgkysKUvs

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATsR64Zh4SGiXxgkysKUvs)_