### PR TITLE
プレースメントテスト結果のおすすめレッスンにレッスン名を表示

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -90,11 +90,11 @@ const STRINGS: Record<Locale, Strings> = {
     'onboarding.slide2.title': 'AI が「あなた専用」で練習相手に',
     'onboarding.slide2.body': 'ロールプレイ、フェルミ推定、AI 問題生成、コーヒーブレイクの日常シーン。座学だけでなく、実践しながら身につけられます。',
     'onboarding.slide3.title': 'まずは偏差値テストで現在地を知る',
-    'onboarding.slide3.body': '8 問のプレイスメントテストであなたの論理思考レベルを判定し、あなたに合った学習ルートをおすすめします。3 分で終わります。',
-    'onboarding.toPlacement': 'プレイスメントテストへ',
+    'onboarding.slide3.body': '8 問のプレースメントテストであなたの論理思考レベルを判定し、あなたに合った学習ルートをおすすめします。3 分で終わります。',
+    'onboarding.toPlacement': 'プレースメントテストへ',
 
     // Placement test
-    'placement.title': 'プレイスメントテスト',
+    'placement.title': 'プレースメントテスト',
     'placement.lead': 'あなたの論理思考力を 8 問でチェックします。所要時間は約 3 分。\n結果から偏差値を出し、レベルに合ったおすすめレッスンを表示します。',
     'placement.questionCount': '{count} 問・約 3 分',
     'placement.topicLine': 'MECE / 演繹 / 帰納 / 形式論理',
@@ -327,7 +327,7 @@ const STRINGS: Record<Locale, Strings> = {
 
     // Ranking
     'ranking.title': '偏差値ランキング',
-    'ranking.ctaTitle': 'まだプレイスメントテストを受けていません',
+    'ranking.ctaTitle': 'まだプレースメントテストを受けていません',
     'ranking.ctaDesc': 'テストを受けると、偏差値ランキングに参加できます。',
     'ranking.ctaButton': 'テストを受ける',
     'ranking.loading': '読み込み中...',

--- a/src/screens/CompletedLessonsScreen.tsx
+++ b/src/screens/CompletedLessonsScreen.tsx
@@ -49,7 +49,7 @@ const LESSON_MAP: Record<string, LessonMeta> = {
   'fermi':          { name: 'フェルミ推定',      category: 'AI練習' },
   'daily-problem':  { name: '今日の問題',        category: 'デイリー' },
   'flashcards':     { name: 'フラッシュカード',  category: '復習' },
-  'placement-test': { name: 'プレイスメントテスト', category: 'テスト' },
+  'placement-test': { name: 'プレースメントテスト', category: 'テスト' },
 }
 
 const CAT_ORDER = ['ロジカルシンキング', 'ケース面接', 'クリティカルシンキング', '仮説思考', '課題設定', 'デザインシンキング', 'ラテラルシンキング', 'アナロジー思考', 'システムシンキング', 'AI練習', 'デイリー', '復習', 'テスト']

--- a/src/screens/DeviationScreen.tsx
+++ b/src/screens/DeviationScreen.tsx
@@ -221,15 +221,8 @@ export function DeviationScreen({ onBack, onRetakeTest, onStartLesson }: Deviati
                     border: '1px solid var(--border)',
                   }}
                 >
-                  <span style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 0, flex: 1 }}>
-                    <span style={{ fontSize: 12, color: 'var(--text-muted)', fontWeight: 500 }}>
-                      Lesson #{id}
-                    </span>
-                    {lesson && (
-                      <span style={{ fontSize: 15, fontWeight: 600 }}>
-                        {lesson.title}
-                      </span>
-                    )}
+                  <span style={{ fontSize: 16, fontWeight: 600, minWidth: 0, flex: 1 }}>
+                    {lesson?.title ?? `Lesson #${id}`}
                   </span>
                   <span className="badge badge-accent" style={{ flexShrink: 0 }}>おすすめ</span>
                 </button>

--- a/src/screens/DeviationScreen.tsx
+++ b/src/screens/DeviationScreen.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { loadPlacementResult, rankLabel, recommendedLessons } from '../placementData'
+import { getAllLessonsFlat } from '../lessonData'
 import { ArrowLeftIcon } from '../icons'
 import { Button } from '../components/Button'
 import { IconButton } from '../components/IconButton'
@@ -45,6 +46,7 @@ export function DeviationScreen({ onBack, onRetakeTest, onStartLesson }: Deviati
   }
   const rank = rankLabel(result.deviation)
   const recommended = recommendedLessons(result.deviation)
+  const allLessons = getAllLessonsFlat()
   // バーの幅: 偏差値25〜75を 0%〜100% にマップ
   const fill = Math.min(100, Math.max(0, ((result.deviation - 25) / 50) * 100))
 
@@ -202,27 +204,37 @@ export function DeviationScreen({ onBack, onRetakeTest, onStartLesson }: Deviati
             おすすめレッスン
           </h2>
           <div className="stack-sm">
-            {recommended.map((id) => (
-              <button
-                key={id}
-                className="card card-compact"
-                onClick={() => onStartLesson(id)}
-                style={{
-                  cursor: 'pointer',
-                  textAlign: 'left',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                  gap: 'var(--s-3)',
-                  border: '1px solid var(--border)',
-                }}
-              >
-                <span style={{ fontSize: 16, fontWeight: 600 }}>
-                  Lesson #{id}
-                </span>
-                <span className="badge badge-accent">おすすめ</span>
-              </button>
-            ))}
+            {recommended.map((id) => {
+              const lesson = allLessons[id]
+              return (
+                <button
+                  key={id}
+                  className="card card-compact"
+                  onClick={() => onStartLesson(id)}
+                  style={{
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: 'var(--s-3)',
+                    border: '1px solid var(--border)',
+                  }}
+                >
+                  <span style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 0, flex: 1 }}>
+                    <span style={{ fontSize: 12, color: 'var(--text-muted)', fontWeight: 500 }}>
+                      Lesson #{id}
+                    </span>
+                    {lesson && (
+                      <span style={{ fontSize: 15, fontWeight: 600 }}>
+                        {lesson.title}
+                      </span>
+                    )}
+                  </span>
+                  <span className="badge badge-accent" style={{ flexShrink: 0 }}>おすすめ</span>
+                </button>
+              )
+            })}
           </div>
         </section>
       )}

--- a/src/screens/ProfileScreenV3.tsx
+++ b/src/screens/ProfileScreenV3.tsx
@@ -109,7 +109,7 @@ export function ProfileScreenV3(props: ProfileScreenV3Props) {
           </div>
         </div>
 
-        {/* プレイスメントテスト */}
+        {/* プレースメントテスト */}
         {onOpenPlacementTest && (
           <div onClick={onOpenPlacementTest} style={{
             background: `linear-gradient(135deg, ${v3.color.accentSoft} 0%, rgba(108,142,245,.1) 100%)`,
@@ -121,7 +121,7 @@ export function ProfileScreenV3(props: ProfileScreenV3Props) {
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={v3.color.bg} strokeWidth="2.5" strokeLinecap="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
             </div>
             <div style={{ flex: 1 }}>
-              <div style={{ fontSize: 14, fontWeight: 700, color: '#FFFFFF' }}>プレイスメントテスト</div>
+              <div style={{ fontSize: 14, fontWeight: 700, color: '#FFFFFF' }}>プレースメントテスト</div>
               <div style={{ fontSize: 13, color: v3.color.text2, marginTop: 2 }}>自分のレベルを確認して最適なレッスンを受けよう</div>
             </div>
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={v3.color.text3} strokeWidth="2.5"><polyline points="9 18 15 12 9 6" /></svg>


### PR DESCRIPTION
## Summary
- 偏差値結果画面のおすすめレッスンに「Lesson #N」ではなくレッスン名（例: MECE — 漏れなくダブりなく）を表示
- 表記ゆれ「プレイスメント」を「プレースメント」に統一（i18n / ProfileScreenV3 / CompletedLessonsScreen）

## Test plan
- [ ] プロフィール → 偏差値画面で、おすすめレッスン4件にレッスン名が表示されることを確認
- [ ] オンボーディング/ランキング/プロフィール/完了レッスン画面で「プレースメントテスト」表記になっていることを確認
- [ ] レッスンタップで該当レッスンが起動することを確認

https://claude.ai/code/session_01PPtoxeHK12xiLEgi8PBuHc

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPtoxeHK12xiLEgi8PBuHc)_