### PR TITLE
Persist tutorial FAB dismissal state in localStorage

### DIFF
--- a/src/AppV3.tsx
+++ b/src/AppV3.tsx
@@ -53,6 +53,7 @@ import { isAdmin } from './admin'
 import { onAuthChange, logout, getInitialUser, type User } from './supabase'
 import { syncOnLogin, syncOnLogout } from './syncService'
 import { TutorialOverlay, TutorialFAB } from './components/TutorialOverlay'
+import { tutorial } from './tutorial/tutorialStorage'
 
 const ONBOARDED_KEY = 'logic-onboarded'
 const INSTALL_ID_KEY = 'logic-install-id'
@@ -143,7 +144,7 @@ function AppV3() {
   const [currentUser, setCurrentUser] = useState<User | null>(null)
   const [authReady, setAuthReady] = useState(false)
   const [showTutorial, setShowTutorial] = useState(false)
-  const [showFAB, setShowFAB] = useState(true)
+  const [showFAB, setShowFAB] = useState(() => !tutorial.hasFABDismissed())
   const [showNamePopup, setShowNamePopup] = useState(false)
   const [nameInput, setNameInput] = useState('')
   const [nameSaving, setNameSaving] = useState(false)
@@ -570,7 +571,7 @@ function AppV3() {
     {/* SCRUM-195: チュートリアルオーバーレイ */}
     {/* チュートリアルFAB（右下固定ボタン） */}
     {screen.type === 'home' && !showTutorial && showFAB && (
-      <TutorialFAB onClick={() => setShowTutorial(true)} onHide={() => setShowFAB(false)} />
+      <TutorialFAB onClick={() => setShowTutorial(true)} onHide={() => { tutorial.markFABDismissed(); setShowFAB(false) }} />
     )}
     {showTutorial && (
       <TutorialOverlay

--- a/src/tutorial/tutorialStorage.ts
+++ b/src/tutorial/tutorialStorage.ts
@@ -3,6 +3,7 @@ const KEYS = {
   daily: 'logic-tutorial-daily-done',
   lesson: 'logic-tutorial-lesson-done',
   placementDismissed: 'logic-tutorial-placement-dismissed',
+  fabDismissed: 'logic-tutorial-fab-dismissed',
 } as const
 
 export const tutorial = {
@@ -10,8 +11,10 @@ export const tutorial = {
   hasSeenDaily: () => { try { return localStorage.getItem(KEYS.daily) === '1' } catch { return false } },
   hasSeenLesson: () => { try { return localStorage.getItem(KEYS.lesson) === '1' } catch { return false } },
   hasPlacementDismissed: () => { try { return localStorage.getItem(KEYS.placementDismissed) === '1' } catch { return false } },
+  hasFABDismissed: () => { try { return localStorage.getItem(KEYS.fabDismissed) === '1' } catch { return false } },
   markHome: () => { try { localStorage.setItem(KEYS.home, '1') } catch { /* */ } },
   markDaily: () => { try { localStorage.setItem(KEYS.daily, '1') } catch { /* */ } },
   markLesson: () => { try { localStorage.setItem(KEYS.lesson, '1') } catch { /* */ } },
   markPlacementDismissed: () => { try { localStorage.setItem(KEYS.placementDismissed, '1') } catch { /* */ } },
+  markFABDismissed: () => { try { localStorage.setItem(KEYS.fabDismissed, '1') } catch { /* */ } },
 }


### PR DESCRIPTION
## Summary
This PR adds persistent storage for the tutorial FAB (Floating Action Button) dismissal state, ensuring that when users dismiss the tutorial FAB, it remains hidden across browser sessions.

## Key Changes
- **tutorialStorage.ts**: Added FAB dismissal tracking to the tutorial storage module
  - New `fabDismissed` key in the KEYS constant
  - New `hasFABDismissed()` method to check if FAB has been dismissed
  - New `markFABDismissed()` method to persist the dismissal state
  
- **AppV3.tsx**: Updated FAB state management to use persistent storage
  - Changed `showFAB` initial state from hardcoded `true` to `!tutorial.hasFABDismissed()` to respect saved dismissal state
  - Updated the FAB `onHide` callback to call `tutorial.markFABDismissed()` before hiding the FAB

## Implementation Details
- Follows the existing pattern used for other tutorial state tracking (home, daily, lesson, placement)
- Uses localStorage with try-catch error handling for robustness
- FAB will now remain hidden on subsequent visits after user dismissal

https://claude.ai/code/session_01KN9jyzedHQWRMMX9VMSCfk