### PR TITLE
Show course titles grouped into 5 themes on the Lessons grid

### DIFF
--- a/src/courseData.ts
+++ b/src/courseData.ts
@@ -24,11 +24,11 @@ export type CourseGroup = {
 }
 
 export const COURSE_GROUPS: CourseGroup[] = [
-  { id: 'foundations',     label: '思考の基礎',       description: '論理と批判思考で、考える土台をつくる' },
-  { id: 'problem-solving', label: '課題発見・解決',   description: '問いを立て、仮説と構造で本質を捉える' },
-  { id: 'creative',        label: '発想・創造',       description: '常識を超え、新しい切り口を生み出す' },
-  { id: 'communication',   label: '伝える・提案する', description: '相手の判断基準から逆算して動かす' },
-  { id: 'business',        label: 'ビジネス実践',     description: '戦略・数字・ケースで現場に応用する' },
+  { id: 'foundations',     label: '論理的に考え、批判的に問い直す',  description: '論理・批判・哲学で、考える土台を固める' },
+  { id: 'problem-solving', label: '本質的な課題を見極めて、解決する', description: '問いを立て、仮説と構造で本質を捉える' },
+  { id: 'creative',        label: '常識を超えて、発想を広げる',       description: 'リフレーミングと類推で、新しい切り口を生む' },
+  { id: 'communication',   label: '論点を整理し、相手を動かす',       description: '対話・提案・面接で、論理を相手に届ける' },
+  { id: 'business',        label: '数字と戦略で、ビジネスを動かす',   description: 'クライアント現場・戦略・数字感覚を総動員する' },
 ]
 
 export const COURSES: Course[] = [
@@ -143,7 +143,7 @@ export const COURSES: Course[] = [
     id: 'philosophy-01',
     title: '哲学の問いで、思考を深める',
     category: '哲学・思考の原理',
-    group: 'creative',
+    group: 'foundations',
     lessonIds: [77, 78, 79, 80, 81],
     level: '上級',
     description: 'ソクラテスの問答法と反証可能性を通じて、思考の原理を学ぶ。',
@@ -185,7 +185,7 @@ export const COURSES: Course[] = [
     id: 'client-02',
     title: '論点を定め、深く引き出す',
     category: 'クライアントワーク',
-    group: 'business',
+    group: 'communication',
     lessonIds: [93, 94, 95, 96, 315],
     level: '中級',
     description: '正しい論点設定とヒアリング技術で、クライアントの本質的な課題を引き出す。',
@@ -205,7 +205,7 @@ export const COURSES: Course[] = [
     id: 'case-01',
     title: 'ケース面接で、論理力を証明する',
     category: 'ケース面接',
-    group: 'business',
+    group: 'communication',
     lessonIds: [28, 29, 35, 36, 316],
     level: '上級',
     description: '利益構造の分解から市場参入まで、ケース面接の頻出テーマを体系的に攻略する。',

--- a/src/courseData.ts
+++ b/src/courseData.ts
@@ -1,13 +1,35 @@
 // courseData.ts — コース定義（1コース = 5レッスン）
 
+export type CourseGroupId =
+  | 'foundations'    // 思考の基礎
+  | 'problem-solving'// 課題発見・解決
+  | 'creative'       // 発想・創造
+  | 'communication'  // 伝える・提案する
+  | 'business'       // ビジネス実践
+
 export type Course = {
   id: string
   title: string           // Doingタイトル
   category: string        // カテゴリ（大分類）
+  group: CourseGroupId    // コース一覧でのグルーピング
   lessonIds: number[]     // 5件のレッスンID
   level: '初級' | '中級' | '上級'
   description: string
 }
+
+export type CourseGroup = {
+  id: CourseGroupId
+  label: string
+  description: string
+}
+
+export const COURSE_GROUPS: CourseGroup[] = [
+  { id: 'foundations',     label: '思考の基礎',       description: '論理と批判思考で、考える土台をつくる' },
+  { id: 'problem-solving', label: '課題発見・解決',   description: '問いを立て、仮説と構造で本質を捉える' },
+  { id: 'creative',        label: '発想・創造',       description: '常識を超え、新しい切り口を生み出す' },
+  { id: 'communication',   label: '伝える・提案する', description: '相手の判断基準から逆算して動かす' },
+  { id: 'business',        label: 'ビジネス実践',     description: '戦略・数字・ケースで現場に応用する' },
+]
 
 export const COURSES: Course[] = [
   // ── ロジカルシンキング ──────────────────────────────
@@ -15,6 +37,7 @@ export const COURSES: Course[] = [
     id: 'logic-01',
     title: 'ロジカルに考えて、整理する',
     category: 'ロジカルシンキング',
+    group: 'foundations',
     lessonIds: [20, 21, 22, 23, 24],
     level: '初級',
     description: 'MECEとロジックツリーで、考えを漏れなく・ダブりなく整理する力を身につける。',
@@ -23,6 +46,7 @@ export const COURSES: Course[] = [
     id: 'logic-02',
     title: '論理を組み立て、相手を動かす',
     category: 'ロジカルシンキング',
+    group: 'foundations',
     lessonIds: [25, 26, 27, 68, 23],
     level: '初級',
     description: 'So What / Why Soで論理を検証し、ピラミッド構造で伝わる話し方を習得する。',
@@ -33,6 +57,7 @@ export const COURSES: Course[] = [
     id: 'critical-01',
     title: '思い込みを疑い、正しく判断する',
     category: 'クリティカルシンキング',
+    group: 'foundations',
     lessonIds: [40, 41, 42, 43, 69],
     level: '初級',
     description: '批判的思考の基礎から論理的誤謬の見破り方まで、判断力を鍛える。',
@@ -41,6 +66,7 @@ export const COURSES: Course[] = [
     id: 'critical-02',
     title: 'バイアスを外し、客観的に見る',
     category: 'クリティカルシンキング',
+    group: 'foundations',
     lessonIds: [71, 300, 301, 302, 303],
     level: '中級',
     description: '確証バイアスをはじめとした認知の歪みを理解し、より精度の高い判断をする。',
@@ -51,6 +77,7 @@ export const COURSES: Course[] = [
     id: 'hypothesis-01',
     title: '仮説を立ててから、調べる',
     category: '仮説思考',
+    group: 'problem-solving',
     lessonIds: [50, 51, 52, 70, 304],
     level: '中級',
     description: '仮説を先に立て、検証で磨く思考サイクルを身につける。',
@@ -61,6 +88,7 @@ export const COURSES: Course[] = [
     id: 'problem-01',
     title: '本当の問題を見極め、定義する',
     category: '課題設定',
+    group: 'problem-solving',
     lessonIds: [53, 54, 55, 305, 306],
     level: '中級',
     description: '問題と課題の違いを理解し、本質的な問いを設定する力を養う。',
@@ -71,9 +99,21 @@ export const COURSES: Course[] = [
     id: 'design-01',
     title: 'ユーザーの本音を掘り下げ、解決する',
     category: 'デザインシンキング',
+    group: 'problem-solving',
     lessonIds: [56, 57, 58, 307, 308],
     level: '初級',
     description: '共感からプロトタイプまで、人間中心設計の思考プロセスを実践する。',
+  },
+
+  // ── システムシンキング ──────────────────────────────
+  {
+    id: 'systems-01',
+    title: '全体を俯瞰し、根本から変える',
+    category: 'システムシンキング',
+    group: 'problem-solving',
+    lessonIds: [65, 66, 67, 313, 314],
+    level: '上級',
+    description: 'フィードバックループと氷山モデルで、問題の根本原因を構造的に捉える。',
   },
 
   // ── ラテラルシンキング ──────────────────────────────
@@ -81,6 +121,7 @@ export const COURSES: Course[] = [
     id: 'lateral-01',
     title: '常識を疑い、突破口を開く',
     category: 'ラテラルシンキング',
+    group: 'creative',
     lessonIds: [59, 60, 61, 309, 310],
     level: '中級',
     description: 'リフレーミングと逆転の発想で、固定観念を超えたアイデアを生み出す。',
@@ -91,19 +132,21 @@ export const COURSES: Course[] = [
     id: 'analogy-01',
     title: '別分野の知恵を借りて、応用する',
     category: 'アナロジー思考',
+    group: 'creative',
     lessonIds: [62, 63, 64, 311, 312],
     level: '中級',
     description: '構造的類似性を見抜き、異分野の知見を自分の課題に応用する。',
   },
 
-  // ── システムシンキング ──────────────────────────────
+  // ── 哲学 ────────────────────────────────────────────
   {
-    id: 'systems-01',
-    title: '全体を俯瞰し、根本から変える',
-    category: 'システムシンキング',
-    lessonIds: [65, 66, 67, 313, 314],
+    id: 'philosophy-01',
+    title: '哲学の問いで、思考を深める',
+    category: '哲学・思考の原理',
+    group: 'creative',
+    lessonIds: [77, 78, 79, 80, 81],
     level: '上級',
-    description: 'フィードバックループと氷山モデルで、問題の根本原因を構造的に捉える。',
+    description: 'ソクラテスの問答法と反証可能性を通じて、思考の原理を学ぶ。',
   },
 
   // ── 提案・伝える技術 ────────────────────────────────
@@ -111,6 +154,7 @@ export const COURSES: Course[] = [
     id: 'proposal-01',
     title: '相手が動く提案をつくる',
     category: '提案・伝える技術',
+    group: 'communication',
     lessonIds: [72, 73, 74, 75, 76],
     level: '中級',
     description: '読み手の判断基準から逆算し、決断を引き出す提案書の構造を習得する。',
@@ -121,19 +165,10 @@ export const COURSES: Course[] = [
     id: 'proposal-course-01',
     title: '仮説と検証で、提案書を仕上げる',
     category: '提案書作成',
+    group: 'communication',
     lessonIds: [82, 83, 84, 86, 87],
     level: '上級',
     description: 'コンサル的アプローチで仮説を立て、検証しながら説得力のある提案書を完成させる。',
-  },
-
-  // ── 哲学 ────────────────────────────────────────────
-  {
-    id: 'philosophy-01',
-    title: '哲学の問いで、思考を深める',
-    category: '哲学・思考の原理',
-    lessonIds: [77, 78, 79, 80, 81],
-    level: '上級',
-    description: 'ソクラテスの問答法と反証可能性を通じて、思考の原理を学ぶ。',
   },
 
   // ── クライアントワーク ──────────────────────────────
@@ -141,6 +176,7 @@ export const COURSES: Course[] = [
     id: 'client-01',
     title: '数字で状況を素早く読み解く',
     category: 'クライアントワーク',
+    group: 'business',
     lessonIds: [89, 90, 91, 92, 97],
     level: '中級',
     description: '桁感覚と概算力を鍛え、クライアントの場でも即座に数字を扱えるようになる。',
@@ -149,6 +185,7 @@ export const COURSES: Course[] = [
     id: 'client-02',
     title: '論点を定め、深く引き出す',
     category: 'クライアントワーク',
+    group: 'business',
     lessonIds: [93, 94, 95, 96, 315],
     level: '中級',
     description: '正しい論点設定とヒアリング技術で、クライアントの本質的な課題を引き出す。',
@@ -157,6 +194,7 @@ export const COURSES: Course[] = [
     id: 'client-03',
     title: '未経験の業界で、短期間で立ち上がる',
     category: 'クライアントワーク',
+    group: 'business',
     lessonIds: [330, 331, 332, 333, 334, 335],
     level: '上級',
     description: '本・事例・有識者・仮説を総動員し、新しい案件で「専門家」として価値発揮するキャッチアップの技術を学ぶ。',
@@ -167,6 +205,7 @@ export const COURSES: Course[] = [
     id: 'case-01',
     title: 'ケース面接で、論理力を証明する',
     category: 'ケース面接',
+    group: 'business',
     lessonIds: [28, 29, 35, 36, 316],
     level: '上級',
     description: '利益構造の分解から市場参入まで、ケース面接の頻出テーマを体系的に攻略する。',
@@ -177,6 +216,7 @@ export const COURSES: Course[] = [
     id: 'strategy-01',
     title: '戦略の源流と競争戦略を学ぶ',
     category: '経営戦略',
+    group: 'business',
     lessonIds: [320, 321, 322, 323, 324],
     level: '上級',
     description: 'テイラー・フォードからアンゾフ、PPM、ポーターまで。経営戦略の古典理論を通史的に押さえる。',
@@ -185,6 +225,7 @@ export const COURSES: Course[] = [
     id: 'strategy-02',
     title: '資源・能力・共進化の戦略へ',
     category: '経営戦略',
+    group: 'business',
     lessonIds: [325, 326, 327, 328, 329],
     level: '上級',
     description: 'RBV・コアコンピタンスからブルーオーシャン、ダイナミック・ケイパビリティ、プラットフォーム戦略まで現代の進化を学ぶ。',
@@ -195,6 +236,7 @@ export const COURSES: Course[] = [
     id: 'fermi-01',
     title: '概算で、世界の規模を掴む',
     category: 'フェルミ推定',
+    group: 'business',
     lessonIds: [200, 201, 202, 203, 204],
     level: '中級',
     description: '数式を立てて分解し、正確さより「だいたい正しい」答えを素早く出す力を鍛える。',
@@ -205,6 +247,7 @@ export const COURSES: Course[] = [
     id: 'numeracy-01',
     title: '数字に強くなる',
     category: '数字に強くなる',
+    group: 'business',
     lessonIds: [401, 400, 402, 403, 404, 405, 406],
     level: '中級',
     description: '伝え方・暗算・割合操作・単位換算・複利・統計・落とし穴の7本立てで、ビジネス数字感覚を体系的に鍛える。',
@@ -219,4 +262,13 @@ export function getCoursesByCategory(category: string): Course[] {
 // 全カテゴリ一覧（重複なし・順序保持）
 export function getAllCategories(): string[] {
   return [...new Set(COURSES.map(c => c.category))]
+}
+
+// グループ別コース一覧
+export function getCoursesByGroup(group: CourseGroupId): Course[] {
+  return COURSES.filter(c => c.group === group)
+}
+
+export function getCourseById(id: string): Course | undefined {
+  return COURSES.find(c => c.id === id)
 }

--- a/src/courseData.ts
+++ b/src/courseData.ts
@@ -24,11 +24,11 @@ export type CourseGroup = {
 }
 
 export const COURSE_GROUPS: CourseGroup[] = [
-  { id: 'foundations',     label: '論理的に考え、批判的に問い直す',  description: '論理・批判・哲学で、考える土台を固める' },
-  { id: 'problem-solving', label: '本質的な課題を見極めて、解決する', description: '問いを立て、仮説と構造で本質を捉える' },
-  { id: 'creative',        label: '常識を超えて、発想を広げる',       description: 'リフレーミングと類推で、新しい切り口を生む' },
-  { id: 'communication',   label: '論点を整理し、相手を動かす',       description: '対話・提案・面接で、論理を相手に届ける' },
-  { id: 'business',        label: '数字と戦略で、ビジネスを動かす',   description: 'クライアント現場・戦略・数字感覚を総動員する' },
+  { id: 'foundations',     label: '論理的に考える',  description: '論理・批判・哲学で土台を固める' },
+  { id: 'problem-solving', label: '課題を解決する',  description: '仮説と構造で本質に迫る' },
+  { id: 'creative',        label: '発想を広げる',    description: '常識を超えて、新しい切り口を生む' },
+  { id: 'communication',   label: '相手を動かす',    description: '提案・面接・ヒアリングで論理を届ける' },
+  { id: 'business',        label: '現場で実践する',  description: '戦略・数字・クライアント実務に活かす' },
 ]
 
 export const COURSES: Course[] = [

--- a/src/screens/RoadmapScreenV3.tsx
+++ b/src/screens/RoadmapScreenV3.tsx
@@ -11,9 +11,123 @@ import LessonIcon from '../LessonIcon'
 import { getAllLessonsFlat } from '../lessonData'
 import type { LessonData } from '../lessonData'
 import { getCompletedLessons } from '../stats'
-import { getCoursesByCategory, COURSES, type Course } from '../courseData'
+import { getCoursesByCategory, getCoursesByGroup, COURSES, COURSE_GROUPS, type Course } from '../courseData'
 
 const IMG = '/images/v3'
+
+// ──────── カテゴリ別ビジュアル（アイコン・色・画像） ────────
+type CategoryVisual = {
+  icon: ReactNode
+  iconBg: string
+  image: string
+  routeKey: string  // CategoryDetailView へ渡す識別子
+}
+
+const CATEGORY_VISUAL: Record<string, CategoryVisual> = {
+  'ロジカルシンキング': {
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={v3.color.accent} strokeWidth="2" strokeLinecap="round"><path d="M3 3h7v7H3zM14 3h7v7h-7zM3 14h7v7H3zM14 14h7v7h-7z"/></svg>,
+    iconBg: 'rgba(108,142,245,.14)',
+    image: `${IMG}/course-logical.webp`,
+    routeKey: 'logic',
+  },
+  'クリティカルシンキング': {
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#F87171" strokeWidth="2" strokeLinecap="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>,
+    iconBg: 'rgba(248,113,113,.14)',
+    image: `${IMG}/lesson-critical-thinking.webp`,
+    routeKey: 'critical',
+  },
+  '仮説思考': {
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#FBBF24" strokeWidth="2" strokeLinecap="round"><line x1="12" y1="2" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="22"/><line x1="4.93" y1="4.93" x2="7.76" y2="7.76"/><line x1="16.24" y1="16.24" x2="19.07" y2="19.07"/><line x1="2" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="22" y2="12"/><line x1="4.93" y1="19.07" x2="7.76" y2="16.24"/><line x1="16.24" y1="7.76" x2="19.07" y2="4.93"/></svg>,
+    iconBg: 'rgba(251,191,36,.14)',
+    image: `${IMG}/lesson-hypothesis.webp`,
+    routeKey: 'hypothesis',
+  },
+  '課題設定': {
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#34D399" strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>,
+    iconBg: 'rgba(52,211,153,.14)',
+    image: `${IMG}/lesson-issue-setting.webp`,
+    routeKey: 'problem-setting',
+  },
+  'デザインシンキング': {
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#60A5FA" strokeWidth="2" strokeLinecap="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>,
+    iconBg: 'rgba(96,165,250,.14)',
+    image: `${IMG}/lesson-design-thinking.webp`,
+    routeKey: 'design-thinking',
+  },
+  'ラテラルシンキング': {
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#A78BFA" strokeWidth="2" strokeLinecap="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>,
+    iconBg: 'rgba(167,139,250,.14)',
+    image: `${IMG}/lesson-lateral-thinking.webp`,
+    routeKey: 'lateral',
+  },
+  'アナロジー思考': {
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#F472B6" strokeWidth="2" strokeLinecap="round"><path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92z"/></svg>,
+    iconBg: 'rgba(244,114,182,.14)',
+    image: `${IMG}/lesson-analogy.webp`,
+    routeKey: 'analogy',
+  },
+  'システムシンキング': {
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#2DD4BF" strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="3"/><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>,
+    iconBg: 'rgba(45,212,191,.14)',
+    image: `${IMG}/lesson-systems-thinking.webp`,
+    routeKey: 'systems',
+  },
+  '提案・伝える技術': {
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={v3.color.warm} strokeWidth="2" strokeLinecap="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>,
+    iconBg: 'rgba(244,162,97,.14)',
+    image: `${IMG}/lesson-proposal.webp`,
+    routeKey: 'proposal',
+  },
+  '提案書作成': {
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#FB923C" strokeWidth="2" strokeLinecap="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>,
+    iconBg: 'rgba(251,146,60,.14)',
+    image: `${IMG}/course-proposal-writing.svg`,
+    routeKey: '提案書作成',
+  },
+  '哲学・思考の原理': {
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#C4B5FD" strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="4"/><circle cx="12" cy="12" r="10" strokeDasharray="4 3"/></svg>,
+    iconBg: 'rgba(196,181,253,.14)',
+    image: `${IMG}/course-philosophy.webp`,
+    routeKey: 'philosophy',
+  },
+  'クライアントワーク': {
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#C49A3C" strokeWidth="2" strokeLinecap="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>,
+    iconBg: 'rgba(196,154,60,.14)',
+    image: `${IMG}/course-client.webp`,
+    routeKey: 'クライアントワーク',
+  },
+  'ケース面接': {
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={v3.color.warm} strokeWidth="2" strokeLinecap="round"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/></svg>,
+    iconBg: 'rgba(244,162,97,.14)',
+    image: `${IMG}/course-business.webp`,
+    routeKey: 'case',
+  },
+  '経営戦略': {
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#7AAEFF" strokeWidth="2" strokeLinecap="round"><path d="M3 21V10l5 3V10l5 3V10l5 3v8z"/><line x1="3" y1="21" x2="21" y2="21"/></svg>,
+    iconBg: 'rgba(122,174,255,.14)',
+    image: `${IMG}/course-strategy.svg`,
+    routeKey: '経営戦略',
+  },
+  'フェルミ推定': {
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#6C8EF5" strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/></svg>,
+    iconBg: 'rgba(108,142,245,.14)',
+    image: `${IMG}/fermi-card.png`,
+    routeKey: 'フェルミ推定',
+  },
+  '数字に強くなる': {
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#7AAEFF" strokeWidth="2" strokeLinecap="round"><path d="M4 7h16M4 12h16M4 17h10"/></svg>,
+    iconBg: 'rgba(122,174,255,.14)',
+    image: `${IMG}/fermi-card.png`,
+    routeKey: '数字に強くなる',
+  },
+}
+
+const DEFAULT_VISUAL: CategoryVisual = {
+  icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={v3.color.accent} strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>,
+  iconBg: 'rgba(108,142,245,.14)',
+  image: `${IMG}/course-logical.webp`,
+  routeKey: '',
+}
 
 // ──────── 検索ユーティリティ ────────
 // クエリを正規化（NFKC + 小文字 + カタカナ→ひらがな）
@@ -178,24 +292,35 @@ export function RoadmapScreenV3(props: RoadmapScreenV3Props) {
 
 
 
-        {/* 2列グリッド — courseData.ts の全15カテゴリ */}
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
-          <CategoryCard icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={v3.color.accent} strokeWidth="2" strokeLinecap="round"><path d="M3 3h7v7H3zM14 3h7v7h-7zM3 14h7v7H3zM14 14h7v7h-7z"/></svg>} iconBg="rgba(108,142,245,.14)" name="ロジカルシンキング" meta="2コース · 初〜中級" image={`${IMG}/course-logical.webp`} onClick={() => props.onOpenCategory('logic')} />
-          <CategoryCard icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#F87171" strokeWidth="2" strokeLinecap="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>} iconBg="rgba(248,113,113,.14)" name="クリティカルシンキング" meta="2コース · 初〜中級" image={`${IMG}/lesson-critical-thinking.webp`} onClick={() => props.onOpenCategory('critical')} />
-          <CategoryCard icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#FBBF24" strokeWidth="2" strokeLinecap="round"><line x1="12" y1="2" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="22"/><line x1="4.93" y1="4.93" x2="7.76" y2="7.76"/><line x1="16.24" y1="16.24" x2="19.07" y2="19.07"/><line x1="2" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="22" y2="12"/><line x1="4.93" y1="19.07" x2="7.76" y2="16.24"/><line x1="16.24" y1="7.76" x2="19.07" y2="4.93"/></svg>} iconBg="rgba(251,191,36,.14)" name="仮説思考" meta="1コース · 中級" image={`${IMG}/lesson-hypothesis.webp`} onClick={() => props.onOpenCategory('hypothesis')} />
-          <CategoryCard icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#34D399" strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>} iconBg="rgba(52,211,153,.14)" name="課題設定" meta="1コース · 中級" image={`${IMG}/lesson-issue-setting.webp`} onClick={() => props.onOpenCategory('problem-setting')} />
-          <CategoryCard icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#60A5FA" strokeWidth="2" strokeLinecap="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>} iconBg="rgba(96,165,250,.14)" name="デザインシンキング" meta="1コース · 初級" image={`${IMG}/lesson-design-thinking.webp`} onClick={() => props.onOpenCategory('design-thinking')} />
-          <CategoryCard icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#A78BFA" strokeWidth="2" strokeLinecap="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>} iconBg="rgba(167,139,250,.14)" name="ラテラルシンキング" meta="1コース · 中級" image={`${IMG}/lesson-lateral-thinking.webp`} onClick={() => props.onOpenCategory('lateral')} />
-          <CategoryCard icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#F472B6" strokeWidth="2" strokeLinecap="round"><path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92z"/></svg>} iconBg="rgba(244,114,182,.14)" name="アナロジー思考" meta="1コース · 中級" image={`${IMG}/lesson-analogy.webp`} onClick={() => props.onOpenCategory('analogy')} />
-          <CategoryCard icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#2DD4BF" strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="3"/><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>} iconBg="rgba(45,212,191,.14)" name="システムシンキング" meta="1コース · 上級" image={`${IMG}/lesson-systems-thinking.webp`} onClick={() => props.onOpenCategory('systems')} />
-          <CategoryCard icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={v3.color.warm} strokeWidth="2" strokeLinecap="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>} iconBg="rgba(244,162,97,.14)" name="提案・伝える技術" meta="1コース · 中級" image={`${IMG}/lesson-proposal.webp`} onClick={() => props.onOpenCategory('proposal')} />
-          <CategoryCard icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#FB923C" strokeWidth="2" strokeLinecap="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>} iconBg="rgba(251,146,60,.14)" name="提案書作成" meta="1コース · 上級" image={`${IMG}/course-proposal-writing.svg`} onClick={() => props.onOpenCategory('提案書作成')} />
-          <CategoryCard icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#C4B5FD" strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="4"/><circle cx="12" cy="12" r="10" strokeDasharray="4 3"/></svg>} iconBg="rgba(196,181,253,.14)" name="哲学・思考の原理" meta="1コース · 上級" image={`${IMG}/course-philosophy.webp`} onClick={() => props.onOpenCategory('philosophy')} />
-          <CategoryCard icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#C49A3C" strokeWidth="2" strokeLinecap="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>} iconBg="rgba(196,154,60,.14)" name="クライアントワーク" meta="3コース · 中〜上級" image={`${IMG}/course-client.webp`} onClick={() => props.onOpenCategory('クライアントワーク')} />
-          <CategoryCard icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={v3.color.warm} strokeWidth="2" strokeLinecap="round"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/></svg>} iconBg="rgba(244,162,97,.14)" name="ケース面接" meta="1コース · 上級" image={`${IMG}/course-business.webp`} onClick={() => props.onOpenCategory('case')} />
-          <CategoryCard icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#7AAEFF" strokeWidth="2" strokeLinecap="round"><path d="M3 21V10l5 3V10l5 3V10l5 3v8z"/><line x1="3" y1="21" x2="21" y2="21"/></svg>} iconBg="rgba(122,174,255,.14)" name="経営戦略" meta="2コース · 上級" image={`${IMG}/course-strategy.svg`} onClick={() => props.onOpenCategory('経営戦略')} />
-          <CategoryCard icon={<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#6C8EF5" strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/></svg>} iconBg="rgba(108,142,245,.14)" name="フェルミ推定" meta="1コース · 中級" image={`${IMG}/fermi-card.png`} onClick={() => props.onOpenCategory('フェルミ推定')} />
-        </div>
+        {/* グループ別コース一覧 — 5グループ × 全21コース */}
+        {COURSE_GROUPS.map(group => {
+          const groupCourses = getCoursesByGroup(group.id)
+          if (groupCourses.length === 0) return null
+          return (
+            <div key={group.id} style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              <div style={{ padding: '8px 4px 0' }}>
+                <div style={{ fontSize: 16, fontWeight: 700, color: v3.color.text, letterSpacing: '-.005em' }}>{group.label}</div>
+                <div style={{ fontSize: 12, color: v3.color.text2, marginTop: 2, lineHeight: 1.45 }}>{group.description}</div>
+              </div>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+                {groupCourses.map(course => {
+                  const v = CATEGORY_VISUAL[course.category] || DEFAULT_VISUAL
+                  return (
+                    <CategoryCard
+                      key={course.id}
+                      icon={v.icon}
+                      iconBg={v.iconBg}
+                      name={course.title}
+                      meta={`${course.lessonIds.length}レッスン · ${course.level}`}
+                      image={v.image}
+                      onClick={() => props.onOpenCategory(v.routeKey)}
+                    />
+                  )
+                })}
+              </div>
+            </div>
+          )
+        })}
       </div>}
     </div>
   )


### PR DESCRIPTION
## Summary

The Lessons screen previously rendered one card per category (e.g. "ロジカルシンキング"), hiding the fact that several categories contain multiple courses. This PR switches to per-course cards titled with the course's "Doing" title (e.g. "ロジカルに考えて、整理する") and groups all 21 courses under 5 thematic, action-oriented sections so the screen is both more discoverable and easier to scan.

### What changed
- **Per-course cards** – every course is now individually clickable; the previously hidden `数字に強くなる` course is now also surfaced
- **5 thematic groups** with `〜する` action labels:
  - **論理的に考える** — 論理・批判・哲学で土台を固める (5)
  - **課題を解決する** — 仮説と構造で本質に迫る (4)
  - **発想を広げる** — 常識を超えて、新しい切り口を生む (2)
  - **相手を動かす** — 提案・面接・ヒアリングで論理を届ける (4)
  - **現場で実践する** — 戦略・数字・クライアント実務に活かす (6)
- **MECE refinements** to course→group assignment:
  - `philosophy-01`: creative → foundations (思考の原理は土台側)
  - `client-02` (論点を引き出す): business → communication
  - `case-01` (ケース面接): business → communication
- **Code structure**: added `CourseGroupId` / `COURSE_GROUPS` / `getCoursesByGroup` / `getCourseById` to `courseData.ts`; replaced the static 15-card grid in `RoadmapScreenV3.tsx` with a section-per-group layout that reads from the data; extracted per-category icon/color/image into a single `CATEGORY_VISUAL` lookup so the visual identity is preserved

### Final balance
5 / 4 / 2 / 4 / 6 — max-min gap halved from 6 to 4 vs. the initial draft.

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally, exit 0)
- [ ] Open the Lessons (トレーニング) tab in AppV3 and confirm 5 group sections render in order with correct labels and one-line descriptions
- [ ] Confirm all 21 courses appear (especially `numeracy-01` "数字に強くなる" which was missing before)
- [ ] Tap a course card and confirm it routes to the existing CategoryDetailView correctly
- [ ] Search box still surfaces both course-level and lesson-level results

---
_Generated by [Claude Code](https://claude.ai/code/session_019Z2dHXa9TLpfoCnsbe1nqj)_