### PR TITLE
fix(server): CORS_ORIGIN を複数オリジン対応・不正文字でクラッシュしないよう堅牢化

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -112,7 +112,25 @@ const app = express()
 // (without this all requests look like they come from the load balancer = no per-IP limiting).
 app.set('trust proxy', 1)
 
-app.use(cors({ origin: process.env.CORS_ORIGIN || 'http://localhost:5173' }))
+// CORS オリジン: カンマ区切りで複数指定可能。制御文字・引用符・前後空白は除去。
+// 例: "capacitor://localhost,https://localhost,https://logic-u5wn.onrender.com"
+function parseCorsOrigins(raw: string | undefined): string[] {
+  const fallback = ['http://localhost:5173']
+  if (!raw) return fallback
+  // eslint-disable-next-line no-control-regex
+  const cleaned = raw
+    .split(',')
+    .map(s => s.replace(/[\x00-\x1f\x7f"']/g, '').trim())
+    .filter(Boolean)
+  if (cleaned.length === 0) {
+    console.warn('[WARN] CORS_ORIGIN contained no valid entries — falling back to default')
+    return fallback
+  }
+  return cleaned
+}
+const corsOrigins = parseCorsOrigins(process.env.CORS_ORIGIN)
+console.log('[CORS] allowed origins:', corsOrigins.join(', '))
+app.use(cors({ origin: corsOrigins }))
 
 // Billing ルート（Stripe webhook は RAW ボディが必要なので express.json() より前にマウント）
 if (supabase) {


### PR DESCRIPTION
## 背景
本番 (`logic-u5wn.onrender.com`) が起動直後に以下で落ちて応答しなくなっていた:

```
TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["Access-Control-Allow-Origin"]
    at applyHeaders (.../cors/lib/index.js:153:15)
```

原因: Render 側の `CORS_ORIGIN` 環境変数に制御文字（改行など）が混入しており、cors ミドルウェアが ACAO ヘッダ設定時に Node の `setHeader` で例外を投げていた。

## 変更内容
`server/index.ts` の cors 初期化部分を以下のように堅牢化:

- **複数オリジン対応**: カンマ区切りで複数指定可能に
  - 例: `capacitor://localhost,https://localhost,https://logic-u5wn.onrender.com`
  - iOS (`capacitor://localhost`) と Android (`https://localhost`) の両方を許可するため必須
- **不正文字サニタイズ**: 制御文字 (0x00-0x1F)、DEL (0x7F)、引用符 (`"` `'`) を除去 + 前後空白 trim
- **空/不正フォールバック**: 全エントリが除去された場合は警告ログを出してデフォルトに戻す
- **起動ログ追加**: 許可オリジン一覧を起動時に出力（運用時の検証用）

## デプロイ手順
1. このPRをマージ
2. Render ダッシュボードから `logic` サービスを Manual Deploy
3. （任意）`CORS_ORIGIN` を以下に更新済みであることを再確認:
   ```
   capacitor://localhost,https://localhost,https://logic-u5wn.onrender.com
   ```

## テスト
ローカルで `parseCorsOrigins` のロジックを以下の入力で検証済み:
- 通常: `"capacitor://localhost,https://localhost,https://logic-u5wn.onrender.com"` → 3件
- 改行・空白・引用符混入: → 全て除去されて正常パース
- 空文字 / undefined / カンマのみ: → デフォルトにフォールバック

---
_Generated by [Claude Code](https://claude.ai/code/session_017L9McqWbdBU3vYNbPHHDuz)_