### PR TITLE
fix(daily-fermi): GuideLabel が次セクションと重なる問題を修正

### DIFF
--- a/src/screens/DailyFermiScreen.tsx
+++ b/src/screens/DailyFermiScreen.tsx
@@ -479,7 +479,7 @@ export function DailyFermiScreen({ onBack, onReport }: DailyFermiScreenProps) {
 
           {/* ヒント */}
           {hint && submitPhase === 'idle' && (
-            <div>
+            <div style={{ marginBottom: guideActive && !showHint ? 28 : 0 }}>
               {!showHint ? (
                 <div style={{ position: 'relative', display: 'inline-block' }}>
                   <button
@@ -557,8 +557,9 @@ export function DailyFermiScreen({ onBack, onReport }: DailyFermiScreenProps) {
                 まずは「誰が・どこで・どれくらいの頻度で」を考えてみよう。数字は大まかでOK！
               </div>
 
-              {guideActive && <GuideLabel text="まず自分の考えを書いてみましょう" position="top" />}
-              <textarea
+              <div style={{ position: 'relative', marginTop: guideActive ? 28 : 0 }}>
+                {guideActive && <GuideLabel text="まず自分の考えを書いてみましょう" position="top" />}
+                <textarea
                   value={answer}
                   onChange={(e) => { setAnswer(e.target.value); if (guideActive) dismissGuide() }}
                   placeholder={t('fermi.placeholder')}
@@ -576,8 +577,10 @@ export function DailyFermiScreen({ onBack, onReport }: DailyFermiScreenProps) {
                     outline: 'none',
                     fontFamily: 'inherit',
                     boxSizing: 'border-box',
+                    display: 'block',
                   }}
                 />
+              </div>
 
               <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: 'var(--text-muted)', lineHeight: 1.5 }}>
                 <MicIcon width={14} height={14} style={{ flexShrink: 0, opacity: 0.8 }} />


### PR DESCRIPTION
## Summary
- `GuideLabel`（チュートリアルラベル）が `position: absolute` のため垂直方向のスペースを確保せず、隣接セクションのテキストにかぶさっていた問題を修正
- ヒントボタン側: 親 `<div>` に `marginBottom: 28px`（`guideActive && !showHint` 時のみ）を追加
- 回答 textarea 側: `position: relative` の祖先がなくラベル位置が壊れていたので、textarea を相対配置の `<div>` で包み、同時に上方向のスペースも確保

## Test plan
- [ ] `localStorage` の `tutorial-daily-seen` を消してデイリーフェルミ画面を開き、ヒントボタン下のラベル「詰まったら見てみましょう」が次セクションと重ならないことを確認
- [ ] 同じく初回チュートリアル状態で、textarea 上のラベル「まず自分の考えを書いてみましょう」が正しい位置に表示されることを確認
- [ ] チュートリアル非表示状態（`guideActive=false`）でレイアウトが従来と変わっていないことを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_015GwXRUPmKiSiLhqgfovdm7)_