### PR TITLE
Add flashcard review modes (due and weak cards)

### DIFF
--- a/src/AppV3.tsx
+++ b/src/AppV3.tsx
@@ -80,7 +80,7 @@ type Screen =
   | { type: 'profile' }
   | { type: 'lesson'; lessonId: number }
   | { type: 'lesson-complete'; lessonId: number; durationSec: number; prevLevel: number }
-  | { type: 'flashcards' }
+  | { type: 'flashcards'; mode?: 'due' | 'weak' }
   | { type: 'fermi' }
   | { type: 'daily-fermi' }
   | { type: 'deviation' }
@@ -376,6 +376,7 @@ function AppV3() {
           onOpenRoadmap={() => { setTab('lessons'); navigate({ type: 'lessons' }, true) }}
           onNavigateToDailyFermi={() => navigate({ type: 'daily-fermi' })}
           onOpenPlacementTest={() => navigate({ type: 'placement-test' })}
+          onOpenFlashcards={(mode) => navigate({ type: 'flashcards', mode })}
         />
       )}
 
@@ -396,7 +397,7 @@ function AppV3() {
         />
       )}
 
-      {screen.type === 'flashcards' && <FlashcardsScreen onBack={handleBack} />}
+      {screen.type === 'flashcards' && <FlashcardsScreen onBack={handleBack} mode={screen.mode} />}
       {screen.type === 'fermi' && <FermiScreen onBack={handleBack} onReport={(ctx) => navigate({ type: 'report-problem', context: ctx })} />}
       {screen.type === 'daily-fermi' && <DailyFermiScreen onBack={handleBack} onReport={(ctx) => navigate({ type: 'report-problem', context: ctx })} />}
       {screen.type === 'journal-input' && <JournalInputScreen onBack={handleBack} />}

--- a/src/flashcardData.ts
+++ b/src/flashcardData.ts
@@ -83,12 +83,25 @@ export function getDueCards(): Flashcard[] {
   return loadCards().filter((c) => c.nextReview <= today)
 }
 
+/** 過去に間違えたことがあるカード（弱点カード）。間違えた回数が多い順 */
+export function getWeakCards(): Flashcard[] {
+  return loadCards()
+    .filter((c) => c.wrongCount > 0)
+    .sort((a, b) => {
+      const aScore = b.wrongCount - b.correctCount
+      const bScore = a.wrongCount - a.correctCount
+      if (aScore !== bScore) return aScore - bScore
+      return b.wrongCount - a.wrongCount
+    })
+}
+
 export function getCardStats() {
   const cards = loadCards()
   const today = new Date().toISOString().slice(0, 10)
   const due = cards.filter((c) => c.nextReview <= today).length
+  const weak = cards.filter((c) => c.wrongCount > 0).length
   const mastered = cards.filter((c) => c.correctCount >= 3 && c.interval >= 7).length
-  return { total: cards.length, due, mastered }
+  return { total: cards.length, due, weak, mastered }
 }
 
 // Generate flashcards from lesson quiz results

--- a/src/screens/FlashcardsScreen.tsx
+++ b/src/screens/FlashcardsScreen.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { getDueCards, reviewCard, type Flashcard } from '../flashcardData'
+import { getDueCards, getWeakCards, reviewCard, type Flashcard } from '../flashcardData'
 import { ArrowLeftIcon, CheckIcon } from '../icons'
 import { Button } from '../components/Button'
 import { IconButton } from '../components/IconButton'
@@ -7,10 +7,13 @@ import { t } from '../i18n'
 
 interface FlashcardsScreenProps {
   onBack: () => void
+  mode?: 'due' | 'weak'
 }
 
-export function FlashcardsScreen({ onBack }: FlashcardsScreenProps) {
-  const [queue] = useState<Flashcard[]>(() => getDueCards())
+export function FlashcardsScreen({ onBack, mode = 'due' }: FlashcardsScreenProps) {
+  const [queue] = useState<Flashcard[]>(() =>
+    mode === 'weak' ? getWeakCards() : getDueCards(),
+  )
   const [idx, setIdx] = useState(0)
   const [flipped, setFlipped] = useState(false)
   const total = useMemo(() => queue.length, [queue.length])
@@ -55,10 +58,14 @@ export function FlashcardsScreen({ onBack }: FlashcardsScreenProps) {
         <div className="card empty" style={{ padding: 'var(--s-7)' }}>
           <div style={{ fontSize: 40, marginBottom: 'var(--s-3)' }}>✨</div>
           <h3 style={{ fontSize: 20, marginBottom: 'var(--s-2)' }}>
-            復習するカードはありません
+            {mode === 'weak'
+              ? '復習する弱点カードはありません'
+              : '復習するカードはありません'}
           </h3>
           <p className="muted" style={{ fontSize: 16 }}>
-            レッスンを完了するとここにカードが追加されます
+            {mode === 'weak'
+              ? 'まだ間違えた問題がありません。レッスンを進めましょう。'
+              : 'レッスンを完了するとここにカードが追加されます'}
           </p>
         </div>
       ) : done ? (

--- a/src/screens/HomeScreenV3.tsx
+++ b/src/screens/HomeScreenV3.tsx
@@ -5,6 +5,7 @@
  */
 import { useRef } from 'react'
 import { getDailyFermi } from '../fermiData'
+import { getCardStats } from '../flashcardData'
 import { v3 } from '../styles/tokensV3'
 import { HomeCoachmark, useShouldShowHomeCoachmark } from '../tutorial/coachmark'
 import { PlacementCard } from '../tutorial/placementCard'
@@ -71,12 +72,13 @@ interface HomeScreenV3Props {
   onOpenStats?: () => void
   onNavigateToDailyFermi?: () => void
   onOpenPlacementTest?: () => void
+  onOpenFlashcards?: (mode?: 'due' | 'weak') => void
 }
 
 const IMG = '/images/v3'
 
 export function HomeScreenV3(props: HomeScreenV3Props) {
-  const { userName, onOpenLesson, onOpenAIGen, onOpenRoleplay, onNavigateToDailyFermi, onOpenPlacementTest, onOpenCategory: _onOpenCategory, onOpenRank: _onOpenRank, onOpenStats: _onOpenStats, onOpenRoadmap: _onOpenRoadmap } = props
+  const { userName, onOpenLesson, onOpenAIGen, onOpenRoleplay, onNavigateToDailyFermi, onOpenPlacementTest, onOpenFlashcards, onOpenCategory: _onOpenCategory, onOpenRank: _onOpenRank, onOpenStats: _onOpenStats, onOpenRoadmap: _onOpenRoadmap } = props
   const dailyCardRef = useRef<HTMLDivElement>(null)
   const [showCoachmark, dismissCoachmark] = useShouldShowHomeCoachmark()
   const { width } = useWindowSize()
@@ -87,6 +89,7 @@ export function HomeScreenV3(props: HomeScreenV3Props) {
   const recommendedLesson = useRef(getRandomLesson()).current
   const dailyFermi = getDailyFermi()
   const fermiQuestion = dailyFermi.question
+  const cardStats = getCardStats()
 
 
 
@@ -139,6 +142,16 @@ export function HomeScreenV3(props: HomeScreenV3Props) {
           </div>
         </div>
 
+        {/* 復習カード - 過去に学んだ内容と間違えた問題を重点復習 */}
+        {onOpenFlashcards && cardStats.total > 0 && (
+          <ReviewCard
+            due={cardStats.due}
+            weak={cardStats.weak}
+            total={cardStats.total}
+            onOpen={(mode) => onOpenFlashcards(mode)}
+          />
+        )}
+
         {/* Hero Recommend - ランダム表示 */}
         <div
           onClick={() => onOpenLesson(recommendedLesson.id)}
@@ -186,6 +199,86 @@ export function HomeScreenV3(props: HomeScreenV3Props) {
       />
     )}
     </>
+  )
+}
+
+function ReviewCard({ due, weak, total, onOpen }: { due: number; weak: number; total: number; onOpen: (mode?: 'due' | 'weak') => void }) {
+  const hasDue = due > 0
+  const hasWeak = weak > 0
+  const primaryMode: 'due' | 'weak' = hasDue ? 'due' : 'weak'
+  const headline = hasDue
+    ? `今日の復習 ${due}枚`
+    : hasWeak
+      ? `弱点の復習 ${weak}枚`
+      : 'すべて完了'
+  const sub = hasDue
+    ? hasWeak
+      ? `うち弱点 ${weak}枚 · 全${total}枚`
+      : `全${total}枚`
+    : hasWeak
+      ? `間違えた問題を重点的に学び直そう`
+      : `また明日カードを追加しましょう`
+
+  return (
+    <div
+      onClick={() => onOpen(primaryMode)}
+      style={{
+        background: v3.color.card,
+        borderRadius: v3.radius.card,
+        padding: '18px 20px',
+        cursor: 'pointer',
+        boxShadow: v3.shadow.card,
+        flexShrink: 0,
+        position: 'relative',
+        overflow: 'hidden',
+        border: hasDue || hasWeak ? `1px solid ${v3.color.accentSoft}` : '1px solid transparent',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+        <div style={{
+          width: 44, height: 44, flexShrink: 0,
+          borderRadius: 12,
+          background: v3.color.accentSoft,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          color: v3.color.accent,
+        }}>
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M3 12a9 9 0 1 0 3-6.7" />
+            <path d="M3 4v5h5" />
+          </svg>
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2 }}>
+            <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: '.12em', textTransform: 'uppercase', color: v3.color.accent }}>復習</span>
+          </div>
+          <div style={{ fontSize: 16, fontWeight: 700, lineHeight: 1.35, marginBottom: 2 }}>{headline}</div>
+          <div style={{ fontSize: 13, color: v3.color.text2, fontWeight: 500, lineHeight: 1.4 }}>{sub}</div>
+        </div>
+        <div style={{ color: v3.color.text3, fontSize: 22, fontWeight: 400, lineHeight: 1, paddingLeft: 4 }}>›</div>
+      </div>
+
+      {hasDue && hasWeak && (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onOpen('weak') }}
+          style={{
+            marginTop: 12,
+            width: '100%',
+            background: 'transparent',
+            border: `1px solid ${v3.color.line}`,
+            borderRadius: v3.radius.pill,
+            padding: '10px 14px',
+            color: v3.color.text,
+            fontSize: 14,
+            fontWeight: 600,
+            cursor: 'pointer',
+            fontFamily: "'Noto Sans JP', sans-serif",
+          }}
+        >
+          弱点だけ復習する（{weak}枚）
+        </button>
+      )}
+    </div>
   )
 }
 

--- a/src/screens/HomeScreenV3.tsx
+++ b/src/screens/HomeScreenV3.tsx
@@ -142,16 +142,6 @@ export function HomeScreenV3(props: HomeScreenV3Props) {
           </div>
         </div>
 
-        {/* 復習カード - 過去に学んだ内容と間違えた問題を重点復習 */}
-        {onOpenFlashcards && cardStats.total > 0 && (
-          <ReviewCard
-            due={cardStats.due}
-            weak={cardStats.weak}
-            total={cardStats.total}
-            onOpen={(mode) => onOpenFlashcards(mode)}
-          />
-        )}
-
         {/* Hero Recommend - ランダム表示 */}
         <div
           onClick={() => onOpenLesson(recommendedLesson.id)}
@@ -178,6 +168,16 @@ export function HomeScreenV3(props: HomeScreenV3Props) {
         {/* 診断カード（HeroRecommendの直下） */}
         {!hasCompletedPlacement() && onOpenPlacementTest && (
           <PlacementCard onTakeTest={onOpenPlacementTest} />
+        )}
+
+        {/* 復習カード - 過去に学んだ内容と間違えた問題を重点復習 */}
+        {onOpenFlashcards && cardStats.total > 0 && (
+          <ReviewCard
+            due={cardStats.due}
+            weak={cardStats.weak}
+            total={cardStats.total}
+            onOpen={(mode) => onOpenFlashcards(mode)}
+          />
         )}
 
         {/* AI practice cards (large, vertical) */}


### PR DESCRIPTION
## Summary
This PR adds support for two flashcard review modes to the home screen: reviewing cards due today and reviewing weak cards (previously incorrect answers). Users can now access flashcard reviews directly from the home screen with a new ReviewCard component that displays statistics and allows switching between review modes.

## Key Changes
- **New ReviewCard component** on HomeScreenV3 that displays flashcard statistics (due cards, weak cards, total cards) and provides quick access to review modes
- **Weak cards mode** in FlashcardsScreen that filters and sorts cards by mistake frequency (cards with more wrong answers appear first)
- **New `getWeakCards()` function** in flashcardData.ts that returns cards with wrong attempts, sorted by error rate
- **Updated `getCardStats()`** to include weak card count alongside due and mastered counts
- **Mode parameter** added to flashcard navigation to support switching between 'due' and 'weak' review modes
- **Conditional messaging** in FlashcardsScreen that adapts empty state and completion messages based on the active review mode

## Implementation Details
- The ReviewCard intelligently determines the primary review mode (due cards take priority over weak cards)
- When both due and weak cards exist, a secondary button allows users to switch to weak card review
- Weak cards are sorted by a score calculation: `(wrongCount - correctCount)` descending, then by `wrongCount` descending
- The review mode is passed through the navigation stack from HomeScreenV3 → AppV3 → FlashcardsScreen

https://claude.ai/code/session_01FPadAv2VzwzffmfP8mWwpg