### PR TITLE
重複していたコース画像を、シーン重視のSVGに刷新

### DIFF
--- a/public/images/v3/course-client-02.svg
+++ b/public/images/v3/course-client-02.svg
@@ -4,91 +4,91 @@
       <stop offset="0%" stop-color="#1F2942"/>
       <stop offset="100%" stop-color="#101729"/>
     </linearGradient>
-    <linearGradient id="bub-cl2" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#6C8EF5"/>
-      <stop offset="100%" stop-color="#3B5BBF"/>
-    </linearGradient>
-    <linearGradient id="bub2-cl2" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#E7ECF7" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#B8C4DD" stop-opacity="0.92"/>
-    </linearGradient>
-    <radialGradient id="glow-cl2" cx="0.5" cy="0.5" r="0.6">
-      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    <radialGradient id="lamp-cl2" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.32"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
     </radialGradient>
-    <radialGradient id="ring-cl2" cx="0.5" cy="0.5" r="0.5">
-      <stop offset="60%" stop-color="#FFD566" stop-opacity="0"/>
-      <stop offset="100%" stop-color="#FFD566" stop-opacity="0.4"/>
-    </radialGradient>
+    <linearGradient id="figureL-cl2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3B5BBF"/>
+      <stop offset="100%" stop-color="#1B2954"/>
+    </linearGradient>
+    <linearGradient id="figureR-cl2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4A6BD6"/>
+      <stop offset="100%" stop-color="#22305A"/>
+    </linearGradient>
+    <linearGradient id="table-cl2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2A3656"/>
+      <stop offset="100%" stop-color="#0E1424"/>
+    </linearGradient>
   </defs>
 
   <rect width="800" height="400" fill="url(#bg-cl2)"/>
 
-  <!-- 背景グリッド -->
-  <g stroke="#2A3656" stroke-width="1" opacity="0.30">
+  <g stroke="#2A3656" stroke-width="1" opacity="0.25">
     <line x1="0" y1="100" x2="800" y2="100"/>
     <line x1="0" y1="200" x2="800" y2="200"/>
-    <line x1="0" y1="300" x2="800" y2="300"/>
   </g>
 
-  <circle cx="400" cy="200" r="260" fill="url(#glow-cl2)"/>
+  <!-- 中央のランプ光 -->
+  <circle cx="400" cy="220" r="180" fill="url(#lamp-cl2)"/>
 
-  <!-- 中心：論点（同心円で深掘り） -->
-  <g transform="translate(400,200)">
-    <circle cx="0" cy="0" r="120" fill="none" stroke="#6C8EF5" stroke-width="1" opacity="0.25"/>
-    <circle cx="0" cy="0" r="85" fill="none" stroke="#6C8EF5" stroke-width="1" opacity="0.35" stroke-dasharray="4 3"/>
-    <circle cx="0" cy="0" r="55" fill="none" stroke="#7AAEFF" stroke-width="1.2" opacity="0.55"/>
-    <!-- 中心の的 -->
-    <circle cx="0" cy="0" r="22" fill="url(#bub-cl2)"/>
-    <circle cx="0" cy="0" r="22" fill="none" stroke="#FFFFFF" stroke-width="1.5" opacity="0.85"/>
-    <!-- 真ん中の点（本質） -->
-    <circle cx="0" cy="0" r="6" fill="#FFD566"/>
+  <!-- 後ろの窓（夜景） -->
+  <g opacity="0.55">
+    <rect x="240" y="60" width="320" height="120" rx="2" fill="none" stroke="#6C8EF5" stroke-width="1.2"/>
+    <line x1="400" y1="60" x2="400" y2="180" stroke="#6C8EF5" stroke-width="1" opacity="0.5"/>
+    <line x1="240" y1="120" x2="560" y2="120" stroke="#6C8EF5" stroke-width="1" opacity="0.5"/>
+  </g>
+  <!-- 窓の星 -->
+  <g fill="#7AAEFF" opacity="0.7">
+    <circle cx="280" cy="90" r="1.4"/>
+    <circle cx="340" cy="100" r="1.2"/>
+    <circle cx="450" cy="85" r="1.4"/>
+    <circle cx="520" cy="110" r="1.2"/>
   </g>
 
-  <!-- 矢印：周辺から中心へ（深く引き出す） -->
-  <g stroke="#FFD566" stroke-width="2.2" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.85">
-    <path d="M 200 110 L 350 180"/>
-    <polyline points="338 168 350 180 338 184"/>
+  <!-- テーブル -->
+  <ellipse cx="400" cy="320" rx="280" ry="22" fill="url(#table-cl2)"/>
+  <rect x="120" y="320" width="560" height="14" fill="#0B1424" opacity="0.85"/>
 
-    <path d="M 600 110 L 450 180"/>
-    <polyline points="462 168 450 180 462 184"/>
-
-    <path d="M 200 290 L 350 220"/>
-    <polyline points="338 232 350 220 338 216"/>
-
-    <path d="M 600 290 L 450 220"/>
-    <polyline points="462 232 450 220 462 216"/>
+  <!-- テーブル上のティーカップ -->
+  <g transform="translate(400,308)">
+    <ellipse cx="0" cy="0" rx="14" ry="3" fill="#0B1424"/>
+    <path d="M -10 -2 Q -12 -14 0 -14 Q 12 -14 10 -2 Z" fill="#E7ECF7" opacity="0.9"/>
+    <path d="M 10 -10 Q 16 -8 16 -4" fill="none" stroke="#E7ECF7" stroke-width="1.4"/>
   </g>
 
-  <!-- 左上：質問のフキダシ -->
-  <g transform="translate(110,80)">
-    <path d="M 0 0 L 130 0 Q 145 0 145 14 L 145 50 Q 145 64 130 64 L 50 64 L 36 80 L 38 64 L 16 64 Q 0 64 0 50 Z" fill="url(#bub2-cl2)"/>
-    <text x="64" y="40" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="22" font-weight="700" fill="#1F2942" text-anchor="middle">なぜ？</text>
+  <!-- 左の人物（聴く側・少し前傾） -->
+  <g transform="translate(220,260)">
+    <!-- 体（前傾） -->
+    <path d="M -50 70 Q -54 10 -20 -12 Q -6 -20 6 -20 Q 26 -20 38 -8 Q 56 16 50 70 Z" fill="url(#figureL-cl2)"/>
+    <!-- 首 -->
+    <path d="M -8 -16 L 16 -16 L 14 -36 L -6 -36 Z" fill="url(#figureL-cl2)"/>
+    <!-- 頭（横顔・右向き） -->
+    <ellipse cx="6" cy="-46" rx="18" ry="20" fill="url(#figureL-cl2)"/>
+    <!-- 髪 -->
+    <path d="M -12 -52 Q 0 -66 22 -64 Q 26 -50 22 -42 L -10 -42 Z" fill="#0E1424"/>
+    <!-- 手をテーブルに（聴く姿勢） -->
+    <path d="M 30 0 Q 60 30 70 50" fill="none" stroke="url(#figureL-cl2)" stroke-width="14" stroke-linecap="round"/>
   </g>
 
-  <!-- 右上：質問のフキダシ -->
-  <g transform="translate(560,75)">
-    <path d="M 0 0 L 150 0 Q 165 0 165 14 L 165 50 Q 165 64 150 64 L 110 64 L 124 84 L 96 64 L 16 64 Q 0 64 0 50 Z" fill="url(#bub-cl2)"/>
-    <text x="82" y="40" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="20" font-weight="700" fill="#FFFFFF" text-anchor="middle">本当に？</text>
+  <!-- 右の人物（話す側・落ち着いた姿勢） -->
+  <g transform="translate(580,250)">
+    <!-- 体 -->
+    <path d="M -52 80 Q -58 16 -26 -8 Q -10 -16 4 -16 Q 22 -16 36 -8 Q 60 16 50 80 Z" fill="url(#figureR-cl2)"/>
+    <!-- 首 -->
+    <path d="M -10 -12 L 14 -12 L 12 -32 L -8 -32 Z" fill="url(#figureR-cl2)"/>
+    <!-- 頭（横顔・左向き） -->
+    <ellipse cx="-4" cy="-44" rx="18" ry="20" fill="url(#figureR-cl2)"/>
+    <!-- 髪 -->
+    <path d="M 12 -52 Q 0 -66 -22 -62 Q -26 -50 -22 -42 L 14 -42 Z" fill="#0E1424"/>
+    <!-- 手（軽く手前に出す） -->
+    <path d="M -28 6 Q -52 24 -64 40" fill="none" stroke="url(#figureR-cl2)" stroke-width="14" stroke-linecap="round"/>
   </g>
 
-  <!-- 左下：質問のフキダシ -->
-  <g transform="translate(120,260)">
-    <path d="M 0 0 L 145 0 Q 160 0 160 14 L 160 50 Q 160 64 145 64 L 60 64 L 50 84 L 42 64 L 16 64 Q 0 64 0 50 Z" fill="url(#bub-cl2)" opacity="0.92"/>
-    <text x="80" y="40" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="20" font-weight="700" fill="#FFFFFF" text-anchor="middle">それで？</text>
-  </g>
-
-  <!-- 右下：質問のフキダシ -->
-  <g transform="translate(560,260)">
-    <path d="M 0 0 L 150 0 Q 165 0 165 14 L 165 50 Q 165 64 150 64 L 130 64 L 120 84 L 112 64 L 16 64 Q 0 64 0 50 Z" fill="url(#bub2-cl2)"/>
-    <text x="82" y="40" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="20" font-weight="700" fill="#1F2942" text-anchor="middle">具体的に？</text>
-  </g>
-
-  <!-- 細かい星 -->
-  <g fill="#FFD566" opacity="0.7">
-    <circle cx="60" cy="200" r="1.8"/>
-    <circle cx="740" cy="200" r="1.8"/>
-    <circle cx="400" cy="40" r="1.8"/>
-    <circle cx="400" cy="370" r="1.8"/>
+  <!-- 聴く側の小さな耳のサイン（…） -->
+  <g transform="translate(140,200)" fill="#FFD566" opacity="0.85">
+    <circle cx="0" cy="0" r="2"/>
+    <circle cx="10" cy="0" r="2"/>
+    <circle cx="20" cy="0" r="2"/>
   </g>
 </svg>

--- a/public/images/v3/course-client-02.svg
+++ b/public/images/v3/course-client-02.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-cl2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <linearGradient id="bub-cl2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#6C8EF5"/>
+      <stop offset="100%" stop-color="#3B5BBF"/>
+    </linearGradient>
+    <linearGradient id="bub2-cl2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#E7ECF7" stop-opacity="0.95"/>
+      <stop offset="100%" stop-color="#B8C4DD" stop-opacity="0.92"/>
+    </linearGradient>
+    <radialGradient id="glow-cl2" cx="0.5" cy="0.5" r="0.6">
+      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.28"/>
+      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="ring-cl2" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="60%" stop-color="#FFD566" stop-opacity="0"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0.4"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-cl2)"/>
+
+  <!-- 背景グリッド -->
+  <g stroke="#2A3656" stroke-width="1" opacity="0.30">
+    <line x1="0" y1="100" x2="800" y2="100"/>
+    <line x1="0" y1="200" x2="800" y2="200"/>
+    <line x1="0" y1="300" x2="800" y2="300"/>
+  </g>
+
+  <circle cx="400" cy="200" r="260" fill="url(#glow-cl2)"/>
+
+  <!-- 中心：論点（同心円で深掘り） -->
+  <g transform="translate(400,200)">
+    <circle cx="0" cy="0" r="120" fill="none" stroke="#6C8EF5" stroke-width="1" opacity="0.25"/>
+    <circle cx="0" cy="0" r="85" fill="none" stroke="#6C8EF5" stroke-width="1" opacity="0.35" stroke-dasharray="4 3"/>
+    <circle cx="0" cy="0" r="55" fill="none" stroke="#7AAEFF" stroke-width="1.2" opacity="0.55"/>
+    <!-- 中心の的 -->
+    <circle cx="0" cy="0" r="22" fill="url(#bub-cl2)"/>
+    <circle cx="0" cy="0" r="22" fill="none" stroke="#FFFFFF" stroke-width="1.5" opacity="0.85"/>
+    <!-- 真ん中の点（本質） -->
+    <circle cx="0" cy="0" r="6" fill="#FFD566"/>
+  </g>
+
+  <!-- 矢印：周辺から中心へ（深く引き出す） -->
+  <g stroke="#FFD566" stroke-width="2.2" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.85">
+    <path d="M 200 110 L 350 180"/>
+    <polyline points="338 168 350 180 338 184"/>
+
+    <path d="M 600 110 L 450 180"/>
+    <polyline points="462 168 450 180 462 184"/>
+
+    <path d="M 200 290 L 350 220"/>
+    <polyline points="338 232 350 220 338 216"/>
+
+    <path d="M 600 290 L 450 220"/>
+    <polyline points="462 232 450 220 462 216"/>
+  </g>
+
+  <!-- 左上：質問のフキダシ -->
+  <g transform="translate(110,80)">
+    <path d="M 0 0 L 130 0 Q 145 0 145 14 L 145 50 Q 145 64 130 64 L 50 64 L 36 80 L 38 64 L 16 64 Q 0 64 0 50 Z" fill="url(#bub2-cl2)"/>
+    <text x="64" y="40" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="22" font-weight="700" fill="#1F2942" text-anchor="middle">なぜ？</text>
+  </g>
+
+  <!-- 右上：質問のフキダシ -->
+  <g transform="translate(560,75)">
+    <path d="M 0 0 L 150 0 Q 165 0 165 14 L 165 50 Q 165 64 150 64 L 110 64 L 124 84 L 96 64 L 16 64 Q 0 64 0 50 Z" fill="url(#bub-cl2)"/>
+    <text x="82" y="40" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="20" font-weight="700" fill="#FFFFFF" text-anchor="middle">本当に？</text>
+  </g>
+
+  <!-- 左下：質問のフキダシ -->
+  <g transform="translate(120,260)">
+    <path d="M 0 0 L 145 0 Q 160 0 160 14 L 160 50 Q 160 64 145 64 L 60 64 L 50 84 L 42 64 L 16 64 Q 0 64 0 50 Z" fill="url(#bub-cl2)" opacity="0.92"/>
+    <text x="80" y="40" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="20" font-weight="700" fill="#FFFFFF" text-anchor="middle">それで？</text>
+  </g>
+
+  <!-- 右下：質問のフキダシ -->
+  <g transform="translate(560,260)">
+    <path d="M 0 0 L 150 0 Q 165 0 165 14 L 165 50 Q 165 64 150 64 L 130 64 L 120 84 L 112 64 L 16 64 Q 0 64 0 50 Z" fill="url(#bub2-cl2)"/>
+    <text x="82" y="40" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="20" font-weight="700" fill="#1F2942" text-anchor="middle">具体的に？</text>
+  </g>
+
+  <!-- 細かい星 -->
+  <g fill="#FFD566" opacity="0.7">
+    <circle cx="60" cy="200" r="1.8"/>
+    <circle cx="740" cy="200" r="1.8"/>
+    <circle cx="400" cy="40" r="1.8"/>
+    <circle cx="400" cy="370" r="1.8"/>
+  </g>
+</svg>

--- a/public/images/v3/course-client-03.svg
+++ b/public/images/v3/course-client-03.svg
@@ -4,109 +4,111 @@
       <stop offset="0%" stop-color="#1F2942"/>
       <stop offset="100%" stop-color="#101729"/>
     </linearGradient>
-    <linearGradient id="step-cl3" x1="0" y1="1" x2="0" y2="0">
-      <stop offset="0%" stop-color="#3B5BBF"/>
-      <stop offset="100%" stop-color="#7AAEFF"/>
-    </linearGradient>
-    <linearGradient id="step2-cl3" x1="0" y1="1" x2="0" y2="0">
-      <stop offset="0%" stop-color="#4A6BD6"/>
-      <stop offset="100%" stop-color="#A8C7FF"/>
-    </linearGradient>
-    <linearGradient id="book-cl3" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#FFD566"/>
-      <stop offset="100%" stop-color="#C49A3C"/>
-    </linearGradient>
-    <linearGradient id="book2-cl3" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#F87171"/>
-      <stop offset="100%" stop-color="#B23B3B"/>
-    </linearGradient>
-    <linearGradient id="book3-cl3" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#34D399"/>
-      <stop offset="100%" stop-color="#1B7A4F"/>
-    </linearGradient>
-    <radialGradient id="glow-cl3" cx="0.7" cy="0.4" r="0.55">
-      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.22"/>
+    <radialGradient id="lampGlow-cl3" cx="0.5" cy="0.5" r="0.55">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.55"/>
+      <stop offset="60%" stop-color="#FFD566" stop-opacity="0.12"/>
       <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
     </radialGradient>
+    <linearGradient id="desk-cl3" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2A3656"/>
+      <stop offset="100%" stop-color="#0B1424"/>
+    </linearGradient>
+    <linearGradient id="book-a-cl3" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#C49A3C"/>
+      <stop offset="100%" stop-color="#7A5A1F"/>
+    </linearGradient>
+    <linearGradient id="book-b-cl3" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3B5BBF"/>
+      <stop offset="100%" stop-color="#1B2954"/>
+    </linearGradient>
+    <linearGradient id="book-c-cl3" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7A2E2E"/>
+      <stop offset="100%" stop-color="#3F1313"/>
+    </linearGradient>
   </defs>
 
   <rect width="800" height="400" fill="url(#bg-cl3)"/>
 
-  <g stroke="#2A3656" stroke-width="1" opacity="0.30">
-    <line x1="0" y1="100" x2="800" y2="100"/>
-    <line x1="0" y1="200" x2="800" y2="200"/>
-    <line x1="0" y1="300" x2="800" y2="300"/>
+  <!-- 後ろの窓（夜・星空） -->
+  <g opacity="0.45">
+    <rect x="80" y="40" width="640" height="200" rx="3" fill="none" stroke="#6C8EF5" stroke-width="1.4"/>
+    <line x1="400" y1="40" x2="400" y2="240" stroke="#6C8EF5" stroke-width="1" opacity="0.5"/>
+    <line x1="80" y1="140" x2="720" y2="140" stroke="#6C8EF5" stroke-width="1" opacity="0.5"/>
+  </g>
+  <!-- 月（窓越し） -->
+  <g transform="translate(620,90)" opacity="0.85">
+    <circle cx="0" cy="0" r="32" fill="#E7ECF7"/>
+    <circle cx="-10" cy="-6" r="28" fill="#1F2942"/>
+  </g>
+  <!-- 星 -->
+  <g fill="#7AAEFF" opacity="0.7">
+    <circle cx="160" cy="80" r="1.4"/>
+    <circle cx="240" cy="120" r="1.2"/>
+    <circle cx="320" cy="80" r="1.4"/>
+    <circle cx="500" cy="100" r="1.4"/>
+    <circle cx="540" cy="180" r="1.2"/>
+    <circle cx="180" cy="200" r="1.2"/>
   </g>
 
-  <circle cx="600" cy="150" r="240" fill="url(#glow-cl3)"/>
+  <!-- ランプの光 -->
+  <circle cx="240" cy="200" r="200" fill="url(#lampGlow-cl3)"/>
 
-  <!-- 階段（短期間で立ち上がる） -->
-  <g>
-    <rect x="80" y="320" width="120" height="40" rx="3" fill="url(#step-cl3)" opacity="0.85"/>
-    <rect x="180" y="270" width="120" height="90" rx="3" fill="url(#step-cl3)" opacity="0.92"/>
-    <rect x="280" y="220" width="120" height="140" rx="3" fill="url(#step2-cl3)"/>
-    <rect x="380" y="170" width="120" height="190" rx="3" fill="url(#step2-cl3)"/>
-    <rect x="480" y="120" width="120" height="240" rx="3" fill="url(#step2-cl3)"/>
+  <!-- 机の天板 -->
+  <rect x="0" y="290" width="800" height="14" fill="url(#desk-cl3)"/>
+  <rect x="0" y="304" width="800" height="96" fill="#0B1424"/>
+
+  <!-- ランプ -->
+  <g transform="translate(240,200)">
+    <!-- 笠 -->
+    <path d="M -36 0 L 36 0 L 26 -34 L -26 -34 Z" fill="#1A2540" stroke="#FFD566" stroke-width="1.5"/>
+    <!-- 笠の内側のグロー（明るい底） -->
+    <ellipse cx="0" cy="-2" rx="34" ry="6" fill="#FFD566" opacity="0.85"/>
+    <!-- 棒 -->
+    <line x1="0" y1="0" x2="0" y2="78" stroke="#1A2540" stroke-width="3"/>
+    <!-- 台座 -->
+    <ellipse cx="0" cy="86" rx="22" ry="5" fill="#1A2540"/>
   </g>
 
-  <!-- 階段の上の小さな人物（専門家として立つ） -->
-  <g transform="translate(540,80)">
-    <circle cx="0" cy="0" r="11" fill="#E7ECF7"/>
-    <path d="M -16 12 Q -22 32 -16 50 L 16 50 Q 22 32 16 12 Q 8 8 0 8 Q -8 8 -16 12 Z" fill="#7AAEFF"/>
-    <line x1="-12" y1="22" x2="-22" y2="42" stroke="#7AAEFF" stroke-width="6" stroke-linecap="round"/>
-    <line x1="12" y1="22" x2="22" y2="42" stroke="#7AAEFF" stroke-width="6" stroke-linecap="round"/>
+  <!-- 開かれた本（ランプの下） -->
+  <g transform="translate(380,300)">
+    <!-- 紙の影 -->
+    <path d="M -80 -2 Q -2 -22 80 -2 L 78 0 Q -2 -18 -78 0 Z" fill="#1A2540"/>
+    <!-- 左ページ -->
+    <path d="M -80 -4 Q -42 -18 -2 -16 L -2 -4 Q -42 -8 -76 0 Z" fill="#E7ECF7" opacity="0.95"/>
+    <!-- 右ページ -->
+    <path d="M 80 -4 Q 42 -18 2 -16 L 2 -4 Q 42 -8 76 0 Z" fill="#E7ECF7" opacity="0.92"/>
+    <!-- 文字行 -->
+    <g stroke="#3B4663" stroke-width="0.8" opacity="0.7">
+      <line x1="-72" y1="-10" x2="-12" y2="-14"/>
+      <line x1="-70" y1="-7" x2="-12" y2="-10"/>
+      <line x1="12" y1="-14" x2="72" y2="-10"/>
+      <line x1="12" y1="-10" x2="70" y2="-7"/>
+    </g>
   </g>
 
-  <!-- 階段上の星（達成） -->
-  <g transform="translate(540,46)" fill="#FFD566">
-    <polygon points="0,-12 3.5,-3.5 12,-3.5 5,2 8,11 0,5.5 -8,11 -5,2 -12,-3.5 -3.5,-3.5"/>
+  <!-- 積み上がった本（左奥・少し低く） -->
+  <g transform="translate(120,260)">
+    <rect x="0" y="20" width="120" height="20" rx="2" fill="url(#book-c-cl3)"/>
+    <rect x="6" y="0" width="118" height="20" rx="2" fill="url(#book-a-cl3)"/>
+    <rect x="-2" y="-20" width="120" height="20" rx="2" fill="url(#book-b-cl3)"/>
+    <!-- 背の細い線 -->
+    <g stroke="#FFD566" stroke-width="1" opacity="0.4">
+      <line x1="14" y1="-4" x2="106" y2="-4"/>
+    </g>
   </g>
 
-  <!-- 上昇矢印（成長の方向） -->
-  <g stroke="#FFD566" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.95">
-    <polyline points="100,300 200,250 300,200 400,150 500,100"/>
-    <polyline points="478,100 500,100 500,122"/>
+  <!-- 右奥の本立て（数冊立てかけ） -->
+  <g transform="translate(560,250)">
+    <rect x="0" y="0" width="14" height="50" rx="2" fill="url(#book-b-cl3)"/>
+    <rect x="16" y="-4" width="14" height="54" rx="2" fill="url(#book-a-cl3)"/>
+    <rect x="32" y="-2" width="14" height="52" rx="2" fill="url(#book-c-cl3)"/>
+    <rect x="48" y="2" width="14" height="48" rx="2" fill="url(#book-b-cl3)" opacity="0.85"/>
   </g>
 
-  <!-- 左：本（書物・知識のソース） -->
-  <g transform="translate(40,180)">
-    <!-- 本1 -->
-    <rect x="0" y="0" width="60" height="80" rx="2" fill="url(#book-cl3)"/>
-    <rect x="0" y="0" width="8" height="80" fill="#1A2540" opacity="0.5"/>
-    <line x1="14" y1="20" x2="50" y2="20" stroke="#1A2540" stroke-width="1.5" opacity="0.6"/>
-    <line x1="14" y1="32" x2="44" y2="32" stroke="#1A2540" stroke-width="1.5" opacity="0.6"/>
-    <!-- 本2 -->
-    <rect x="-8" y="-30" width="60" height="80" rx="2" fill="url(#book2-cl3)" transform="rotate(-8)"/>
-    <!-- 本3 -->
-    <rect x="6" y="-58" width="60" height="80" rx="2" fill="url(#book3-cl3)" transform="rotate(-14)"/>
-  </g>
-
-  <!-- 流れ：本→人物 -->
-  <g stroke="#7AAEFF" stroke-width="1.5" fill="none" stroke-dasharray="3 4" opacity="0.55">
-    <path d="M 100 180 Q 280 120 530 80"/>
-  </g>
-  <g fill="#7AAEFF" opacity="0.85">
-    <circle cx="180" cy="148" r="2"/>
-    <circle cx="280" cy="118" r="2"/>
-    <circle cx="380" cy="98" r="2"/>
-    <circle cx="480" cy="84" r="2"/>
-  </g>
-
-  <!-- 右下：データ（事例） -->
-  <g transform="translate(640,250)" opacity="0.9">
-    <rect x="0" y="0" width="120" height="90" rx="6" fill="#1A2540" stroke="#6C8EF5" stroke-width="1.5"/>
-    <line x1="14" y1="20" x2="106" y2="20" stroke="#6C8EF5" stroke-width="1.2" opacity="0.65"/>
-    <line x1="14" y1="34" x2="80" y2="34" stroke="#6C8EF5" stroke-width="1.2" opacity="0.65"/>
-    <line x1="14" y1="48" x2="92" y2="48" stroke="#6C8EF5" stroke-width="1.2" opacity="0.65"/>
-    <line x1="14" y1="62" x2="70" y2="62" stroke="#6C8EF5" stroke-width="1.2" opacity="0.65"/>
-    <line x1="14" y1="76" x2="100" y2="76" stroke="#6C8EF5" stroke-width="1.2" opacity="0.65"/>
-  </g>
-
-  <!-- アクセント星 -->
-  <g fill="#FFD566" opacity="0.85">
-    <circle cx="120" cy="60" r="1.8"/>
-    <circle cx="280" cy="50" r="1.5"/>
-    <circle cx="660" cy="80" r="1.8"/>
-    <circle cx="720" cy="50" r="1.5"/>
+  <!-- ペン（本の右側） -->
+  <g transform="translate(458,294) rotate(-12)">
+    <line x1="0" y1="0" x2="46" y2="0" stroke="#C49A3C" stroke-width="3" stroke-linecap="round"/>
+    <line x1="0" y1="0" x2="10" y2="0" stroke="#1A2540" stroke-width="3" stroke-linecap="round"/>
+    <polygon points="46,0 52,-2 52,2" fill="#1A2540"/>
   </g>
 </svg>

--- a/public/images/v3/course-client-03.svg
+++ b/public/images/v3/course-client-03.svg
@@ -1,0 +1,112 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-cl3" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <linearGradient id="step-cl3" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#3B5BBF"/>
+      <stop offset="100%" stop-color="#7AAEFF"/>
+    </linearGradient>
+    <linearGradient id="step2-cl3" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#4A6BD6"/>
+      <stop offset="100%" stop-color="#A8C7FF"/>
+    </linearGradient>
+    <linearGradient id="book-cl3" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FFD566"/>
+      <stop offset="100%" stop-color="#C49A3C"/>
+    </linearGradient>
+    <linearGradient id="book2-cl3" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F87171"/>
+      <stop offset="100%" stop-color="#B23B3B"/>
+    </linearGradient>
+    <linearGradient id="book3-cl3" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#34D399"/>
+      <stop offset="100%" stop-color="#1B7A4F"/>
+    </linearGradient>
+    <radialGradient id="glow-cl3" cx="0.7" cy="0.4" r="0.55">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.22"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-cl3)"/>
+
+  <g stroke="#2A3656" stroke-width="1" opacity="0.30">
+    <line x1="0" y1="100" x2="800" y2="100"/>
+    <line x1="0" y1="200" x2="800" y2="200"/>
+    <line x1="0" y1="300" x2="800" y2="300"/>
+  </g>
+
+  <circle cx="600" cy="150" r="240" fill="url(#glow-cl3)"/>
+
+  <!-- 階段（短期間で立ち上がる） -->
+  <g>
+    <rect x="80" y="320" width="120" height="40" rx="3" fill="url(#step-cl3)" opacity="0.85"/>
+    <rect x="180" y="270" width="120" height="90" rx="3" fill="url(#step-cl3)" opacity="0.92"/>
+    <rect x="280" y="220" width="120" height="140" rx="3" fill="url(#step2-cl3)"/>
+    <rect x="380" y="170" width="120" height="190" rx="3" fill="url(#step2-cl3)"/>
+    <rect x="480" y="120" width="120" height="240" rx="3" fill="url(#step2-cl3)"/>
+  </g>
+
+  <!-- 階段の上の小さな人物（専門家として立つ） -->
+  <g transform="translate(540,80)">
+    <circle cx="0" cy="0" r="11" fill="#E7ECF7"/>
+    <path d="M -16 12 Q -22 32 -16 50 L 16 50 Q 22 32 16 12 Q 8 8 0 8 Q -8 8 -16 12 Z" fill="#7AAEFF"/>
+    <line x1="-12" y1="22" x2="-22" y2="42" stroke="#7AAEFF" stroke-width="6" stroke-linecap="round"/>
+    <line x1="12" y1="22" x2="22" y2="42" stroke="#7AAEFF" stroke-width="6" stroke-linecap="round"/>
+  </g>
+
+  <!-- 階段上の星（達成） -->
+  <g transform="translate(540,46)" fill="#FFD566">
+    <polygon points="0,-12 3.5,-3.5 12,-3.5 5,2 8,11 0,5.5 -8,11 -5,2 -12,-3.5 -3.5,-3.5"/>
+  </g>
+
+  <!-- 上昇矢印（成長の方向） -->
+  <g stroke="#FFD566" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.95">
+    <polyline points="100,300 200,250 300,200 400,150 500,100"/>
+    <polyline points="478,100 500,100 500,122"/>
+  </g>
+
+  <!-- 左：本（書物・知識のソース） -->
+  <g transform="translate(40,180)">
+    <!-- 本1 -->
+    <rect x="0" y="0" width="60" height="80" rx="2" fill="url(#book-cl3)"/>
+    <rect x="0" y="0" width="8" height="80" fill="#1A2540" opacity="0.5"/>
+    <line x1="14" y1="20" x2="50" y2="20" stroke="#1A2540" stroke-width="1.5" opacity="0.6"/>
+    <line x1="14" y1="32" x2="44" y2="32" stroke="#1A2540" stroke-width="1.5" opacity="0.6"/>
+    <!-- 本2 -->
+    <rect x="-8" y="-30" width="60" height="80" rx="2" fill="url(#book2-cl3)" transform="rotate(-8)"/>
+    <!-- 本3 -->
+    <rect x="6" y="-58" width="60" height="80" rx="2" fill="url(#book3-cl3)" transform="rotate(-14)"/>
+  </g>
+
+  <!-- 流れ：本→人物 -->
+  <g stroke="#7AAEFF" stroke-width="1.5" fill="none" stroke-dasharray="3 4" opacity="0.55">
+    <path d="M 100 180 Q 280 120 530 80"/>
+  </g>
+  <g fill="#7AAEFF" opacity="0.85">
+    <circle cx="180" cy="148" r="2"/>
+    <circle cx="280" cy="118" r="2"/>
+    <circle cx="380" cy="98" r="2"/>
+    <circle cx="480" cy="84" r="2"/>
+  </g>
+
+  <!-- 右下：データ（事例） -->
+  <g transform="translate(640,250)" opacity="0.9">
+    <rect x="0" y="0" width="120" height="90" rx="6" fill="#1A2540" stroke="#6C8EF5" stroke-width="1.5"/>
+    <line x1="14" y1="20" x2="106" y2="20" stroke="#6C8EF5" stroke-width="1.2" opacity="0.65"/>
+    <line x1="14" y1="34" x2="80" y2="34" stroke="#6C8EF5" stroke-width="1.2" opacity="0.65"/>
+    <line x1="14" y1="48" x2="92" y2="48" stroke="#6C8EF5" stroke-width="1.2" opacity="0.65"/>
+    <line x1="14" y1="62" x2="70" y2="62" stroke="#6C8EF5" stroke-width="1.2" opacity="0.65"/>
+    <line x1="14" y1="76" x2="100" y2="76" stroke="#6C8EF5" stroke-width="1.2" opacity="0.65"/>
+  </g>
+
+  <!-- アクセント星 -->
+  <g fill="#FFD566" opacity="0.85">
+    <circle cx="120" cy="60" r="1.8"/>
+    <circle cx="280" cy="50" r="1.5"/>
+    <circle cx="660" cy="80" r="1.8"/>
+    <circle cx="720" cy="50" r="1.5"/>
+  </g>
+</svg>

--- a/public/images/v3/course-critical-02.svg
+++ b/public/images/v3/course-critical-02.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-c2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <linearGradient id="prism-c2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#A8C7FF" stop-opacity="0.95"/>
+      <stop offset="100%" stop-color="#6C8EF5" stop-opacity="0.85"/>
+    </linearGradient>
+    <radialGradient id="glow-c2" cx="0.65" cy="0.5" r="0.55">
+      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="rayR-c2" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#F87171" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#F87171" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="rayY-c2" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FBBF24" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#FBBF24" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="rayG-c2" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#34D399" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#34D399" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="rayB-c2" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-c2)"/>
+
+  <!-- 背景グリッド -->
+  <g stroke="#2A3656" stroke-width="1" opacity="0.30">
+    <line x1="0" y1="80" x2="800" y2="80"/>
+    <line x1="0" y1="160" x2="800" y2="160"/>
+    <line x1="0" y1="240" x2="800" y2="240"/>
+    <line x1="0" y1="320" x2="800" y2="320"/>
+  </g>
+
+  <circle cx="500" cy="200" r="240" fill="url(#glow-c2)"/>
+
+  <!-- 入射光（バイアス・歪んだ視点） -->
+  <g stroke="#FFFFFF" stroke-width="2.5" opacity="0.85">
+    <line x1="60" y1="200" x2="280" y2="200"/>
+  </g>
+  <g fill="#FFFFFF" opacity="0.55">
+    <circle cx="80" cy="200" r="2.5"/>
+    <circle cx="140" cy="200" r="2"/>
+    <circle cx="200" cy="200" r="2"/>
+  </g>
+
+  <!-- プリズム（思考のフィルタ／バイアスを分解） -->
+  <g transform="translate(340,140)">
+    <polygon points="0,120 60,0 120,120" fill="url(#prism-c2)" stroke="#FFFFFF" stroke-width="1.5" opacity="0.95"/>
+    <!-- ハイライト -->
+    <polygon points="60,0 120,120 100,120 60,30" fill="#FFFFFF" opacity="0.18"/>
+    <polygon points="60,0 0,120 20,120 60,30" fill="#FFFFFF" opacity="0.08"/>
+  </g>
+
+  <!-- 出射光（分解された＝客観的な視点） -->
+  <g stroke-width="3" stroke-linecap="round">
+    <line x1="460" y1="200" x2="740" y2="120" stroke="url(#rayR-c2)"/>
+    <line x1="460" y1="200" x2="760" y2="170" stroke="url(#rayY-c2)"/>
+    <line x1="460" y1="200" x2="760" y2="220" stroke="url(#rayG-c2)"/>
+    <line x1="460" y1="200" x2="740" y2="270" stroke="url(#rayB-c2)"/>
+  </g>
+
+  <!-- 出射点に小さな円（焦点） -->
+  <circle cx="460" cy="200" r="5" fill="#FFFFFF"/>
+  <circle cx="460" cy="200" r="9" fill="none" stroke="#FFFFFF" stroke-width="1" opacity="0.4"/>
+
+  <!-- 左上：歪んだ目／疑問符（バイアス） -->
+  <g transform="translate(120,100)" opacity="0.7">
+    <ellipse cx="0" cy="0" rx="28" ry="14" fill="none" stroke="#6C8EF5" stroke-width="2"/>
+    <circle cx="0" cy="0" r="7" fill="#7AAEFF"/>
+    <circle cx="2" cy="-2" r="2" fill="#FFFFFF"/>
+  </g>
+
+  <!-- 右下：チェックマーク（客観性の獲得） -->
+  <g transform="translate(680,330)">
+    <circle cx="0" cy="0" r="22" fill="#34D399" opacity="0.92"/>
+    <polyline points="-8,0 -2,7 9,-6" stroke="#FFFFFF" stroke-width="3.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <!-- 細かい星 -->
+  <g fill="#FFD566" opacity="0.85">
+    <circle cx="80" cy="50" r="1.8"/>
+    <circle cx="240" cy="60" r="1.5"/>
+    <circle cx="560" cy="60" r="1.8"/>
+    <circle cx="700" cy="50" r="1.5"/>
+    <circle cx="140" cy="340" r="1.5"/>
+    <circle cx="300" cy="350" r="1.5"/>
+  </g>
+</svg>

--- a/public/images/v3/course-critical-02.svg
+++ b/public/images/v3/course-critical-02.svg
@@ -4,94 +4,68 @@
       <stop offset="0%" stop-color="#1F2942"/>
       <stop offset="100%" stop-color="#101729"/>
     </linearGradient>
-    <linearGradient id="prism-c2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#A8C7FF" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#6C8EF5" stop-opacity="0.85"/>
-    </linearGradient>
-    <radialGradient id="glow-c2" cx="0.65" cy="0.5" r="0.55">
-      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    <radialGradient id="lensGlow-c2" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.45"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
     </radialGradient>
-    <linearGradient id="rayR-c2" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#F87171" stop-opacity="0.85"/>
-      <stop offset="100%" stop-color="#F87171" stop-opacity="0"/>
-    </linearGradient>
-    <linearGradient id="rayY-c2" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#FBBF24" stop-opacity="0.85"/>
-      <stop offset="100%" stop-color="#FBBF24" stop-opacity="0"/>
-    </linearGradient>
-    <linearGradient id="rayG-c2" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#34D399" stop-opacity="0.85"/>
-      <stop offset="100%" stop-color="#34D399" stop-opacity="0"/>
-    </linearGradient>
-    <linearGradient id="rayB-c2" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.85"/>
-      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    <radialGradient id="lens-c2" cx="0.4" cy="0.35" r="0.7">
+      <stop offset="0%" stop-color="#A8C7FF" stop-opacity="0.55"/>
+      <stop offset="100%" stop-color="#3B5BBF" stop-opacity="0.30"/>
+    </radialGradient>
+    <linearGradient id="figure-c2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3B5BBF"/>
+      <stop offset="100%" stop-color="#1B2954"/>
     </linearGradient>
   </defs>
 
   <rect width="800" height="400" fill="url(#bg-c2)"/>
 
-  <!-- 背景グリッド -->
-  <g stroke="#2A3656" stroke-width="1" opacity="0.30">
-    <line x1="0" y1="80" x2="800" y2="80"/>
-    <line x1="0" y1="160" x2="800" y2="160"/>
-    <line x1="0" y1="240" x2="800" y2="240"/>
-    <line x1="0" y1="320" x2="800" y2="320"/>
+  <g stroke="#2A3656" stroke-width="1" opacity="0.25">
+    <line x1="0" y1="100" x2="800" y2="100"/>
+    <line x1="0" y1="200" x2="800" y2="200"/>
+    <line x1="0" y1="300" x2="800" y2="300"/>
   </g>
 
-  <circle cx="500" cy="200" r="240" fill="url(#glow-c2)"/>
+  <!-- 視線の先のグロー（"見えてきたもの" -->
+  <circle cx="600" cy="180" r="170" fill="url(#lensGlow-c2)"/>
 
-  <!-- 入射光（バイアス・歪んだ視点） -->
-  <g stroke="#FFFFFF" stroke-width="2.5" opacity="0.85">
-    <line x1="60" y1="200" x2="280" y2="200"/>
-  </g>
-  <g fill="#FFFFFF" opacity="0.55">
-    <circle cx="80" cy="200" r="2.5"/>
-    <circle cx="140" cy="200" r="2"/>
-    <circle cx="200" cy="200" r="2"/>
-  </g>
-
-  <!-- プリズム（思考のフィルタ／バイアスを分解） -->
-  <g transform="translate(340,140)">
-    <polygon points="0,120 60,0 120,120" fill="url(#prism-c2)" stroke="#FFFFFF" stroke-width="1.5" opacity="0.95"/>
-    <!-- ハイライト -->
-    <polygon points="60,0 120,120 100,120 60,30" fill="#FFFFFF" opacity="0.18"/>
-    <polygon points="60,0 0,120 20,120 60,30" fill="#FFFFFF" opacity="0.08"/>
+  <!-- レンズが照らした先の小さな真実（鍵） -->
+  <g transform="translate(600,180)" stroke="#FFD566" stroke-width="2.5" fill="none" stroke-linecap="round">
+    <circle cx="-6" cy="-2" r="10"/>
+    <line x1="2" y1="0" x2="20" y2="0"/>
+    <line x1="14" y1="0" x2="14" y2="6"/>
+    <line x1="20" y1="0" x2="20" y2="6"/>
   </g>
 
-  <!-- 出射光（分解された＝客観的な視点） -->
-  <g stroke-width="3" stroke-linecap="round">
-    <line x1="460" y1="200" x2="740" y2="120" stroke="url(#rayR-c2)"/>
-    <line x1="460" y1="200" x2="760" y2="170" stroke="url(#rayY-c2)"/>
-    <line x1="460" y1="200" x2="760" y2="220" stroke="url(#rayG-c2)"/>
-    <line x1="460" y1="200" x2="740" y2="270" stroke="url(#rayB-c2)"/>
+  <!-- 人物（左、胸像シルエット） -->
+  <g transform="translate(220,220)">
+    <!-- 肩〜胸 -->
+    <path d="M -60 130 Q -70 50 -30 22 Q -10 14 4 14 Q 24 14 40 22 Q 70 50 60 130 Z" fill="url(#figure-c2)"/>
+    <!-- 首 -->
+    <path d="M -10 18 L 14 18 L 12 -2 L -8 -2 Z" fill="url(#figure-c2)"/>
+    <!-- 頭（横顔シルエット） -->
+    <path d="M -10 -2 Q -22 -16 -16 -36 Q -8 -56 14 -58 Q 36 -56 38 -32 Q 38 -16 30 -10 Q 28 -4 22 -2 Z" fill="url(#figure-c2)"/>
+    <!-- 上げた手（虫眼鏡を持つ） -->
+    <path d="M 40 26 Q 80 -4 130 -28" fill="none" stroke="url(#figure-c2)" stroke-width="14" stroke-linecap="round"/>
   </g>
 
-  <!-- 出射点に小さな円（焦点） -->
-  <circle cx="460" cy="200" r="5" fill="#FFFFFF"/>
-  <circle cx="460" cy="200" r="9" fill="none" stroke="#FFFFFF" stroke-width="1" opacity="0.4"/>
-
-  <!-- 左上：歪んだ目／疑問符（バイアス） -->
-  <g transform="translate(120,100)" opacity="0.7">
-    <ellipse cx="0" cy="0" rx="28" ry="14" fill="none" stroke="#6C8EF5" stroke-width="2"/>
-    <circle cx="0" cy="0" r="7" fill="#7AAEFF"/>
-    <circle cx="2" cy="-2" r="2" fill="#FFFFFF"/>
-  </g>
-
-  <!-- 右下：チェックマーク（客観性の獲得） -->
-  <g transform="translate(680,330)">
-    <circle cx="0" cy="0" r="22" fill="#34D399" opacity="0.92"/>
-    <polyline points="-8,0 -2,7 9,-6" stroke="#FFFFFF" stroke-width="3.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- 虫眼鏡 -->
+  <g transform="translate(360,160)">
+    <!-- 持ち手 -->
+    <line x1="-30" y1="22" x2="-72" y2="48" stroke="#C49A3C" stroke-width="9" stroke-linecap="round"/>
+    <line x1="-30" y1="22" x2="-72" y2="48" stroke="#FFD566" stroke-width="3" stroke-linecap="round" opacity="0.7"/>
+    <!-- レンズの枠 -->
+    <circle cx="6" cy="-4" r="56" fill="url(#lens-c2)" stroke="#FFD566" stroke-width="3"/>
+    <!-- レンズの反射 -->
+    <ellipse cx="-12" cy="-22" rx="14" ry="6" fill="#FFFFFF" opacity="0.5" transform="rotate(-30 -12 -22)"/>
   </g>
 
   <!-- 細かい星 -->
-  <g fill="#FFD566" opacity="0.85">
-    <circle cx="80" cy="50" r="1.8"/>
-    <circle cx="240" cy="60" r="1.5"/>
-    <circle cx="560" cy="60" r="1.8"/>
-    <circle cx="700" cy="50" r="1.5"/>
-    <circle cx="140" cy="340" r="1.5"/>
-    <circle cx="300" cy="350" r="1.5"/>
+  <g fill="#7AAEFF" opacity="0.55">
+    <circle cx="100" cy="60" r="1.4"/>
+    <circle cx="240" cy="50" r="1.2"/>
+    <circle cx="500" cy="70" r="1.4"/>
+    <circle cx="700" cy="60" r="1.2"/>
+    <circle cx="120" cy="350" r="1.4"/>
   </g>
 </svg>

--- a/public/images/v3/course-logic-02.svg
+++ b/public/images/v3/course-logic-02.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-l2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <linearGradient id="pyr-l2" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#3B5BBF"/>
+      <stop offset="100%" stop-color="#7AAEFF"/>
+    </linearGradient>
+    <linearGradient id="pyr-top-l2" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#6C8EF5"/>
+      <stop offset="100%" stop-color="#A8C7FF"/>
+    </linearGradient>
+    <radialGradient id="glow-l2" cx="0.5" cy="0.4" r="0.55">
+      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.32"/>
+      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-l2)"/>
+
+  <!-- 背景グリッド -->
+  <g stroke="#2A3656" stroke-width="1" opacity="0.35">
+    <line x1="0" y1="100" x2="800" y2="100"/>
+    <line x1="0" y1="200" x2="800" y2="200"/>
+    <line x1="0" y1="300" x2="800" y2="300"/>
+    <line x1="200" y1="0" x2="200" y2="400"/>
+    <line x1="400" y1="0" x2="400" y2="400"/>
+    <line x1="600" y1="0" x2="600" y2="400"/>
+  </g>
+
+  <!-- グロー -->
+  <circle cx="400" cy="180" r="240" fill="url(#glow-l2)"/>
+
+  <!-- ピラミッド構造（メイン結論 → 根拠 → 詳細） -->
+  <g transform="translate(400,80)">
+    <!-- 最上段（結論） -->
+    <rect x="-50" y="0" width="100" height="46" rx="4" fill="url(#pyr-top-l2)"/>
+    <!-- 中段（3つの根拠） -->
+    <rect x="-145" y="74" width="80" height="46" rx="4" fill="url(#pyr-l2)" opacity="0.95"/>
+    <rect x="-40" y="74" width="80" height="46" rx="4" fill="url(#pyr-l2)" opacity="0.95"/>
+    <rect x="65" y="74" width="80" height="46" rx="4" fill="url(#pyr-l2)" opacity="0.95"/>
+    <!-- 下段（詳細） -->
+    <rect x="-200" y="148" width="60" height="40" rx="3" fill="#2A3B7A" opacity="0.9"/>
+    <rect x="-130" y="148" width="60" height="40" rx="3" fill="#2A3B7A" opacity="0.9"/>
+    <rect x="-60" y="148" width="60" height="40" rx="3" fill="#2A3B7A" opacity="0.9"/>
+    <rect x="10" y="148" width="60" height="40" rx="3" fill="#2A3B7A" opacity="0.9"/>
+    <rect x="80" y="148" width="60" height="40" rx="3" fill="#2A3B7A" opacity="0.9"/>
+    <rect x="150" y="148" width="60" height="40" rx="3" fill="#2A3B7A" opacity="0.9"/>
+
+    <!-- 接続線 -->
+    <g stroke="#6C8EF5" stroke-width="1.6" opacity="0.55" fill="none">
+      <line x1="0" y1="46" x2="-105" y2="74"/>
+      <line x1="0" y1="46" x2="0" y2="74"/>
+      <line x1="0" y1="46" x2="105" y2="74"/>
+
+      <line x1="-105" y1="120" x2="-170" y2="148"/>
+      <line x1="-105" y1="120" x2="-100" y2="148"/>
+      <line x1="0" y1="120" x2="-30" y2="148"/>
+      <line x1="0" y1="120" x2="40" y2="148"/>
+      <line x1="105" y1="120" x2="110" y2="148"/>
+      <line x1="105" y1="120" x2="180" y2="148"/>
+    </g>
+  </g>
+
+  <!-- So What 矢印（上へ） -->
+  <g transform="translate(180,260)" stroke="#FFD566" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.95">
+    <line x1="0" y1="40" x2="0" y2="-30"/>
+    <polyline points="-10,-20 0,-30 10,-20"/>
+  </g>
+  <g transform="translate(150,295)" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#FFD566" opacity="0.95">
+    <text x="0" y="0">So What?</text>
+  </g>
+
+  <!-- Why So 矢印（下へ） -->
+  <g transform="translate(620,230)" stroke="#7AAEFF" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.95">
+    <line x1="0" y1="-40" x2="0" y2="30"/>
+    <polyline points="-10,20 0,30 10,20"/>
+  </g>
+  <g transform="translate(595,295)" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#7AAEFF" opacity="0.95">
+    <text x="0" y="0">Why So?</text>
+  </g>
+
+  <!-- 小さな星（アクセント） -->
+  <g fill="#FFD566" opacity="0.8">
+    <circle cx="80" cy="60" r="2"/>
+    <circle cx="720" cy="50" r="1.8"/>
+    <circle cx="360" cy="40" r="1.5"/>
+    <circle cx="540" cy="350" r="1.5"/>
+  </g>
+</svg>

--- a/public/images/v3/course-logic-02.svg
+++ b/public/images/v3/course-logic-02.svg
@@ -4,89 +4,78 @@
       <stop offset="0%" stop-color="#1F2942"/>
       <stop offset="100%" stop-color="#101729"/>
     </linearGradient>
-    <linearGradient id="pyr-l2" x1="0" y1="1" x2="0" y2="0">
-      <stop offset="0%" stop-color="#3B5BBF"/>
-      <stop offset="100%" stop-color="#7AAEFF"/>
-    </linearGradient>
-    <linearGradient id="pyr-top-l2" x1="0" y1="1" x2="0" y2="0">
-      <stop offset="0%" stop-color="#6C8EF5"/>
-      <stop offset="100%" stop-color="#A8C7FF"/>
-    </linearGradient>
-    <radialGradient id="glow-l2" cx="0.5" cy="0.4" r="0.55">
-      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.32"/>
-      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    <radialGradient id="spot-l2" cx="0.5" cy="0.4" r="0.4">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.32"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
     </radialGradient>
+    <linearGradient id="figure-l2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3B5BBF"/>
+      <stop offset="100%" stop-color="#1B2954"/>
+    </linearGradient>
   </defs>
 
   <rect width="800" height="400" fill="url(#bg-l2)"/>
 
-  <!-- 背景グリッド -->
-  <g stroke="#2A3656" stroke-width="1" opacity="0.35">
-    <line x1="0" y1="100" x2="800" y2="100"/>
-    <line x1="0" y1="200" x2="800" y2="200"/>
-    <line x1="0" y1="300" x2="800" y2="300"/>
-    <line x1="200" y1="0" x2="200" y2="400"/>
-    <line x1="400" y1="0" x2="400" y2="400"/>
-    <line x1="600" y1="0" x2="600" y2="400"/>
+  <!-- 細かいグリッド（舞台の床） -->
+  <g stroke="#2A3656" stroke-width="1" opacity="0.25">
+    <line x1="0" y1="80" x2="800" y2="80"/>
+    <line x1="0" y1="160" x2="800" y2="160"/>
+    <line x1="0" y1="240" x2="800" y2="240"/>
   </g>
 
-  <!-- グロー -->
-  <circle cx="400" cy="180" r="240" fill="url(#glow-l2)"/>
+  <!-- 舞台奥のスポットライト -->
+  <circle cx="430" cy="130" r="200" fill="url(#spot-l2)"/>
 
-  <!-- ピラミッド構造（メイン結論 → 根拠 → 詳細） -->
-  <g transform="translate(400,80)">
-    <!-- 最上段（結論） -->
-    <rect x="-50" y="0" width="100" height="46" rx="4" fill="url(#pyr-top-l2)"/>
-    <!-- 中段（3つの根拠） -->
-    <rect x="-145" y="74" width="80" height="46" rx="4" fill="url(#pyr-l2)" opacity="0.95"/>
-    <rect x="-40" y="74" width="80" height="46" rx="4" fill="url(#pyr-l2)" opacity="0.95"/>
-    <rect x="65" y="74" width="80" height="46" rx="4" fill="url(#pyr-l2)" opacity="0.95"/>
-    <!-- 下段（詳細） -->
-    <rect x="-200" y="148" width="60" height="40" rx="3" fill="#2A3B7A" opacity="0.9"/>
-    <rect x="-130" y="148" width="60" height="40" rx="3" fill="#2A3B7A" opacity="0.9"/>
-    <rect x="-60" y="148" width="60" height="40" rx="3" fill="#2A3B7A" opacity="0.9"/>
-    <rect x="10" y="148" width="60" height="40" rx="3" fill="#2A3B7A" opacity="0.9"/>
-    <rect x="80" y="148" width="60" height="40" rx="3" fill="#2A3B7A" opacity="0.9"/>
-    <rect x="150" y="148" width="60" height="40" rx="3" fill="#2A3B7A" opacity="0.9"/>
-
-    <!-- 接続線 -->
-    <g stroke="#6C8EF5" stroke-width="1.6" opacity="0.55" fill="none">
-      <line x1="0" y1="46" x2="-105" y2="74"/>
-      <line x1="0" y1="46" x2="0" y2="74"/>
-      <line x1="0" y1="46" x2="105" y2="74"/>
-
-      <line x1="-105" y1="120" x2="-170" y2="148"/>
-      <line x1="-105" y1="120" x2="-100" y2="148"/>
-      <line x1="0" y1="120" x2="-30" y2="148"/>
-      <line x1="0" y1="120" x2="40" y2="148"/>
-      <line x1="105" y1="120" x2="110" y2="148"/>
-      <line x1="105" y1="120" x2="180" y2="148"/>
-    </g>
+  <!-- 背景のスクリーン（淡い） -->
+  <g opacity="0.5">
+    <rect x="280" y="60" width="320" height="180" rx="3" fill="none" stroke="#6C8EF5" stroke-width="1.2"/>
+    <!-- スクリーンに描かれた一行（要点） -->
+    <line x1="320" y1="120" x2="560" y2="120" stroke="#6C8EF5" stroke-width="2" opacity="0.6"/>
+    <line x1="320" y1="150" x2="500" y2="150" stroke="#6C8EF5" stroke-width="2" opacity="0.4"/>
+    <line x1="320" y1="180" x2="540" y2="180" stroke="#6C8EF5" stroke-width="2" opacity="0.4"/>
   </g>
 
-  <!-- So What 矢印（上へ） -->
-  <g transform="translate(180,260)" stroke="#FFD566" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.95">
-    <line x1="0" y1="40" x2="0" y2="-30"/>
-    <polyline points="-10,-20 0,-30 10,-20"/>
-  </g>
-  <g transform="translate(150,295)" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#FFD566" opacity="0.95">
-    <text x="0" y="0">So What?</text>
-  </g>
-
-  <!-- Why So 矢印（下へ） -->
-  <g transform="translate(620,230)" stroke="#7AAEFF" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.95">
-    <line x1="0" y1="-40" x2="0" y2="30"/>
-    <polyline points="-10,20 0,30 10,20"/>
-  </g>
-  <g transform="translate(595,295)" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#7AAEFF" opacity="0.95">
-    <text x="0" y="0">Why So?</text>
+  <!-- 演者シルエット（中央・腕を上げて指し示す） -->
+  <g transform="translate(430,260)">
+    <!-- 体 -->
+    <path d="M -28 80 Q -32 30 -16 -8 Q -8 -16 0 -16 Q 8 -16 16 -8 Q 32 30 28 80 Z" fill="url(#figure-l2)"/>
+    <!-- 顔 -->
+    <circle cx="0" cy="-26" r="13" fill="#E7ECF7"/>
+    <!-- 髪 -->
+    <path d="M -13 -32 Q 0 -42 13 -32 L 13 -26 L -13 -26 Z" fill="#1A2540"/>
+    <!-- 上げた腕（右） -->
+    <path d="M 14 -8 Q 32 -28 38 -52" fill="none" stroke="url(#figure-l2)" stroke-width="11" stroke-linecap="round"/>
+    <!-- 下ろした腕（左） -->
+    <path d="M -14 -8 Q -22 18 -22 38" fill="none" stroke="url(#figure-l2)" stroke-width="11" stroke-linecap="round"/>
+    <!-- 床の影 -->
+    <ellipse cx="0" cy="84" rx="36" ry="5" fill="#0B1424" opacity="0.7"/>
   </g>
 
-  <!-- 小さな星（アクセント） -->
-  <g fill="#FFD566" opacity="0.8">
-    <circle cx="80" cy="60" r="2"/>
-    <circle cx="720" cy="50" r="1.8"/>
-    <circle cx="360" cy="40" r="1.5"/>
-    <circle cx="540" cy="350" r="1.5"/>
+  <!-- 観客のシルエット（前景・3〜4人） -->
+  <g fill="#0B1424" opacity="0.92">
+    <ellipse cx="120" cy="370" rx="36" ry="14"/>
+    <circle cx="120" cy="338" r="14"/>
+
+    <ellipse cx="220" cy="380" rx="36" ry="14"/>
+    <circle cx="220" cy="346" r="13"/>
+
+    <ellipse cx="630" cy="380" rx="36" ry="14"/>
+    <circle cx="630" cy="346" r="13"/>
+
+    <ellipse cx="720" cy="370" rx="36" ry="14"/>
+    <circle cx="720" cy="338" r="14"/>
+  </g>
+
+  <!-- スポット先の小さなアクセント（金の星） -->
+  <g transform="translate(458,108)" fill="#FFD566">
+    <polygon points="0,-7 2,-2 7,-2 3,1 5,6 0,3 -5,6 -3,1 -7,-2 -2,-2"/>
+  </g>
+
+  <!-- 細かい星（空気感） -->
+  <g fill="#7AAEFF" opacity="0.55">
+    <circle cx="80" cy="60" r="1.4"/>
+    <circle cx="200" cy="40" r="1.2"/>
+    <circle cx="660" cy="50" r="1.4"/>
+    <circle cx="740" cy="80" r="1.2"/>
   </g>
 </svg>

--- a/public/images/v3/course-numeracy.svg
+++ b/public/images/v3/course-numeracy.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-n" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <linearGradient id="card-n" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.97"/>
+      <stop offset="100%" stop-color="#E7ECF7" stop-opacity="0.95"/>
+    </linearGradient>
+    <linearGradient id="bar-n" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#3B5BBF"/>
+      <stop offset="100%" stop-color="#7AAEFF"/>
+    </linearGradient>
+    <linearGradient id="bar2-n" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#C49A3C"/>
+      <stop offset="100%" stop-color="#FFD566"/>
+    </linearGradient>
+    <radialGradient id="glow-n" cx="0.5" cy="0.5" r="0.6">
+      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.28"/>
+      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-n)"/>
+
+  <g stroke="#2A3656" stroke-width="1" opacity="0.30">
+    <line x1="0" y1="100" x2="800" y2="100"/>
+    <line x1="0" y1="200" x2="800" y2="200"/>
+    <line x1="0" y1="300" x2="800" y2="300"/>
+  </g>
+
+  <circle cx="400" cy="200" r="260" fill="url(#glow-n)"/>
+
+  <!-- 背景の大きな数字（淡い） -->
+  <g opacity="0.10" fill="#7AAEFF" font-family="-apple-system, 'Helvetica Neue', sans-serif" font-weight="900">
+    <text x="40" y="180" font-size="160">3</text>
+    <text x="640" y="340" font-size="160">7</text>
+  </g>
+
+  <!-- 中央：棒グラフ（数字感覚） -->
+  <g transform="translate(120,140)">
+    <!-- 軸 -->
+    <line x1="0" y1="0" x2="0" y2="160" stroke="#6C8EF5" stroke-width="1.5" opacity="0.6"/>
+    <line x1="0" y1="160" x2="220" y2="160" stroke="#6C8EF5" stroke-width="1.5" opacity="0.6"/>
+
+    <!-- バー -->
+    <rect x="20" y="100" width="32" height="60" rx="3" fill="url(#bar-n)" opacity="0.88"/>
+    <rect x="64" y="60" width="32" height="100" rx="3" fill="url(#bar-n)"/>
+    <rect x="108" y="80" width="32" height="80" rx="3" fill="url(#bar-n)" opacity="0.92"/>
+    <rect x="152" y="30" width="32" height="130" rx="3" fill="url(#bar2-n)"/>
+
+    <!-- トレンド線 -->
+    <polyline points="36,100 80,60 124,80 168,30" stroke="#FFFFFF" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.85"/>
+    <g fill="#FFFFFF">
+      <circle cx="36" cy="100" r="3"/>
+      <circle cx="80" cy="60" r="3"/>
+      <circle cx="124" cy="80" r="3"/>
+      <circle cx="168" cy="30" r="4" stroke="#FFD566" stroke-width="1.5"/>
+    </g>
+  </g>
+
+  <!-- 右：電卓風カード -->
+  <g transform="translate(440,80)">
+    <rect x="0" y="0" width="240" height="240" rx="14" fill="url(#card-n)"/>
+    <!-- 表示部 -->
+    <rect x="16" y="16" width="208" height="48" rx="6" fill="#1F2942"/>
+    <text x="208" y="50" font-family="-apple-system, 'Helvetica Neue', sans-serif" font-size="26" font-weight="700" fill="#7AAEFF" text-anchor="end">1,247</text>
+    <!-- ボタン -->
+    <g fill="#1F2942" opacity="0.85">
+      <rect x="16" y="80" width="46" height="36" rx="6"/>
+      <rect x="70" y="80" width="46" height="36" rx="6"/>
+      <rect x="124" y="80" width="46" height="36" rx="6"/>
+      <rect x="178" y="80" width="46" height="36" rx="6"/>
+
+      <rect x="16" y="124" width="46" height="36" rx="6"/>
+      <rect x="70" y="124" width="46" height="36" rx="6"/>
+      <rect x="124" y="124" width="46" height="36" rx="6"/>
+    </g>
+    <g fill="url(#bar-n)">
+      <rect x="178" y="124" width="46" height="36" rx="6"/>
+      <rect x="178" y="168" width="46" height="36" rx="6"/>
+    </g>
+    <g fill="#1F2942" opacity="0.85">
+      <rect x="16" y="168" width="46" height="36" rx="6"/>
+      <rect x="70" y="168" width="46" height="36" rx="6"/>
+      <rect x="124" y="168" width="46" height="36" rx="6"/>
+    </g>
+    <!-- = ボタン -->
+    <rect x="16" y="212" width="208" height="14" rx="6" fill="url(#bar2-n)"/>
+
+    <!-- ボタン上の数字（示唆） -->
+    <g fill="#FFFFFF" font-family="-apple-system, sans-serif" font-size="13" font-weight="600" text-anchor="middle" opacity="0.85">
+      <text x="39" y="103">7</text>
+      <text x="93" y="103">8</text>
+      <text x="147" y="103">9</text>
+      <text x="201" y="103">×</text>
+
+      <text x="39" y="147">4</text>
+      <text x="93" y="147">5</text>
+      <text x="147" y="147">6</text>
+      <text x="201" y="147">−</text>
+
+      <text x="39" y="191">1</text>
+      <text x="93" y="191">2</text>
+      <text x="147" y="191">3</text>
+      <text x="201" y="191">+</text>
+    </g>
+  </g>
+
+  <!-- 左下：%（割合） -->
+  <g transform="translate(110,330)" font-family="-apple-system, 'Helvetica Neue', sans-serif" font-size="42" font-weight="800" fill="#FFD566">
+    <text x="0" y="0">%</text>
+  </g>
+
+  <!-- 通貨・単位記号 -->
+  <g font-family="-apple-system, 'Helvetica Neue', sans-serif" font-size="22" font-weight="700" opacity="0.85">
+    <text x="60" y="80" fill="#7AAEFF">¥</text>
+    <text x="720" y="100" fill="#7AAEFF">$</text>
+    <text x="380" y="370" fill="#FFD566">×10⁶</text>
+  </g>
+
+  <!-- 星 -->
+  <g fill="#FFD566" opacity="0.7">
+    <circle cx="40" cy="40" r="1.5"/>
+    <circle cx="760" cy="40" r="1.5"/>
+    <circle cx="60" cy="380" r="1.5"/>
+  </g>
+</svg>

--- a/public/images/v3/course-numeracy.svg
+++ b/public/images/v3/course-numeracy.svg
@@ -4,126 +4,117 @@
       <stop offset="0%" stop-color="#1F2942"/>
       <stop offset="100%" stop-color="#101729"/>
     </linearGradient>
-    <linearGradient id="card-n" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.97"/>
-      <stop offset="100%" stop-color="#E7ECF7" stop-opacity="0.95"/>
-    </linearGradient>
-    <linearGradient id="bar-n" x1="0" y1="1" x2="0" y2="0">
-      <stop offset="0%" stop-color="#3B5BBF"/>
-      <stop offset="100%" stop-color="#7AAEFF"/>
-    </linearGradient>
-    <linearGradient id="bar2-n" x1="0" y1="1" x2="0" y2="0">
-      <stop offset="0%" stop-color="#C49A3C"/>
-      <stop offset="100%" stop-color="#FFD566"/>
-    </linearGradient>
-    <radialGradient id="glow-n" cx="0.5" cy="0.5" r="0.6">
-      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    <radialGradient id="lampGlow-n" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.40"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
     </radialGradient>
+    <linearGradient id="paper-n" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F4ECC4"/>
+      <stop offset="100%" stop-color="#D8C898"/>
+    </linearGradient>
+    <linearGradient id="frame-n" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7A5A1F"/>
+      <stop offset="100%" stop-color="#3F2E0F"/>
+    </linearGradient>
   </defs>
 
   <rect width="800" height="400" fill="url(#bg-n)"/>
 
-  <g stroke="#2A3656" stroke-width="1" opacity="0.30">
-    <line x1="0" y1="100" x2="800" y2="100"/>
-    <line x1="0" y1="200" x2="800" y2="200"/>
-    <line x1="0" y1="300" x2="800" y2="300"/>
-  </g>
+  <!-- ランプの光 -->
+  <circle cx="500" cy="200" r="240" fill="url(#lampGlow-n)"/>
 
-  <circle cx="400" cy="200" r="260" fill="url(#glow-n)"/>
+  <!-- 机面（俯瞰風 — 手前を暗く） -->
+  <rect x="0" y="290" width="800" height="110" fill="#0E1424"/>
+  <line x1="0" y1="290" x2="800" y2="290" stroke="#2A3656" stroke-width="1" opacity="0.5"/>
 
-  <!-- 背景の大きな数字（淡い） -->
-  <g opacity="0.10" fill="#7AAEFF" font-family="-apple-system, 'Helvetica Neue', sans-serif" font-weight="900">
-    <text x="40" y="180" font-size="160">3</text>
-    <text x="640" y="340" font-size="160">7</text>
-  </g>
+  <!-- 帳簿（中央、開いた状態） -->
+  <g transform="translate(400,200)">
+    <!-- 影 -->
+    <ellipse cx="0" cy="74" rx="232" ry="12" fill="#0B1428" opacity="0.7"/>
+    <!-- 中央の綴じ -->
+    <line x1="0" y1="-58" x2="0" y2="60" stroke="#7A5A1F" stroke-width="2" opacity="0.6"/>
 
-  <!-- 中央：棒グラフ（数字感覚） -->
-  <g transform="translate(120,140)">
-    <!-- 軸 -->
-    <line x1="0" y1="0" x2="0" y2="160" stroke="#6C8EF5" stroke-width="1.5" opacity="0.6"/>
-    <line x1="0" y1="160" x2="220" y2="160" stroke="#6C8EF5" stroke-width="1.5" opacity="0.6"/>
+    <!-- 左ページ -->
+    <g transform="translate(-202,-60)">
+      <rect x="0" y="0" width="200" height="120" rx="2" fill="url(#paper-n)"/>
+      <!-- 縦罫 -->
+      <line x1="40" y1="6" x2="40" y2="114" stroke="#7A5A1F" stroke-width="0.8" opacity="0.5"/>
+      <line x1="155" y1="6" x2="155" y2="114" stroke="#7A5A1F" stroke-width="0.8" opacity="0.5"/>
+      <!-- 横罫 -->
+      <g stroke="#7A5A1F" stroke-width="0.5" opacity="0.4">
+        <line x1="6" y1="20" x2="194" y2="20"/>
+        <line x1="6" y1="36" x2="194" y2="36"/>
+        <line x1="6" y1="52" x2="194" y2="52"/>
+        <line x1="6" y1="68" x2="194" y2="68"/>
+        <line x1="6" y1="84" x2="194" y2="84"/>
+        <line x1="6" y1="100" x2="194" y2="100"/>
+      </g>
+      <!-- 数字（手書き風、ゆるく） -->
+      <g font-family="'Courier New', ui-monospace, monospace" font-size="10" fill="#3F2E0F">
+        <text x="48" y="32">売上</text>
+        <text x="160" y="32" text-anchor="end">1,240</text>
+        <text x="48" y="48">原価</text>
+        <text x="160" y="48" text-anchor="end">680</text>
+        <text x="48" y="64">粗利</text>
+        <text x="160" y="64" text-anchor="end">560</text>
+        <text x="48" y="80">経費</text>
+        <text x="160" y="80" text-anchor="end">320</text>
+      </g>
+      <!-- 合計線 -->
+      <line x1="48" y1="86" x2="170" y2="86" stroke="#7A2E2E" stroke-width="1.2"/>
+      <text x="48" y="100" font-family="'Courier New', ui-monospace, monospace" font-size="11" font-weight="700" fill="#7A2E2E">利益</text>
+      <text x="170" y="100" text-anchor="end" font-family="'Courier New', ui-monospace, monospace" font-size="11" font-weight="700" fill="#7A2E2E">240</text>
+    </g>
 
-    <!-- バー -->
-    <rect x="20" y="100" width="32" height="60" rx="3" fill="url(#bar-n)" opacity="0.88"/>
-    <rect x="64" y="60" width="32" height="100" rx="3" fill="url(#bar-n)"/>
-    <rect x="108" y="80" width="32" height="80" rx="3" fill="url(#bar-n)" opacity="0.92"/>
-    <rect x="152" y="30" width="32" height="130" rx="3" fill="url(#bar2-n)"/>
-
-    <!-- トレンド線 -->
-    <polyline points="36,100 80,60 124,80 168,30" stroke="#FFFFFF" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.85"/>
-    <g fill="#FFFFFF">
-      <circle cx="36" cy="100" r="3"/>
-      <circle cx="80" cy="60" r="3"/>
-      <circle cx="124" cy="80" r="3"/>
-      <circle cx="168" cy="30" r="4" stroke="#FFD566" stroke-width="1.5"/>
+    <!-- 右ページ -->
+    <g transform="translate(2,-60)">
+      <rect x="0" y="0" width="200" height="120" rx="2" fill="url(#paper-n)" opacity="0.95"/>
+      <!-- グラフ -->
+      <g transform="translate(20,16)">
+        <line x1="0" y1="0" x2="0" y2="84" stroke="#7A5A1F" stroke-width="1" opacity="0.65"/>
+        <line x1="0" y1="84" x2="160" y2="84" stroke="#7A5A1F" stroke-width="1" opacity="0.65"/>
+        <!-- バー -->
+        <rect x="14" y="50" width="22" height="34" fill="#3B5BBF" opacity="0.85"/>
+        <rect x="46" y="34" width="22" height="50" fill="#3B5BBF" opacity="0.92"/>
+        <rect x="78" y="44" width="22" height="40" fill="#3B5BBF" opacity="0.88"/>
+        <rect x="110" y="20" width="22" height="64" fill="#C49A3C"/>
+        <!-- 折れ線 -->
+        <polyline points="25,50 57,34 89,44 121,20" stroke="#3F2E0F" stroke-width="1.4" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.85"/>
+        <g fill="#3F2E0F">
+          <circle cx="25" cy="50" r="2"/>
+          <circle cx="57" cy="34" r="2"/>
+          <circle cx="89" cy="44" r="2"/>
+          <circle cx="121" cy="20" r="2.5"/>
+        </g>
+      </g>
+      <!-- 注釈 -->
+      <g font-family="'Courier New', ui-monospace, monospace" font-size="8" fill="#3F2E0F" opacity="0.85">
+        <text x="180" y="22" text-anchor="end">↑ 27%</text>
+      </g>
     </g>
   </g>
 
-  <!-- 右：電卓風カード -->
-  <g transform="translate(440,80)">
-    <rect x="0" y="0" width="240" height="240" rx="14" fill="url(#card-n)"/>
-    <!-- 表示部 -->
-    <rect x="16" y="16" width="208" height="48" rx="6" fill="#1F2942"/>
-    <text x="208" y="50" font-family="-apple-system, 'Helvetica Neue', sans-serif" font-size="26" font-weight="700" fill="#7AAEFF" text-anchor="end">1,247</text>
-    <!-- ボタン -->
-    <g fill="#1F2942" opacity="0.85">
-      <rect x="16" y="80" width="46" height="36" rx="6"/>
-      <rect x="70" y="80" width="46" height="36" rx="6"/>
-      <rect x="124" y="80" width="46" height="36" rx="6"/>
-      <rect x="178" y="80" width="46" height="36" rx="6"/>
-
-      <rect x="16" y="124" width="46" height="36" rx="6"/>
-      <rect x="70" y="124" width="46" height="36" rx="6"/>
-      <rect x="124" y="124" width="46" height="36" rx="6"/>
-    </g>
-    <g fill="url(#bar-n)">
-      <rect x="178" y="124" width="46" height="36" rx="6"/>
-      <rect x="178" y="168" width="46" height="36" rx="6"/>
-    </g>
-    <g fill="#1F2942" opacity="0.85">
-      <rect x="16" y="168" width="46" height="36" rx="6"/>
-      <rect x="70" y="168" width="46" height="36" rx="6"/>
-      <rect x="124" y="168" width="46" height="36" rx="6"/>
-    </g>
-    <!-- = ボタン -->
-    <rect x="16" y="212" width="208" height="14" rx="6" fill="url(#bar2-n)"/>
-
-    <!-- ボタン上の数字（示唆） -->
-    <g fill="#FFFFFF" font-family="-apple-system, sans-serif" font-size="13" font-weight="600" text-anchor="middle" opacity="0.85">
-      <text x="39" y="103">7</text>
-      <text x="93" y="103">8</text>
-      <text x="147" y="103">9</text>
-      <text x="201" y="103">×</text>
-
-      <text x="39" y="147">4</text>
-      <text x="93" y="147">5</text>
-      <text x="147" y="147">6</text>
-      <text x="201" y="147">−</text>
-
-      <text x="39" y="191">1</text>
-      <text x="93" y="191">2</text>
-      <text x="147" y="191">3</text>
-      <text x="201" y="191">+</text>
-    </g>
+  <!-- 万年筆 -->
+  <g transform="translate(620,300) rotate(-22)">
+    <line x1="0" y1="0" x2="60" y2="0" stroke="#1A1F2E" stroke-width="6" stroke-linecap="round"/>
+    <line x1="60" y1="0" x2="80" y2="0" stroke="#C49A3C" stroke-width="6" stroke-linecap="round"/>
+    <polygon points="80,0 90,-2 90,2" fill="#1A1F2E"/>
   </g>
 
-  <!-- 左下：%（割合） -->
-  <g transform="translate(110,330)" font-family="-apple-system, 'Helvetica Neue', sans-serif" font-size="42" font-weight="800" fill="#FFD566">
-    <text x="0" y="0">%</text>
+  <!-- ランプ（右奥、控えめ） -->
+  <g transform="translate(640,168)">
+    <!-- 笠 -->
+    <path d="M -28 0 L 28 0 L 20 -26 L -20 -26 Z" fill="#1A2540" stroke="#FFD566" stroke-width="1.4"/>
+    <ellipse cx="0" cy="-2" rx="26" ry="5" fill="#FFD566" opacity="0.85"/>
+    <line x1="0" y1="0" x2="0" y2="62" stroke="#1A2540" stroke-width="2.5"/>
+    <ellipse cx="0" cy="68" rx="18" ry="4" fill="#1A2540"/>
   </g>
 
-  <!-- 通貨・単位記号 -->
-  <g font-family="-apple-system, 'Helvetica Neue', sans-serif" font-size="22" font-weight="700" opacity="0.85">
-    <text x="60" y="80" fill="#7AAEFF">¥</text>
-    <text x="720" y="100" fill="#7AAEFF">$</text>
-    <text x="380" y="370" fill="#FFD566">×10⁶</text>
-  </g>
-
-  <!-- 星 -->
-  <g fill="#FFD566" opacity="0.7">
-    <circle cx="40" cy="40" r="1.5"/>
-    <circle cx="760" cy="40" r="1.5"/>
-    <circle cx="60" cy="380" r="1.5"/>
+  <!-- 控えめな星（窓越し風） -->
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="60" cy="60" r="1.4"/>
+    <circle cx="140" cy="40" r="1.2"/>
+    <circle cx="240" cy="50" r="1.4"/>
+    <circle cx="720" cy="80" r="1.2"/>
   </g>
 </svg>

--- a/public/images/v3/course-strategy-02.svg
+++ b/public/images/v3/course-strategy-02.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-s2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#0B1428"/>
+    </linearGradient>
+    <linearGradient id="ocean-s2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3B5BBF" stop-opacity="0.7"/>
+      <stop offset="100%" stop-color="#101729" stop-opacity="0.95"/>
+    </linearGradient>
+    <linearGradient id="wave-s2" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.55"/>
+      <stop offset="50%" stop-color="#A8C7FF" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0.55"/>
+    </linearGradient>
+    <radialGradient id="glow-s2" cx="0.7" cy="0.4" r="0.55">
+      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="hub-s2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FFD566"/>
+      <stop offset="100%" stop-color="#C49A3C"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-s2)"/>
+
+  <!-- 上空のグロー -->
+  <circle cx="540" cy="120" r="240" fill="url(#glow-s2)"/>
+
+  <!-- 星空 -->
+  <g fill="#FFFFFF" opacity="0.7">
+    <circle cx="80" cy="60" r="1.2"/>
+    <circle cx="160" cy="40" r="1.5"/>
+    <circle cx="280" cy="70" r="1.2"/>
+    <circle cx="380" cy="50" r="1.5"/>
+    <circle cx="480" cy="80" r="1.2"/>
+    <circle cx="600" cy="40" r="1.5"/>
+    <circle cx="680" cy="70" r="1.2"/>
+    <circle cx="740" cy="50" r="1.5"/>
+  </g>
+
+  <!-- 海のベース -->
+  <rect x="0" y="200" width="800" height="200" fill="url(#ocean-s2)"/>
+
+  <!-- 大きな波（ブルーオーシャン） -->
+  <g fill="url(#wave-s2)" opacity="0.85">
+    <path d="M 0 230 Q 100 200 200 230 T 400 230 T 600 230 T 800 230 L 800 260 Q 700 240 600 260 T 400 260 T 200 260 T 0 260 Z"/>
+  </g>
+  <g fill="url(#wave-s2)" opacity="0.55">
+    <path d="M 0 270 Q 120 245 240 270 T 480 270 T 720 270 T 800 270 L 800 300 Q 680 280 560 300 T 320 300 T 80 300 T 0 300 Z"/>
+  </g>
+  <g fill="url(#wave-s2)" opacity="0.35">
+    <path d="M 0 310 Q 100 290 200 310 T 400 310 T 600 310 T 800 310 L 800 340 Q 700 320 600 340 T 400 340 T 200 340 T 0 340 Z"/>
+  </g>
+
+  <!-- 中央：プラットフォーム（ハブ＆ノード） -->
+  <g transform="translate(420,160)">
+    <!-- 接続線 -->
+    <g stroke="#7AAEFF" stroke-width="1.6" opacity="0.6" fill="none">
+      <line x1="0" y1="0" x2="-120" y2="-50"/>
+      <line x1="0" y1="0" x2="120" y2="-50"/>
+      <line x1="0" y1="0" x2="-130" y2="20"/>
+      <line x1="0" y1="0" x2="130" y2="20"/>
+      <line x1="0" y1="0" x2="-80" y2="80"/>
+      <line x1="0" y1="0" x2="80" y2="80"/>
+      <line x1="0" y1="0" x2="0" y2="-90"/>
+    </g>
+
+    <!-- ノード（資源・能力） -->
+    <circle cx="-120" cy="-50" r="14" fill="#3B5BBF" stroke="#7AAEFF" stroke-width="1.5"/>
+    <circle cx="120" cy="-50" r="14" fill="#3B5BBF" stroke="#7AAEFF" stroke-width="1.5"/>
+    <circle cx="-130" cy="20" r="14" fill="#3B5BBF" stroke="#7AAEFF" stroke-width="1.5"/>
+    <circle cx="130" cy="20" r="14" fill="#3B5BBF" stroke="#7AAEFF" stroke-width="1.5"/>
+    <circle cx="-80" cy="80" r="12" fill="#6C8EF5"/>
+    <circle cx="80" cy="80" r="12" fill="#6C8EF5"/>
+    <circle cx="0" cy="-90" r="12" fill="#6C8EF5"/>
+
+    <!-- ハブ（中心の戦略の要） -->
+    <circle cx="0" cy="0" r="32" fill="url(#hub-s2)"/>
+    <circle cx="0" cy="0" r="32" fill="none" stroke="#FFFFFF" stroke-width="2" opacity="0.7"/>
+    <!-- ダイヤモンド（コアコンピタンス） -->
+    <polygon points="0,-12 12,0 0,12 -12,0" fill="#1F2942"/>
+  </g>
+
+  <!-- 左下：船（市場開拓・進化） -->
+  <g transform="translate(140,250)">
+    <!-- 船体 -->
+    <path d="M -50 0 L 50 0 L 40 24 L -40 24 Z" fill="#1A2540" stroke="#7AAEFF" stroke-width="1.5"/>
+    <!-- 帆 -->
+    <polygon points="0,-50 0,-2 24,-2" fill="#E7ECF7" opacity="0.92"/>
+    <polygon points="0,-40 0,-2 -22,-2" fill="#A8C7FF" opacity="0.8"/>
+    <!-- マスト -->
+    <line x1="0" y1="-52" x2="0" y2="2" stroke="#1A2540" stroke-width="2"/>
+  </g>
+
+  <!-- 帆の風（しなやかな進化） -->
+  <g stroke="#7AAEFF" stroke-width="1.4" fill="none" opacity="0.55" stroke-linecap="round">
+    <path d="M 60 200 Q 80 195 100 200"/>
+    <path d="M 50 215 Q 70 210 90 215"/>
+  </g>
+
+  <!-- 右下：右肩上がりの折れ線（成果） -->
+  <g transform="translate(620,310)" stroke="#FFD566" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.92">
+    <polyline points="0,40 30,30 60,32 90,18 120,22 150,0"/>
+  </g>
+  <g transform="translate(620,310)" fill="#FFD566">
+    <circle cx="0" cy="40" r="3"/>
+    <circle cx="30" cy="30" r="3"/>
+    <circle cx="60" cy="32" r="3"/>
+    <circle cx="90" cy="18" r="3"/>
+    <circle cx="120" cy="22" r="3"/>
+    <circle cx="150" cy="0" r="4" stroke="#FFFFFF" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/public/images/v3/course-strategy-02.svg
+++ b/public/images/v3/course-strategy-02.svg
@@ -1,115 +1,86 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
   <defs>
-    <linearGradient id="bg-s2" x1="0" y1="0" x2="1" y2="1">
+    <linearGradient id="bg-s2" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="60%" stop-color="#162038"/>
       <stop offset="100%" stop-color="#0B1428"/>
     </linearGradient>
     <linearGradient id="ocean-s2" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#3B5BBF" stop-opacity="0.7"/>
-      <stop offset="100%" stop-color="#101729" stop-opacity="0.95"/>
+      <stop offset="0%" stop-color="#243352"/>
+      <stop offset="100%" stop-color="#0B1428"/>
     </linearGradient>
-    <linearGradient id="wave-s2" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.55"/>
-      <stop offset="50%" stop-color="#A8C7FF" stop-opacity="0.85"/>
-      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0.55"/>
-    </linearGradient>
-    <radialGradient id="glow-s2" cx="0.7" cy="0.4" r="0.55">
-      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    <radialGradient id="moon-glow-s2" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#F4ECC4" stop-opacity="0.45"/>
+      <stop offset="100%" stop-color="#F4ECC4" stop-opacity="0"/>
     </radialGradient>
-    <linearGradient id="hub-s2" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#FFD566"/>
-      <stop offset="100%" stop-color="#C49A3C"/>
-    </linearGradient>
   </defs>
 
   <rect width="800" height="400" fill="url(#bg-s2)"/>
 
-  <!-- 上空のグロー -->
-  <circle cx="540" cy="120" r="240" fill="url(#glow-s2)"/>
+  <!-- 月のグロー -->
+  <circle cx="600" cy="120" r="160" fill="url(#moon-glow-s2)"/>
 
-  <!-- 星空 -->
+  <!-- 月 -->
+  <g transform="translate(600,120)">
+    <circle cx="0" cy="0" r="48" fill="#F4ECC4"/>
+    <circle cx="-6" cy="-4" r="44" fill="#1F2942" opacity="0.85"/>
+  </g>
+
+  <!-- 月の海面の反射（縦の白い帯） -->
+  <g transform="translate(600,240)" opacity="0.55">
+    <path d="M -36 0 Q -8 30 0 80 Q 8 30 36 0 Z" fill="#F4ECC4"/>
+  </g>
+  <g transform="translate(600,260)" opacity="0.35">
+    <path d="M -28 0 Q -6 40 0 100 Q 6 40 28 0 Z" fill="#F4ECC4"/>
+  </g>
+
+  <!-- 星 -->
   <g fill="#FFFFFF" opacity="0.7">
-    <circle cx="80" cy="60" r="1.2"/>
-    <circle cx="160" cy="40" r="1.5"/>
-    <circle cx="280" cy="70" r="1.2"/>
-    <circle cx="380" cy="50" r="1.5"/>
-    <circle cx="480" cy="80" r="1.2"/>
-    <circle cx="600" cy="40" r="1.5"/>
-    <circle cx="680" cy="70" r="1.2"/>
-    <circle cx="740" cy="50" r="1.5"/>
+    <circle cx="80" cy="60" r="1.4"/>
+    <circle cx="160" cy="40" r="1.6"/>
+    <circle cx="240" cy="80" r="1.2"/>
+    <circle cx="340" cy="50" r="1.4"/>
+    <circle cx="440" cy="70" r="1.2"/>
+    <circle cx="720" cy="60" r="1.4"/>
+    <circle cx="780" cy="100" r="1.2"/>
+    <circle cx="100" cy="120" r="1.2"/>
   </g>
 
-  <!-- 海のベース -->
-  <rect x="0" y="200" width="800" height="200" fill="url(#ocean-s2)"/>
+  <!-- 海 -->
+  <rect x="0" y="220" width="800" height="180" fill="url(#ocean-s2)"/>
 
-  <!-- 大きな波（ブルーオーシャン） -->
-  <g fill="url(#wave-s2)" opacity="0.85">
-    <path d="M 0 230 Q 100 200 200 230 T 400 230 T 600 230 T 800 230 L 800 260 Q 700 240 600 260 T 400 260 T 200 260 T 0 260 Z"/>
-  </g>
-  <g fill="url(#wave-s2)" opacity="0.55">
-    <path d="M 0 270 Q 120 245 240 270 T 480 270 T 720 270 T 800 270 L 800 300 Q 680 280 560 300 T 320 300 T 80 300 T 0 300 Z"/>
-  </g>
-  <g fill="url(#wave-s2)" opacity="0.35">
-    <path d="M 0 310 Q 100 290 200 310 T 400 310 T 600 310 T 800 310 L 800 340 Q 700 320 600 340 T 400 340 T 200 340 T 0 340 Z"/>
+  <!-- 海面の波（水平方向、繊細に） -->
+  <g stroke="#7AAEFF" stroke-width="1" fill="none" opacity="0.35" stroke-linecap="round">
+    <path d="M 0 250 Q 60 246 120 250 T 240 250 T 360 250 T 480 250 T 600 250 T 720 250 T 800 250"/>
+    <path d="M 0 280 Q 60 276 120 280 T 240 280 T 360 280 T 480 280 T 600 280 T 720 280 T 800 280" opacity="0.6"/>
+    <path d="M 0 312 Q 80 308 160 312 T 320 312 T 480 312 T 640 312 T 800 312" opacity="0.4"/>
+    <path d="M 0 348 Q 100 344 200 348 T 400 348 T 600 348 T 800 348" opacity="0.3"/>
   </g>
 
-  <!-- 中央：プラットフォーム（ハブ＆ノード） -->
-  <g transform="translate(420,160)">
-    <!-- 接続線 -->
-    <g stroke="#7AAEFF" stroke-width="1.6" opacity="0.6" fill="none">
-      <line x1="0" y1="0" x2="-120" y2="-50"/>
-      <line x1="0" y1="0" x2="120" y2="-50"/>
-      <line x1="0" y1="0" x2="-130" y2="20"/>
-      <line x1="0" y1="0" x2="130" y2="20"/>
-      <line x1="0" y1="0" x2="-80" y2="80"/>
-      <line x1="0" y1="0" x2="80" y2="80"/>
-      <line x1="0" y1="0" x2="0" y2="-90"/>
-    </g>
-
-    <!-- ノード（資源・能力） -->
-    <circle cx="-120" cy="-50" r="14" fill="#3B5BBF" stroke="#7AAEFF" stroke-width="1.5"/>
-    <circle cx="120" cy="-50" r="14" fill="#3B5BBF" stroke="#7AAEFF" stroke-width="1.5"/>
-    <circle cx="-130" cy="20" r="14" fill="#3B5BBF" stroke="#7AAEFF" stroke-width="1.5"/>
-    <circle cx="130" cy="20" r="14" fill="#3B5BBF" stroke="#7AAEFF" stroke-width="1.5"/>
-    <circle cx="-80" cy="80" r="12" fill="#6C8EF5"/>
-    <circle cx="80" cy="80" r="12" fill="#6C8EF5"/>
-    <circle cx="0" cy="-90" r="12" fill="#6C8EF5"/>
-
-    <!-- ハブ（中心の戦略の要） -->
-    <circle cx="0" cy="0" r="32" fill="url(#hub-s2)"/>
-    <circle cx="0" cy="0" r="32" fill="none" stroke="#FFFFFF" stroke-width="2" opacity="0.7"/>
-    <!-- ダイヤモンド（コアコンピタンス） -->
-    <polygon points="0,-12 12,0 0,12 -12,0" fill="#1F2942"/>
-  </g>
-
-  <!-- 左下：船（市場開拓・進化） -->
-  <g transform="translate(140,250)">
+  <!-- 帆船（左、海面上） -->
+  <g transform="translate(220,240)">
+    <!-- マストの影（水面） -->
+    <ellipse cx="0" cy="40" rx="42" ry="3" fill="#0B1428" opacity="0.6"/>
     <!-- 船体 -->
-    <path d="M -50 0 L 50 0 L 40 24 L -40 24 Z" fill="#1A2540" stroke="#7AAEFF" stroke-width="1.5"/>
-    <!-- 帆 -->
-    <polygon points="0,-50 0,-2 24,-2" fill="#E7ECF7" opacity="0.92"/>
-    <polygon points="0,-40 0,-2 -22,-2" fill="#A8C7FF" opacity="0.8"/>
+    <path d="M -42 0 L 42 0 L 32 24 L -32 24 Z" fill="#0E1424" stroke="#7AAEFF" stroke-width="1.4"/>
     <!-- マスト -->
-    <line x1="0" y1="-52" x2="0" y2="2" stroke="#1A2540" stroke-width="2"/>
+    <line x1="-2" y1="0" x2="-2" y2="-72" stroke="#0B1428" stroke-width="2"/>
+    <line x1="20" y1="0" x2="20" y2="-58" stroke="#0B1428" stroke-width="1.5"/>
+    <!-- 大きな帆 -->
+    <path d="M -2 -68 L -2 -4 L -36 -4 Z" fill="#E7ECF7" opacity="0.95"/>
+    <path d="M -2 -68 L -2 -4 L 26 -4 L 14 -36 Z" fill="#A8C7FF" opacity="0.92"/>
+    <!-- 第二の帆 -->
+    <path d="M 20 -54 L 20 -4 L 40 -4 Z" fill="#E7ECF7" opacity="0.85"/>
   </g>
 
-  <!-- 帆の風（しなやかな進化） -->
-  <g stroke="#7AAEFF" stroke-width="1.4" fill="none" opacity="0.55" stroke-linecap="round">
-    <path d="M 60 200 Q 80 195 100 200"/>
-    <path d="M 50 215 Q 70 210 90 215"/>
+  <!-- 遠景の島影（ぼんやり） -->
+  <g fill="#0B1428" opacity="0.7">
+    <path d="M 720 270 Q 740 260 760 268 Q 780 272 800 268 L 800 290 L 720 290 Z"/>
   </g>
 
-  <!-- 右下：右肩上がりの折れ線（成果） -->
-  <g transform="translate(620,310)" stroke="#FFD566" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.92">
-    <polyline points="0,40 30,30 60,32 90,18 120,22 150,0"/>
-  </g>
-  <g transform="translate(620,310)" fill="#FFD566">
-    <circle cx="0" cy="40" r="3"/>
-    <circle cx="30" cy="30" r="3"/>
-    <circle cx="60" cy="32" r="3"/>
-    <circle cx="90" cy="18" r="3"/>
-    <circle cx="120" cy="22" r="3"/>
-    <circle cx="150" cy="0" r="4" stroke="#FFFFFF" stroke-width="1.5"/>
+  <!-- 鳥（小さなアクセント） -->
+  <g stroke="#7AAEFF" stroke-width="1.6" fill="none" stroke-linecap="round" opacity="0.7">
+    <path d="M 360 110 Q 366 104 372 110 Q 378 104 384 110"/>
+    <path d="M 410 90 Q 416 86 422 90 Q 428 86 434 90"/>
   </g>
 </svg>

--- a/public/preview-courses.html
+++ b/public/preview-courses.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>新コース画像プレビュー</title>
+<style>
+  :root {
+    --bg: #0E1424;
+    --card: #1A2540;
+    --card2: #232F50;
+    --text: #E7ECF7;
+    --text2: #A8B3CD;
+    --text3: #6B7693;
+    --accent: #6C8EF5;
+    --accent-soft: rgba(108,142,245,.18);
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--text); font-family: -apple-system, "Noto Sans JP", "Segoe UI", sans-serif; }
+  header { padding: 36px 24px 16px; max-width: 1200px; margin: 0 auto; }
+  header h1 { font-size: 22px; font-weight: 800; letter-spacing: -.01em; margin: 0 0 6px; }
+  header p { color: var(--text2); margin: 0; font-size: 14px; line-height: 1.6; }
+  main { max-width: 1200px; margin: 0 auto; padding: 16px 24px 80px; display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+  @media (max-width: 760px) { main { grid-template-columns: 1fr; } }
+  .card {
+    background: linear-gradient(140deg, var(--card2) 0%, var(--card) 100%);
+    border-radius: 18px;
+    overflow: hidden;
+    box-shadow: 0 14px 36px rgba(0,0,0,.35), 0 2px 8px rgba(0,0,0,.2);
+  }
+  .img-wrap { aspect-ratio: 2 / 1; overflow: hidden; position: relative; }
+  .img-wrap img { width: 100%; height: 100%; object-fit: cover; display: block; }
+  .body { padding: 18px 20px 20px; }
+  .badges { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 8px; }
+  .badge { font-size: 10px; font-weight: 800; letter-spacing: .06em; padding: 2px 8px; border-radius: 6px; }
+  .badge.cat { color: var(--text3); background: rgba(107,118,147,.16); }
+  .badge.lvl { color: var(--accent); background: var(--accent-soft); }
+  .title { font-size: 17px; font-weight: 700; line-height: 1.35; margin: 0 0 6px; }
+  .desc { font-size: 13px; color: var(--text2); line-height: 1.55; margin: 0; }
+  .meta { font-size: 11px; color: var(--text3); margin-top: 12px; font-family: ui-monospace, monospace; }
+
+  .grid-mini-title { color: var(--text2); font-size: 13px; margin: 32px 24px 8px; max-width: 1200px; margin-left: auto; margin-right: auto; padding: 0 24px; font-weight: 600; letter-spacing: .04em; }
+  .mini { max-width: 1200px; margin: 0 auto; padding: 0 24px 80px; display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; }
+  .mini .card { border-radius: 14px; }
+  .mini .img-wrap { aspect-ratio: 16 / 9; }
+  .mini .body { padding: 12px 14px 14px; }
+  .mini .title { font-size: 14px; }
+  .mini .desc { font-size: 12px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>新コース画像プレビュー（6枚）</h1>
+  <p>左右で見比べたり、下のミニサイズ（実機の2列レイアウト相当）で全体像を確認できます。</p>
+</header>
+
+<main>
+
+  <div class="card">
+    <div class="img-wrap"><img src="/images/v3/course-logic-02.svg" alt="" /></div>
+    <div class="body">
+      <div class="badges"><span class="badge cat">ロジカルシンキング</span><span class="badge lvl">初級</span></div>
+      <h2 class="title">論理を組み立て、相手を動かす</h2>
+      <p class="desc">So What / Why Soで論理を検証し、ピラミッド構造で伝わる話し方を習得する。</p>
+      <div class="meta">course-logic-02.svg</div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="img-wrap"><img src="/images/v3/course-critical-02.svg" alt="" /></div>
+    <div class="body">
+      <div class="badges"><span class="badge cat">クリティカルシンキング</span><span class="badge lvl">中級</span></div>
+      <h2 class="title">バイアスを外し、客観的に見る</h2>
+      <p class="desc">確証バイアスをはじめとした認知の歪みを理解し、より精度の高い判断をする。</p>
+      <div class="meta">course-critical-02.svg</div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="img-wrap"><img src="/images/v3/course-client-02.svg" alt="" /></div>
+    <div class="body">
+      <div class="badges"><span class="badge cat">クライアントワーク</span><span class="badge lvl">中級</span></div>
+      <h2 class="title">論点を定め、深く引き出す</h2>
+      <p class="desc">正しい論点設定とヒアリング技術で、クライアントの本質的な課題を引き出す。</p>
+      <div class="meta">course-client-02.svg</div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="img-wrap"><img src="/images/v3/course-client-03.svg" alt="" /></div>
+    <div class="body">
+      <div class="badges"><span class="badge cat">クライアントワーク</span><span class="badge lvl">上級</span></div>
+      <h2 class="title">未経験の業界で、短期間で立ち上がる</h2>
+      <p class="desc">本・事例・有識者・仮説を総動員し、新しい案件で「専門家」として価値発揮するキャッチアップの技術を学ぶ。</p>
+      <div class="meta">course-client-03.svg</div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="img-wrap"><img src="/images/v3/course-strategy-02.svg" alt="" /></div>
+    <div class="body">
+      <div class="badges"><span class="badge cat">経営戦略</span><span class="badge lvl">上級</span></div>
+      <h2 class="title">資源・能力・共進化の戦略へ</h2>
+      <p class="desc">RBV・コアコンピタンスからブルーオーシャン、ダイナミック・ケイパビリティ、プラットフォーム戦略まで現代の進化を学ぶ。</p>
+      <div class="meta">course-strategy-02.svg</div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="img-wrap"><img src="/images/v3/course-numeracy.svg" alt="" /></div>
+    <div class="body">
+      <div class="badges"><span class="badge cat">数字に強くなる</span><span class="badge lvl">中級</span></div>
+      <h2 class="title">数字に強くなる</h2>
+      <p class="desc">伝え方・暗算・割合操作・単位換算・複利・統計・落とし穴の7本立てで、ビジネス数字感覚を体系的に鍛える。</p>
+      <div class="meta">course-numeracy.svg</div>
+    </div>
+  </div>
+
+</main>
+
+<div class="grid-mini-title">▼ 実機の2列カード相当（ミニサイズ）</div>
+<div class="mini">
+  <div class="card"><div class="img-wrap"><img src="/images/v3/course-logic-02.svg"></div><div class="body"><h2 class="title">論理を組み立て、相手を動かす</h2></div></div>
+  <div class="card"><div class="img-wrap"><img src="/images/v3/course-critical-02.svg"></div><div class="body"><h2 class="title">バイアスを外し、客観的に見る</h2></div></div>
+  <div class="card"><div class="img-wrap"><img src="/images/v3/course-client-02.svg"></div><div class="body"><h2 class="title">論点を定め、深く引き出す</h2></div></div>
+  <div class="card"><div class="img-wrap"><img src="/images/v3/course-client-03.svg"></div><div class="body"><h2 class="title">未経験の業界で、短期間で立ち上がる</h2></div></div>
+  <div class="card"><div class="img-wrap"><img src="/images/v3/course-strategy-02.svg"></div><div class="body"><h2 class="title">資源・能力・共進化の戦略へ</h2></div></div>
+  <div class="card"><div class="img-wrap"><img src="/images/v3/course-numeracy.svg"></div><div class="body"><h2 class="title">数字に強くなる</h2></div></div>
+</div>
+
+</body>
+</html>

--- a/scripts/preview-svgs.cjs
+++ b/scripts/preview-svgs.cjs
@@ -1,0 +1,29 @@
+const sharp = require('sharp');
+const fs = require('fs');
+const path = require('path');
+
+const baseDir = path.join(__dirname, '..', 'public', 'images', 'v3');
+const outDir = '/tmp/svg-previews';
+
+if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+
+const svgs = [
+  'course-logic-02.svg',
+  'course-critical-02.svg',
+  'course-client-02.svg',
+  'course-client-03.svg',
+  'course-strategy-02.svg',
+  'course-numeracy.svg',
+];
+
+(async () => {
+  for (const name of svgs) {
+    const inPath = path.join(baseDir, name);
+    const outPath = path.join(outDir, name.replace('.svg', '.png'));
+    await sharp(inPath, { density: 200 })
+      .resize(1000, 500)
+      .png()
+      .toFile(outPath);
+    console.log('written', outPath);
+  }
+})();

--- a/src/courseData.ts
+++ b/src/courseData.ts
@@ -51,6 +51,7 @@ export const COURSES: Course[] = [
     lessonIds: [25, 26, 27, 68, 23],
     level: '初級',
     description: 'So What / Why Soで論理を検証し、ピラミッド構造で伝わる話し方を習得する。',
+    image: '/images/v3/course-logic-02.svg',
   },
 
   // ── クリティカルシンキング ──────────────────────────
@@ -71,6 +72,7 @@ export const COURSES: Course[] = [
     lessonIds: [71, 300, 301, 302, 303],
     level: '中級',
     description: '確証バイアスをはじめとした認知の歪みを理解し、より精度の高い判断をする。',
+    image: '/images/v3/course-critical-02.svg',
   },
 
   // ── 仮説思考 ────────────────────────────────────────
@@ -212,6 +214,7 @@ export const COURSES: Course[] = [
     lessonIds: [93, 94, 95, 96, 315],
     level: '中級',
     description: '正しい論点設定とヒアリング技術で、クライアントの本質的な課題を引き出す。',
+    image: '/images/v3/course-client-02.svg',
   },
   {
     id: 'client-03',
@@ -221,6 +224,7 @@ export const COURSES: Course[] = [
     lessonIds: [330, 331, 332, 333, 334, 335],
     level: '上級',
     description: '本・事例・有識者・仮説を総動員し、新しい案件で「専門家」として価値発揮するキャッチアップの技術を学ぶ。',
+    image: '/images/v3/course-client-03.svg',
   },
 
   // ── ケース面接 ──────────────────────────────────────
@@ -252,6 +256,7 @@ export const COURSES: Course[] = [
     lessonIds: [325, 326, 327, 328, 329],
     level: '上級',
     description: 'RBV・コアコンピタンスからブルーオーシャン、ダイナミック・ケイパビリティ、プラットフォーム戦略まで現代の進化を学ぶ。',
+    image: '/images/v3/course-strategy-02.svg',
   },
 
   // ── フェルミ推定 ────────────────────────────────────
@@ -274,6 +279,7 @@ export const COURSES: Course[] = [
     lessonIds: [401, 400, 402, 403, 404, 405, 406],
     level: '中級',
     description: '伝え方・暗算・割合操作・単位換算・複利・統計・落とし穴の7本立てで、ビジネス数字感覚を体系的に鍛える。',
+    image: '/images/v3/course-numeracy.svg',
   },
 ]
 

--- a/src/screens/RoadmapScreenV3.tsx
+++ b/src/screens/RoadmapScreenV3.tsx
@@ -123,7 +123,7 @@ const CATEGORY_VISUAL: Record<string, CategoryVisual> = {
   '数字に強くなる': {
     icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#7AAEFF" strokeWidth="2" strokeLinecap="round"><path d="M4 7h16M4 12h16M4 17h10"/></svg>,
     iconBg: 'rgba(122,174,255,.14)',
-    image: `${IMG}/fermi-card.png`,
+    image: `${IMG}/course-numeracy.svg`,
     routeKey: '数字に強くなる',
   },
 }


### PR DESCRIPTION
## Summary

同じ画像を共有していた6つのコースに、それぞれ専用のSVGイラストを作成しました。既存の `course-eastern-01/02.svg` と同じ「シルエット＋舞台＋雰囲気」のトーンに統一しています。

| コース | 内容 | 新画像のシーン |
|---|---|---|
| logic-02 | 論理を組み立て、相手を動かす | 演者がスクリーンに要点を指し示すプレゼン |
| critical-02 | バイアスを外し、客観的に見る | 虫眼鏡で真実（鍵）を照らし出す人物 |
| client-02 | 論点を定め、深く引き出す | 夜の窓辺で向き合う2人の対話 |
| client-03 | 未経験の業界で立ち上がる | 月夜の書斎・ランプ・開かれた本 |
| strategy-02 | 資源・能力・共進化の戦略へ | 月明かりの海を進む帆船 |
| numeracy-01 | 数字に強くなる | 開かれた帳簿（売上・利益）と棒グラフ |

## 変更内容

- `public/images/v3/course-{logic-02, critical-02, client-02, client-03, strategy-02, numeracy}.svg` 新規追加
- `src/courseData.ts` 各コースに `image:` プロパティ追加
- `src/screens/RoadmapScreenV3.tsx` 「数字に強くなる」カテゴリの画像を `fermi-card.png` から `course-numeracy.svg` に変更
- `public/preview-courses.html` 全6枚を一覧確認できるプレビューページ
- `scripts/preview-svgs.cjs` SVG→PNG 変換スクリプト（dev用ツール）

## Test plan

- [x] `tsc -b` パス
- [x] `npm run build` パス
- [x] `dist/images/v3/` に全6 SVG 出力確認
- [x] PNG変換でビジュアル確認（チャットで全6枚レビュー済み）

---
_Generated by [Claude Code](https://claude.ai/code/session_016p9vnnqJaBPNqebHEs5LdT)_