### PR TITLE
実力診断テストの体験を刷新し、結果からパーソナルコースへ繋げる

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,8 +1,14 @@
+previews:
+  generation: automatic
+  expireAfterDays: 7
+
 services:
   - type: web
     name: logic
     runtime: node
     autoDeploy: true
+    previews:
+      generation: automatic
     buildCommand: npm install --include=dev && npm run build
     startCommand: npm start
     envVars:

--- a/src/AppV3.tsx
+++ b/src/AppV3.tsx
@@ -27,6 +27,7 @@ const AIProblemScreen = lazy(() => import('./screens/AIProblemScreen').then(m =>
 const FeedbackScreen = lazy(() => import('./screens/FeedbackScreen').then(m => ({ default: m.FeedbackScreen })))
 const FeedbackDashboardScreen = lazy(() => import('./screens/FeedbackDashboardScreen').then(m => ({ default: m.FeedbackDashboardScreen })))
 const PlacementTestScreen = lazy(() => import('./screens/PlacementTestScreen').then(m => ({ default: m.PlacementTestScreen })))
+const PersonalCourseScreen = lazy(() => import('./screens/PersonalCourseScreen').then(m => ({ default: m.PersonalCourseScreen })))
 const PricingScreen = lazy(() => import('./screens/PricingScreen').then(m => ({ default: m.PricingScreen })))
 // PricingV3.tsx は AppV3 では未使用。PricingScreen.tsx が最新・完全な実装（startCheckout 接続済み）であるため、
 // PricingV3 は削除せず残しておく（将来参照用）
@@ -98,6 +99,7 @@ type Screen =
   | { type: 'feedback' }
   | { type: 'feedback-dashboard' }
   | { type: 'placement-test' }
+  | { type: 'personal-course' }
   | { type: 'pricing' }
   | { type: 'streak' }
   | { type: 'settings'; section?: 'account' | 'notifications' | 'plan' }
@@ -391,6 +393,8 @@ function AppV3() {
         <RoadmapScreenV3
           onOpenLesson={handleOpenLesson}
           onOpenCategory={(cat) => navigate({ type: 'roadmap', category: cat as any })}
+          onOpenPersonalCourse={() => navigate({ type: 'personal-course' })}
+          onOpenPlacementTest={() => navigate({ type: 'placement-test' })}
         />
       )}
 
@@ -451,8 +455,15 @@ function AppV3() {
       {screen.type === 'placement-test' && (
         <PlacementTestScreen
           onBack={handleBack}
-          onComplete={() => navigate({ type: 'deviation' })}
-          onSkip={handleBack}
+          onComplete={() => navigate({ type: 'personal-course' })}
+        />
+      )}
+
+      {screen.type === 'personal-course' && (
+        <PersonalCourseScreen
+          onStartLesson={handleOpenLesson}
+          onExit={() => { setTab('home'); navigate({ type: 'home' }, true) }}
+          onBack={handleBack}
         />
       )}
 

--- a/src/components/RadarChart.tsx
+++ b/src/components/RadarChart.tsx
@@ -4,6 +4,8 @@ export type RadarAxis = {
   key: string
   label: string
   level: 1 | 2 | 3 | 4 | 5
+  /** Lv.X の代わりに表示するラベル文字列（例: 卓越/上級/中級/基礎/入門） */
+  levelLabel?: string
 }
 
 interface RadarChartProps {
@@ -159,7 +161,7 @@ export function RadarChart({
               fill={strokeColor}
               opacity={0.85}
             >
-              Lv.{a.level}
+              {a.levelLabel ?? `Lv.${a.level}`}
             </text>
           </g>
         )

--- a/src/placementData.ts
+++ b/src/placementData.ts
@@ -629,11 +629,12 @@ export function startSession(): PlacementSession {
 export function getCurrentQuestion(session: PlacementSession): PlacementQuestion | null {
   const slot = session.plan[session.cursor]
   if (!slot) return null
-  // Phase Aは事前に確定
-  if (slot.phase === 'A' && slot.questionId) {
+  // 既に問題が確定していればキャッシュを返す（Phase A/B共通）。
+  // 過去にPhase Bでは毎回再抽選しており、再レンダーで問題が変わる不具合があった。
+  if (slot.questionId) {
     return getQuestionPool().find(q => q.id === slot.questionId) ?? null
   }
-  // Phase B: その軸のPhase A結果を見て難度確定
+  // Phase B 初回: その軸のPhase A結果を見て難度確定
   const aAnswer = session.answers.find(a => a.axis === slot.axis && session.plan.find(p => p.questionId === a.questionId)?.phase === 'A')
   const difficulty: Difficulty = aAnswer?.correct ? 'hard' : 'easy'
   const used = new Set(session.answers.map(a => a.questionId).concat(session.plan.filter(p => p.questionId).map(p => p.questionId)))
@@ -668,13 +669,22 @@ export function computeAxisScores(answers: PlacementAnswer[]): AxisScore[] {
     const phaseA = axisAns[0]
     const phaseB = axisAns[1]
 
+    // 厳しめスコアリング:
+    //  - medium正解 + hard正解 → Lv.5 (卓越)
+    //  - medium正解 + easyフォールバック正解 → Lv.4 (上級)
+    //  - medium正解 + hard不正解 → Lv.3 (中級: 基礎は理解、応用で詰まる)
+    //  - medium不正解 + easy正解 → Lv.2 (基礎: 基礎のみ)
+    //  - medium不正解 + easy不正解 → Lv.1 (入門)
+    //  - phase B未回答（暫定）はphase A結果で評価
     let level: 1 | 2 | 3 | 4 | 5 = 1
     if (phaseA?.correct && phaseB?.correct) {
       level = phaseB.difficulty === 'hard' ? 5 : 4
     } else if (phaseA?.correct && phaseB && !phaseB.correct) {
-      level = 4 // medium正解、hardでつまずく → 中級
-    } else if (!phaseA?.correct && phaseB?.correct) {
-      level = phaseB.difficulty === 'easy' ? 2 : 3
+      level = 3 // medium正解だが応用でつまずく → 中級
+    } else if (phaseA?.correct) {
+      level = 3 // 暫定: medium正解のみ
+    } else if (phaseB?.correct) {
+      level = 2 // 基礎のみ正解
     } else {
       level = 1
     }
@@ -689,10 +699,10 @@ export function calcDeviation(answers: PlacementAnswer[]): number {
   if (answers.length === 0) return 50
   const totalRaw = answers.reduce((sum, a) => sum + (a.correct ? DIFF_VALUE[a.difficulty] : 0), 0)
   // 最大スコア: 5 medium(2) + 5 hard(3) = 25 → 偏差値75
-  // 中央スコア: 全medium正解で 5 medium(2) + 5 easy(1) = 15 → 偏差値58
-  // 最低: 0 → 偏差値28
-  const dev = Math.round(28 + (totalRaw / 25) * 47)
-  return Math.max(25, Math.min(78, dev))
+  // 全問不正解: 0 → 偏差値22 (厳しめ下限)
+  // 旧式は28起点・47幅で底上げが大きかった。22起点・53幅に変更。
+  const dev = Math.round(22 + (totalRaw / 25) * 53)
+  return Math.max(20, Math.min(78, dev))
 }
 
 // 後方互換: 旧APIシグネチャ
@@ -718,6 +728,79 @@ export function rankLabel(dev: number): { label: string; color: string; comment:
   return en
     ? { label: 'Starter', color: '#9B8E7E', comment: 'Begin with the fundamentals of logical thinking, step by step.' }
     : { label: '入門', color: '#9B8E7E', comment: 'ロジカルシンキングの基礎から順番に学びましょう。' }
+}
+
+// 5段階レベル → 言葉ラベル
+export function levelLabel(level: number): string {
+  switch (level) {
+    case 5: return '卓越'
+    case 4: return '上級'
+    case 3: return '中級'
+    case 2: return '基礎'
+    default: return '入門'
+  }
+}
+
+// 軸ごとの強み・弱みコメント（言語化）
+function axisDetailComment(axis: SkillAxis, level: 1 | 2 | 3 | 4 | 5): string {
+  const a = axisLabel(axis).label
+  if (level >= 5) return `${a}は卓越レベル。応用問題でも論点を即座に押さえられている。`
+  if (level >= 4) return `${a}は上級レベル。フレームを使いこなし、実務でも安定して活用できる。`
+  if (level >= 3) return `${a}は中級レベル。基礎は理解しているが、応用問題で抜け漏れが出やすい。`
+  if (level >= 2) return `${a}は基礎レベル。基本問題は解けるが、応用への橋渡しが課題。`
+  return `${a}は入門レベル。まずはこの軸の基本概念から押さえ直す必要がある。`
+}
+
+// 詳細な診断コメント（複数行）
+export function detailedDiagnosis(axisScores: AxisScore[], deviation: number): string[] {
+  const sorted = [...axisScores].sort((a, b) => a.level - b.level)
+  const weakest = sorted[0]
+  const second = sorted[1]
+  const strongest = sorted[sorted.length - 1]
+  const avgLevel = axisScores.reduce((s, a) => s + a.level, 0) / Math.max(1, axisScores.length)
+  const lines: string[] = []
+
+  // 全体評価
+  if (deviation >= 65) {
+    lines.push('全体としてトップクラスの論理思考力。基本〜応用まで安定して解けており、実務でも複雑な論点を整理できる段階にあります。')
+  } else if (deviation >= 55) {
+    lines.push('全体として上級レベル。論理の基礎は完成しており、応用問題でも筋の良い切り口を選べています。あと一歩で「使いこなす側」に到達します。')
+  } else if (deviation >= 45) {
+    lines.push('全体として中級レベル。主要フレームは理解できていますが、応用問題で論点を一段深く詰める力がもう一段必要です。')
+  } else if (deviation >= 35) {
+    lines.push('全体として初級〜基礎レベル。基本概念の理解にバラつきが残っており、まずは土台となる「型」を一つずつ確実にしましょう。')
+  } else {
+    lines.push('全体として入門レベル。論理思考の用語・フレームが定着していない段階です。焦らず基本問題から順に積み上げていきましょう。')
+  }
+
+  // 強み・弱み
+  if (strongest && strongest.level >= 3 && strongest.axis !== weakest?.axis) {
+    lines.push(`強みは「${axisLabel(strongest.axis).label}」（${levelLabel(strongest.level)}）。${axisDetailComment(strongest.axis, strongest.level)}`)
+  }
+  if (weakest) {
+    lines.push(`最大の伸びしろは「${axisLabel(weakest.axis).label}」（${levelLabel(weakest.level)}）。${axisDetailComment(weakest.axis, weakest.level)}`)
+  }
+  if (second && second.axis !== weakest?.axis && second.level <= 2) {
+    lines.push(`次の課題は「${axisLabel(second.axis).label}」（${levelLabel(second.level)}）。ここを底上げすることで全体の安定感が増します。`)
+  }
+
+  // バランス・偏り
+  const minLv = Math.min(...axisScores.map(a => a.level))
+  const maxLv = Math.max(...axisScores.map(a => a.level))
+  if (maxLv - minLv >= 3) {
+    lines.push('軸間の差が大きく、得意・不得意がはっきり分かれています。総合力を上げるには、最も弱い軸を優先的に底上げするのが近道です。')
+  } else if (avgLevel >= 4 && maxLv - minLv <= 1) {
+    lines.push('5軸とも高水準で揃っており、バランス型の論理思考力です。今後はケース・戦略など実務応用で更に磨きをかけられます。')
+  } else if (avgLevel <= 2 && maxLv - minLv <= 1) {
+    lines.push('まだ全体的に基礎が固まりきっていない段階です。1日1レッスン、優先順位を絞って積み上げていきましょう。')
+  }
+
+  // 学習方針
+  if (weakest) {
+    lines.push(`次のアクション: 「${axisLabel(weakest.axis).label}」を補強するレッスンから着手。あなた専用のパーソナルコース（弱点優先順）を自動生成しています。`)
+  }
+
+  return lines
 }
 
 // ───────────────────────────────────────────────────────────────
@@ -860,4 +943,101 @@ export function buildResultFromSession(session: PlacementSession): PlacementResu
     recommendedCourseIds,
     answers: session.answers,
   }
+}
+
+// ───────────────────────────────────────────────────────────────
+// パーソナルコース（既存レッスンの組み合わせ）
+// ───────────────────────────────────────────────────────────────
+
+export type PersonalCourse = {
+  id: 'personal'
+  title: string
+  description: string
+  lessonIds: number[]
+  axisOrder: SkillAxis[]
+  createdAt: string
+}
+
+const PERSONAL_COURSE_KEY = 'logic-personal-course'
+// パーソナルコース内で使うレッスンIDの拡張プール（弱い軸ごとに3〜5件用意）
+const AXIS_LESSON_POOL: Record<SkillAxis, number[]> = {
+  structuring: [20, 21, 23, 22, 68],
+  reasoning:   [25, 26, 27, 68, 23],
+  critical:    [40, 41, 71, 42, 43, 69],
+  hypothesis:  [50, 51, 52, 53, 54, 70],
+  business:    [200, 201, 401, 400, 89, 90],
+}
+
+export function buildPersonalCourse(axisScores: AxisScore[], deviation: number): PersonalCourse {
+  const sorted = [...axisScores].sort((a, b) => a.level - b.level)
+  const axisOrder = sorted.map(a => a.axis)
+  const ids: number[] = []
+  // 弱い軸から優先して2レッスンずつ拾う
+  for (const a of sorted) {
+    let picked = 0
+    for (const id of AXIS_LESSON_POOL[a.axis]) {
+      if (ids.includes(id)) continue
+      ids.push(id)
+      picked++
+      if (picked >= 2) break
+    }
+    if (ids.length >= 8) break
+  }
+  // 8件未満なら他軸から穴埋め
+  if (ids.length < 6) {
+    for (const a of sorted) {
+      for (const id of AXIS_LESSON_POOL[a.axis]) {
+        if (ids.includes(id)) continue
+        ids.push(id)
+        if (ids.length >= 8) break
+      }
+      if (ids.length >= 8) break
+    }
+  }
+  const limit = Math.min(8, Math.max(5, ids.length))
+  const lessonIds = ids.slice(0, limit)
+  const weakestLabel = sorted[0] ? axisLabel(sorted[0].axis).label : ''
+  const title = weakestLabel
+    ? `あなた専用コース：${weakestLabel}を軸に底上げ`
+    : 'あなた専用パーソナルコース'
+  const description = weakestLabel
+    ? `診断結果（偏差値${deviation}）に基づき、最も伸びしろのある「${weakestLabel}」から優先的に学べる${lessonIds.length}レッスン構成のあなた専用コースです。`
+    : `診断結果（偏差値${deviation}）に基づき、あなたの弱点軸を優先的に補強する${lessonIds.length}レッスン構成のコースです。`
+  return {
+    id: 'personal',
+    title,
+    description,
+    lessonIds,
+    axisOrder,
+    createdAt: new Date().toISOString(),
+  }
+}
+
+export function savePersonalCourse(c: PersonalCourse): void {
+  try {
+    localStorage.setItem(PERSONAL_COURSE_KEY, JSON.stringify(c))
+  } catch { /* silent */ }
+}
+
+export function loadPersonalCourse(): PersonalCourse | null {
+  try {
+    const raw = localStorage.getItem(PERSONAL_COURSE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<PersonalCourse>
+    if (!parsed.lessonIds || !Array.isArray(parsed.lessonIds)) return null
+    return {
+      id: 'personal',
+      title: parsed.title ?? 'あなた専用パーソナルコース',
+      description: parsed.description ?? '',
+      lessonIds: parsed.lessonIds,
+      axisOrder: parsed.axisOrder ?? [],
+      createdAt: parsed.createdAt ?? new Date().toISOString(),
+    }
+  } catch {
+    return null
+  }
+}
+
+export function clearPersonalCourse(): void {
+  try { localStorage.removeItem(PERSONAL_COURSE_KEY) } catch { /* silent */ }
 }

--- a/src/screens/DeviationScreen.tsx
+++ b/src/screens/DeviationScreen.tsx
@@ -5,12 +5,11 @@ import {
   recommendedLessons,
   computeAxisScores,
   axisLabel,
-  recommendCourses,
+  levelLabel,
   type AxisScore,
 } from '../placementData'
 import { getAllLessonsFlat } from '../lessonData'
-import { getCourseById } from '../courseData'
-import { ArrowLeftIcon, SparklesIcon } from '../icons'
+import { ArrowLeftIcon } from '../icons'
 import { Button } from '../components/Button'
 import { IconButton } from '../components/IconButton'
 import { RadarChart } from '../components/RadarChart'
@@ -63,16 +62,6 @@ export function DeviationScreen({ onBack, onRetakeTest, onStartLesson }: Deviati
       ? computeAxisScores(result.answers)
       : []
 
-  // コース推薦
-  const courseIds = result.recommendedCourseIds.length
-    ? result.recommendedCourseIds
-    : axisScores.length
-      ? recommendCourses(axisScores, result.deviation)
-      : []
-  const recommendedCourses = courseIds
-    .map(id => getCourseById(id))
-    .filter((c): c is NonNullable<typeof c> => !!c)
-
   // レッスン推薦
   const recommendedLessonIds = result.recommendedLessonIds.length
     ? result.recommendedLessonIds
@@ -87,6 +76,7 @@ export function DeviationScreen({ onBack, onRetakeTest, onStartLesson }: Deviati
     key: a.axis,
     label: axisLabel(a.axis).short,
     level: a.level,
+    levelLabel: levelLabel(a.level),
   }))
   const weakest = axisScores.length ? [...axisScores].sort((a, b) => a.level - b.level)[0] : null
   const strongest = axisScores.length ? [...axisScores].sort((a, b) => b.level - a.level)[0] : null
@@ -189,17 +179,17 @@ export function DeviationScreen({ onBack, onRetakeTest, onStartLesson }: Deviati
                 }}
               >
                 <span style={{ fontSize: 13, fontWeight: 700 }}>{axisLabel(a.axis).label}</span>
-                <span style={{ fontSize: 14, fontWeight: 800, color: '#6C8EF5' }}>Lv.{a.level}</span>
+                <span style={{ fontSize: 13, fontWeight: 800, color: '#6C8EF5' }}>{levelLabel(a.level)}</span>
               </div>
             ))}
           </div>
           {weakest && strongest && weakest.axis !== strongest.axis && (
             <div style={{ marginTop: 'var(--s-3)', padding: '12px', background: 'var(--bg-page, rgba(0,0,0,.04))', borderRadius: 12 }}>
               <div style={{ fontSize: 13, marginBottom: 4 }}>
-                💪 <b>強み:</b> {axisLabel(strongest.axis).label}（Lv.{strongest.level}）
+                💪 <b>強み:</b> {axisLabel(strongest.axis).label}（{levelLabel(strongest.level)}）
               </div>
               <div style={{ fontSize: 13 }}>
-                📈 <b>伸びしろ:</b> {axisLabel(weakest.axis).label}（Lv.{weakest.level}）
+                📈 <b>伸びしろ:</b> {axisLabel(weakest.axis).label}（{levelLabel(weakest.level)}）
               </div>
             </div>
           )}
@@ -275,53 +265,6 @@ export function DeviationScreen({ onBack, onRetakeTest, onStartLesson }: Deviati
         </div>
         <p style={{ fontSize: 16, lineHeight: 1.7 }}>{rank.comment}</p>
       </div>
-
-      {/* ── おすすめコース ───────────────────────── */}
-      {recommendedCourses.length > 0 && (
-        <section style={{ marginTop: 'var(--s-4)' }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 'var(--s-2)' }}>
-            <SparklesIcon width={18} height={18} />
-            <h2 style={{ fontSize: 20, margin: 0 }}>
-              おすすめコース
-            </h2>
-          </div>
-          <p style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: 'var(--s-3)' }}>
-            診断結果に基づくあなたに最適なコース
-          </p>
-          <div className="stack-sm">
-            {recommendedCourses.map((c, idx) => (
-              <div
-                key={c.id}
-                className="card card-compact"
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 12,
-                  border: idx === 0 ? '1.5px solid var(--brand, #6C8EF5)' : '1px solid var(--border)',
-                  background: idx === 0 ? 'rgba(108,142,245,.06)' : undefined,
-                }}
-              >
-                <div style={{
-                  width: 38, height: 38, borderRadius: 10, flexShrink: 0,
-                  background: 'rgba(108,142,245,.18)',
-                  color: '#6C8EF5',
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  fontWeight: 800, fontSize: 16,
-                }}>{idx + 1}</div>
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-secondary)', marginBottom: 2 }}>
-                    {c.category} · {c.level}
-                  </div>
-                  <div style={{ fontSize: 15, fontWeight: 700, lineHeight: 1.4 }}>{c.title}</div>
-                  <div style={{ fontSize: 12, color: 'var(--text-secondary)', marginTop: 4, lineHeight: 1.5 }}>
-                    {c.description}
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
 
       {/* ── 個別レッスン推薦 ─────────────────────── */}
       {recommendedLessonIds.length > 0 && (

--- a/src/screens/PersonalCourseScreen.tsx
+++ b/src/screens/PersonalCourseScreen.tsx
@@ -1,0 +1,170 @@
+/**
+ * PersonalCourseScreen
+ * 実力診断結果から自動生成された「あなた専用パーソナルコース」を表示。
+ * 「コースを進める」で先頭の未完了レッスンへ、「終了する」でホームへ戻る。
+ */
+import { loadPersonalCourse, axisLabel, levelLabel } from '../placementData'
+import { getAllLessonsFlat, type LessonData } from '../lessonData'
+import { getCompletedLessons } from '../stats'
+import { v3 } from '../styles/tokensV3'
+
+interface PersonalCourseScreenProps {
+  onStartLesson: (lessonId: number) => void
+  onExit: () => void
+  onBack?: () => void
+}
+
+export function PersonalCourseScreen({ onStartLesson, onExit, onBack }: PersonalCourseScreenProps) {
+  const course = loadPersonalCourse()
+  const flat = getAllLessonsFlat()
+  const completed = new Set(getCompletedLessons())
+
+  if (!course) {
+    return (
+      <div style={{ background: v3.color.bg, minHeight: '100vh', display: 'flex', flexDirection: 'column', fontFamily: "'Noto Sans JP', sans-serif", color: v3.color.text }}>
+        <div style={{ padding: 'calc(env(safe-area-inset-top, 44px) + 4px) 20px 14px', display: 'flex', alignItems: 'center', gap: 12 }}>
+          {onBack && (
+            <div onClick={onBack} style={{ width: 36, height: 36, borderRadius: '50%', background: v3.color.card, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={v3.color.accent} strokeWidth="2.5" strokeLinecap="round"><polyline points="15 18 9 12 15 6" /></svg>
+            </div>
+          )}
+          <div style={{ fontSize: 20, fontWeight: 700 }}>パーソナルコース</div>
+        </div>
+        <div style={{ padding: 24, textAlign: 'center', color: v3.color.text2, fontSize: 14, lineHeight: 1.7 }}>
+          まだパーソナルコースが生成されていません。実力診断テストを受けると、あなた専用のコースが自動生成されます。
+        </div>
+      </div>
+    )
+  }
+
+  const lessons = course.lessonIds.map(id => flat[id]).filter((l): l is LessonData => !!l)
+  const completedCount = course.lessonIds.filter(id => completed.has(`lesson-${id}`)).length
+  const firstUndone = lessons.find(l => !completed.has(`lesson-${l.id}`))
+  const allDone = !firstUndone
+  const startId = firstUndone?.id ?? lessons[0]?.id
+
+  return (
+    <div style={{ background: v3.color.bg, minHeight: '100vh', display: 'flex', flexDirection: 'column', fontFamily: "'Noto Sans JP', sans-serif", color: v3.color.text }}>
+      {/* ヘッダー */}
+      <div style={{ padding: 'calc(env(safe-area-inset-top, 44px) + 4px) 20px 14px', display: 'flex', alignItems: 'center', gap: 12 }}>
+        {onBack && (
+          <div onClick={onBack} style={{ width: 36, height: 36, borderRadius: '50%', background: v3.color.card, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={v3.color.accent} strokeWidth="2.5" strokeLinecap="round"><polyline points="15 18 9 12 15 6" /></svg>
+          </div>
+        )}
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 12, fontWeight: 800, color: v3.color.accent, letterSpacing: '.08em' }}>YOUR PERSONAL COURSE</div>
+          <div style={{ fontSize: 18, fontWeight: 700, color: v3.color.text, marginTop: 2, lineHeight: 1.35 }}>{course.title}</div>
+        </div>
+      </div>
+
+      <div style={{ flex: 1, padding: '0 16px 32px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+        {/* コース概要カード */}
+        <div style={{ background: v3.color.card, borderRadius: 16, padding: '16px 18px', boxShadow: v3.shadow.card, border: `1.5px solid ${v3.color.accent}30` }}>
+          <div style={{ fontSize: 13, color: v3.color.text2, lineHeight: 1.7, marginBottom: 10 }}>{course.description}</div>
+          {course.axisOrder.length > 0 && (
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 12 }}>
+              {course.axisOrder.slice(0, 3).map((axis, idx) => (
+                <div key={axis} style={{ fontSize: 11, fontWeight: 700, color: idx === 0 ? '#fff' : v3.color.accent, background: idx === 0 ? v3.color.accent : v3.color.accentSoft, borderRadius: 6, padding: '3px 8px' }}>
+                  {idx === 0 ? '優先' : `次点${idx}`}：{axisLabel(axis).label}
+                </div>
+              ))}
+            </div>
+          )}
+          {/* プログレス */}
+          <div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
+              <div style={{ fontSize: 11, color: v3.color.text3 }}>{lessons.length}レッスン構成</div>
+              <div style={{ fontSize: 11, color: v3.color.accent, fontWeight: 600 }}>{completedCount}/{lessons.length} 完了</div>
+            </div>
+            <div style={{ height: 4, background: `${v3.color.text3}22`, borderRadius: 2, overflow: 'hidden' }}>
+              <div style={{ height: '100%', width: `${(completedCount / Math.max(1, lessons.length)) * 100}%`, background: allDone ? '#22C55E' : v3.color.accent, borderRadius: 2, transition: 'width .3s' }} />
+            </div>
+          </div>
+        </div>
+
+        {/* レッスン一覧 */}
+        <div style={{ background: v3.color.card, borderRadius: 16, overflow: 'hidden', boxShadow: v3.shadow.card }}>
+          {lessons.map((lesson, idx) => {
+            const isDone = completed.has(`lesson-${lesson.id}`)
+            const isNext = firstUndone?.id === lesson.id
+            return (
+              <div key={lesson.id} onClick={() => onStartLesson(lesson.id)}
+                style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 16px', cursor: 'pointer', borderTop: idx > 0 ? `1px solid ${v3.color.line}` : 'none', background: isNext ? `${v3.color.accent}08` : 'transparent' }}>
+                <div style={{ width: 28, height: 28, borderRadius: '50%', flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', background: isDone ? v3.color.accent : isNext ? `${v3.color.accent}20` : `${v3.color.text3}18`, border: isNext && !isDone ? `1.5px solid ${v3.color.accent}` : 'none' }}>
+                  {isDone
+                    ? <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="3" strokeLinecap="round"><polyline points="20 6 9 17 4 12"/></svg>
+                    : <span style={{ fontSize: 11, fontWeight: 700, color: isNext ? v3.color.accent : v3.color.text3 }}>{idx + 1}</span>
+                  }
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 14, fontWeight: isNext ? 700 : 600, color: isDone ? v3.color.text2 : v3.color.text, lineHeight: 1.35 }}>{lesson.title}</div>
+                  <div style={{ fontSize: 12, color: v3.color.text3, marginTop: 2 }}>
+                    {lesson.category} · {lesson.steps?.length ?? 0}ステップ
+                  </div>
+                </div>
+                {isNext && !isDone && (
+                  <div style={{ fontSize: 10, fontWeight: 700, color: v3.color.accent, background: v3.color.accentSoft, borderRadius: 6, padding: '3px 8px', flexShrink: 0 }}>次へ</div>
+                )}
+                {!isDone && !isNext && (
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={v3.color.text3} strokeWidth="2" strokeLinecap="round"><polyline points="9 18 15 12 9 6"/></svg>
+                )}
+              </div>
+            )
+          })}
+        </div>
+
+        {/* 「コースを進める」プライマリ */}
+        {startId !== undefined && (
+          <button
+            onClick={() => onStartLesson(startId)}
+            style={{
+              marginTop: 8,
+              width: '100%',
+              background: v3.color.accent,
+              color: '#fff',
+              border: 'none',
+              borderRadius: 14,
+              padding: '14px 0',
+              fontSize: 16,
+              fontWeight: 700,
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 8,
+              fontFamily: 'inherit',
+            }}
+          >
+            {allDone ? 'もう一度進める' : completedCount > 0 ? '続きから進める' : 'コースを進める'}
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </button>
+        )}
+
+        {/* 「終了する」サブ（目立たない） */}
+        <button
+          onClick={onExit}
+          style={{
+            background: 'transparent',
+            color: v3.color.text3,
+            border: 'none',
+            padding: '10px 0',
+            fontSize: 13,
+            fontWeight: 500,
+            cursor: 'pointer',
+            textDecoration: 'underline',
+            fontFamily: 'inherit',
+          }}
+        >
+          終了する
+        </button>
+
+        {course.axisOrder.length > 0 && (
+          <div style={{ marginTop: 4, fontSize: 11, color: v3.color.text3, lineHeight: 1.6, textAlign: 'center' }}>
+            診断で「{axisLabel(course.axisOrder[0]).label}（{levelLabel(1)}〜{levelLabel(3)}）」が伸びしろと判定されました。
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/screens/PlacementTestScreen.tsx
+++ b/src/screens/PlacementTestScreen.tsx
@@ -9,13 +9,15 @@ import {
   rankLabel,
   axisLabel,
   savePlacementResult,
-  skipPlacement,
+  buildPersonalCourse,
+  savePersonalCourse,
+  detailedDiagnosis,
+  levelLabel,
   type PlacementSession,
   type PlacementResult,
 } from '../placementData'
-import { getCourseById } from '../courseData'
-import { getGuestId, getNickname, setNickname, defaultNickname } from '../guestId'
-import { ArrowLeftIcon, ArrowRightIcon, CheckIcon, SparklesIcon } from '../icons'
+import { getGuestId, getNickname, defaultNickname } from '../guestId'
+import { ArrowLeftIcon, ArrowRightIcon } from '../icons'
 import { Button } from '../components/Button'
 import { IconButton } from '../components/IconButton'
 import { RadarChart } from '../components/RadarChart'
@@ -23,9 +25,9 @@ import { API_BASE } from './apiBase'
 import { getXp } from '../stats'
 
 interface PlacementTestScreenProps {
+  /** 「終了する」を押下した直後（パーソナルコース生成完了時）に呼び出される */
   onComplete: () => void
   onBack?: () => void
-  onSkip?: () => void
 }
 
 const TOTAL_QUESTIONS = 10
@@ -40,123 +42,33 @@ async function submitPlacement(deviation: number, correctCount: number, totalCou
   } catch { /* silent */ }
 }
 
-const DIFF_LABEL: Record<'easy' | 'medium' | 'hard', string> = {
-  easy: '基礎',
-  medium: '応用',
-  hard: '発展',
-}
-
-export function PlacementTestScreen({ onComplete, onBack, onSkip }: PlacementTestScreenProps) {
-  const [step, setStep] = useState<'intro' | 'quiz' | 'result'>('intro')
+export function PlacementTestScreen({ onComplete, onBack }: PlacementTestScreenProps) {
+  // 「診断を受ける」をクリック → 即1問目スタートにするためイントロは廃止
+  const [step, setStep] = useState<'quiz' | 'result'>('quiz')
   const [session, setSession] = useState<PlacementSession>(() => startSession())
-  const [selected, setSelected] = useState<number | null>(null)
-  const [answered, setAnswered] = useState(false)
-  const [nicknameInput, setNicknameInput] = useState(getNickname() || defaultNickname(getGuestId()))
   const [result, setResult] = useState<PlacementResult | null>(null)
 
   const currentQ = step === 'quiz' ? getCurrentQuestion(session) : null
   const progress = step === 'quiz' ? (session.cursor / TOTAL_QUESTIONS) * 100 : 0
 
-  const start = () => {
-    setSession(startSession())
-    setStep('quiz')
-    setSelected(null)
-    setAnswered(false)
-  }
-
+  // 選択肢タップ → 即次の問題へ進む（解説・正解表示なし）
   const handleAnswer = (i: number) => {
-    if (answered || !currentQ) return
-    setSelected(i)
-    setAnswered(true)
-  }
-
-  const handleNext = () => {
-    if (!currentQ || selected == null) return
-    const nextSession = recordAnswer(session, currentQ, selected)
+    if (!currentQ) return
+    const nextSession = recordAnswer(session, currentQ, i)
     setSession(nextSession)
-    setSelected(null)
-    setAnswered(false)
     if (nextSession.cursor >= TOTAL_QUESTIONS) {
       const r = buildResultFromSession(nextSession)
       savePlacementResult(r)
-      submitPlacement(r.deviation, r.correctCount, r.totalCount, nicknameInput)
-      setNickname(nicknameInput)
+      const nickname = getNickname() || defaultNickname(getGuestId())
+      submitPlacement(r.deviation, r.correctCount, r.totalCount, nickname)
       setResult(r)
       setStep('result')
     }
   }
 
-  const handleSkip = () => {
-    skipPlacement()
-    onSkip?.()
-    onComplete()
-  }
-
-  // ── Intro ───────────────────────────────────────────
-  if (step === 'intro') {
-    return (
-      <div className="stack">
-        {onBack && (
-          <div className="screen-header">
-            <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
-            <div className="progress-text">実力診断</div>
-          </div>
-        )}
-        <div className="eyebrow accent" style={{ marginTop: onBack ? undefined : 'var(--s-6)' }}>SKILL ASSESSMENT</div>
-        <h1 style={{ fontSize: 32, letterSpacing: '-0.025em', lineHeight: 1.2 }}>実力診断テスト</h1>
-        <p style={{ fontSize: 15, color: 'var(--text-secondary)', lineHeight: 1.7, marginTop: 'var(--s-2)' }}>
-          5つのスキル軸で論理思考力を多角的に診断します。回答に応じて出題内容が変わる適応型テストです。
-        </p>
-
-        <div className="card" style={{ marginTop: 'var(--s-3)' }}>
-          <div className="eyebrow" style={{ marginBottom: 'var(--s-2)' }}>診断概要</div>
-          <ul style={{ fontSize: 15, lineHeight: 1.9, paddingLeft: 'var(--s-4)' }}>
-            <li>問題数: <b>{TOTAL_QUESTIONS} 問</b>（適応出題）</li>
-            <li>所要時間: 約 <b>5 分</b></li>
-            <li>結果: 推定偏差値・5軸レーダーチャート</li>
-            <li>あなたに最適なコースを提案します</li>
-          </ul>
-        </div>
-
-        <div className="card" style={{ marginTop: 'var(--s-3)' }}>
-          <div className="eyebrow" style={{ marginBottom: 'var(--s-2)' }}>診断する5つの軸</div>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: 8, fontSize: 14, lineHeight: 1.5 }}>
-            <AxisRow num="1" title="構造化" desc="MECE / ロジックツリー / ピラミッド" />
-            <AxisRow num="2" title="論証力" desc="演繹 / 帰納 / 対偶 / 形式論理" />
-            <AxisRow num="3" title="批判的思考" desc="バイアス / 因果 / 論理的誤謬" />
-            <AxisRow num="4" title="仮説・課題設定" desc="仮説思考 / イシュー" />
-            <AxisRow num="5" title="ビジネス応用" desc="フェルミ / 数字 / ケース" />
-          </div>
-        </div>
-
-        <div className="card" style={{ marginTop: 'var(--s-3)' }}>
-          <label className="label">ニックネーム（ランキング表示用）</label>
-          <input
-            className="input"
-            type="text"
-            value={nicknameInput}
-            onChange={(e) => setNicknameInput(e.target.value)}
-            maxLength={20}
-            placeholder="ニックネームを入力"
-          />
-        </div>
-
-        <Button variant="primary" size="lg" block onClick={start} style={{ marginTop: 'var(--s-4)' }}>
-          診断を開始する
-          <ArrowRightIcon width={16} height={16} />
-        </Button>
-        {onSkip && (
-          <Button variant="default" size="lg" block onClick={handleSkip}>
-            スキップ
-          </Button>
-        )}
-      </div>
-    )
-  }
-
   // ── Result ──────────────────────────────────────────
   if (step === 'result' && result) {
-    return <ResultView result={result} onContinue={onComplete} onBack={onBack} />
+    return <ResultView result={result} onComplete={onComplete} onBack={onBack} />
   }
 
   // ── Quiz ────────────────────────────────────────────
@@ -168,7 +80,6 @@ export function PlacementTestScreen({ onComplete, onBack, onSkip }: PlacementTes
     )
   }
 
-  const phase = session.plan[session.cursor]?.phase
   return (
     <div className="stack">
       <div className="screen-header">
@@ -178,74 +89,45 @@ export function PlacementTestScreen({ onComplete, onBack, onSkip }: PlacementTes
       <div className="progress">
         <div className="progress-fill" style={{ width: `${progress}%` }} />
       </div>
-      <div className="eyebrow accent" style={{ marginTop: 'var(--s-4)', display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-        <span>{axisLabel(currentQ.axis).label}</span>
-        <span style={{ opacity: 0.6 }}>·</span>
-        <span>{currentQ.topic}</span>
-        <span style={{ opacity: 0.6 }}>·</span>
-        <span>{DIFF_LABEL[currentQ.difficulty]}</span>
-        {phase === 'B' && (
-          <span style={{
-            fontSize: 10, fontWeight: 700, padding: '2px 6px',
-            borderRadius: 999, background: 'rgba(108,142,245,.18)', color: '#6C8EF5',
-          }}>適応出題</span>
-        )}
+      <div className="eyebrow accent" style={{ marginTop: 'var(--s-4)' }}>
+        {axisLabel(currentQ.axis).label}
       </div>
       <h2 style={{ fontSize: 22, lineHeight: 1.55, whiteSpace: 'pre-wrap', fontFamily: 'var(--font-display)' }}>
         {currentQ.question}
       </h2>
       <div className="stack-sm" style={{ marginTop: 'var(--s-3)' }}>
-        {currentQ.options.map((opt, i) => {
-          const isSelected = selected === i
-          const showCorrect = answered && opt.correct
-          const showWrong = answered && isSelected && !opt.correct
-          return (
-            <button
-              key={i}
-              onClick={() => handleAnswer(i)}
-              className="card card-compact"
-              style={{
-                cursor: answered ? 'default' : 'pointer',
-                textAlign: 'left',
-                width: '100%',
-                fontSize: 15,
-                fontWeight: 600,
-                lineHeight: 1.55,
-                color: 'var(--text-primary)',
-                display: 'flex',
-                alignItems: 'center',
-                gap: 'var(--s-3)',
-                borderColor: showCorrect ? 'var(--success)' : showWrong ? 'var(--danger)' : isSelected ? 'var(--brand)' : undefined,
-                background: showCorrect ? 'rgba(16,185,129,0.06)' : showWrong ? 'rgba(220,38,38,0.06)' : isSelected ? 'var(--brand-soft)' : undefined,
-              }}
-            >
-              <span style={{
-                width: 26, height: 26,
-                borderRadius: '999px',
-                border: '1.5px solid currentColor',
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-                fontSize: 14, fontWeight: 700, flexShrink: 0,
-                color: showCorrect ? 'var(--success)' : showWrong ? 'var(--danger)' : isSelected ? 'var(--brand)' : 'var(--text-secondary)',
-              }}>
-                {String.fromCharCode(65 + i)}
-              </span>
-              <span style={{ flex: 1, color: 'var(--text-primary)' }}>{opt.label}</span>
-            </button>
-          )
-        })}
+        {currentQ.options.map((opt, i) => (
+          <button
+            key={`${currentQ.id}-${i}`}
+            onClick={() => handleAnswer(i)}
+            className="card card-compact"
+            style={{
+              cursor: 'pointer',
+              textAlign: 'left',
+              width: '100%',
+              fontSize: 15,
+              fontWeight: 600,
+              lineHeight: 1.55,
+              color: 'var(--text-primary)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--s-3)',
+            }}
+          >
+            <span style={{
+              width: 26, height: 26,
+              borderRadius: '999px',
+              border: '1.5px solid currentColor',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              fontSize: 14, fontWeight: 700, flexShrink: 0,
+              color: 'var(--text-secondary)',
+            }}>
+              {String.fromCharCode(65 + i)}
+            </span>
+            <span style={{ flex: 1, color: 'var(--text-primary)' }}>{opt.label}</span>
+          </button>
+        ))}
       </div>
-      {answered && (
-        <div className="card" style={{ marginTop: 'var(--s-3)', borderLeft: '3px solid var(--brand)' }}>
-          <div className="eyebrow" style={{ marginBottom: 6 }}>解説</div>
-          <p style={{ fontSize: 14, lineHeight: 1.7, margin: 0 }}>{currentQ.explanation}</p>
-        </div>
-      )}
-      {answered && (
-        <Button variant="primary" size="lg" block onClick={handleNext} style={{ marginTop: 'var(--s-4)' }}>
-          {session.cursor + 1 >= TOTAL_QUESTIONS ? '結果を見る' : '次の問題'}
-          <ArrowRightIcon width={16} height={16} />
-        </Button>
-      )}
     </div>
   )
 }
@@ -253,11 +135,11 @@ export function PlacementTestScreen({ onComplete, onBack, onSkip }: PlacementTes
 // ── 結果ビュー ────────────────────────────────────────────
 function ResultView({
   result,
-  onContinue,
+  onComplete,
   onBack,
 }: {
   result: PlacementResult
-  onContinue: () => void
+  onComplete: () => void
   onBack?: () => void
 }) {
   const rank = rankLabel(result.deviation)
@@ -267,17 +149,26 @@ function ResultView({
   const dev = result.deviation || calcDeviation(result.answers)
 
   const radarAxes = useMemo(
-    () => axisScores.map(a => ({ key: a.axis, label: axisLabel(a.axis).short, level: a.level })),
+    () => axisScores.map(a => ({
+      key: a.axis,
+      label: axisLabel(a.axis).short,
+      level: a.level,
+      levelLabel: levelLabel(a.level),
+    })),
     [axisScores],
   )
 
-  const recommendedCourses = result.recommendedCourseIds
-    .map(id => getCourseById(id))
-    .filter((c): c is NonNullable<typeof c> => !!c)
-    .slice(0, 3)
+  const diagnosisLines = useMemo(
+    () => detailedDiagnosis(axisScores, dev),
+    [axisScores, dev],
+  )
 
-  const weakest = [...axisScores].sort((a, b) => a.level - b.level)[0]
-  const strongest = [...axisScores].sort((a, b) => b.level - a.level)[0]
+  // 「終了する」押下 → パーソナルコースを生成・保存し、画面遷移
+  const handleFinish = () => {
+    const personal = buildPersonalCourse(axisScores, dev)
+    savePersonalCourse(personal)
+    onComplete()
+  }
 
   return (
     <div className="stack">
@@ -312,9 +203,9 @@ function ResultView({
         </div>
       </section>
 
-      {/* ── レーダーチャート ─────────────────── */}
+      {/* ── レーダーチャート（言葉ラベル） ─────── */}
       <section className="card" style={{ padding: 'var(--s-4) var(--s-3)' }}>
-        <div className="eyebrow" style={{ marginBottom: 'var(--s-2)' }}>5軸スキルマップ（5段階）</div>
+        <div className="eyebrow" style={{ marginBottom: 'var(--s-2)' }}>5軸スキルマップ</div>
         <RadarChart axes={radarAxes} size={300} maxLevel={5} />
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10, marginTop: 'var(--s-3)' }}>
           {axisScores.map(a => (
@@ -331,104 +222,26 @@ function ResultView({
               }}
             >
               <span style={{ fontSize: 13, fontWeight: 700 }}>{axisLabel(a.axis).label}</span>
-              <span style={{ fontSize: 14, fontWeight: 800, color: '#6C8EF5' }}>Lv.{a.level}</span>
+              <span style={{ fontSize: 13, fontWeight: 800, color: '#6C8EF5' }}>{levelLabel(a.level)}</span>
             </div>
           ))}
         </div>
       </section>
 
-      {/* ── 強み・弱み ───────────────────────── */}
-      {weakest && strongest && weakest.axis !== strongest.axis && (
-        <section className="card">
-          <div className="eyebrow" style={{ marginBottom: 'var(--s-2)' }}>診断コメント</div>
-          <p style={{ fontSize: 15, lineHeight: 1.7, marginBottom: 8 }}>{rank.comment}</p>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 12 }}>
-            <div style={{ fontSize: 14 }}>
-              💪 <b>強み:</b> {axisLabel(strongest.axis).label}（Lv.{strongest.level}）
-            </div>
-            <div style={{ fontSize: 14 }}>
-              📈 <b>伸びしろ:</b> {axisLabel(weakest.axis).label}（Lv.{weakest.level}）
-            </div>
-          </div>
-        </section>
-      )}
-
-      {/* ── おすすめコース ───────────────────── */}
-      {recommendedCourses.length > 0 && (
-        <section>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 'var(--s-2)' }}>
-            <SparklesIcon width={18} height={18} />
-            <h2 style={{ fontSize: 20, margin: 0 }}>あなたへのおすすめコース</h2>
-          </div>
-          <p style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: 'var(--s-3)' }}>
-            診断結果に基づき、今のあなたに最も効果的なコースを選びました。
-          </p>
-          <div className="stack-sm">
-            {recommendedCourses.map((c, idx) => (
-              <div
-                key={c.id}
-                className="card card-compact"
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 12,
-                  border: idx === 0 ? '1.5px solid var(--brand, #6C8EF5)' : '1px solid var(--border)',
-                  background: idx === 0 ? 'rgba(108,142,245,.06)' : undefined,
-                }}
-              >
-                <div style={{
-                  width: 38, height: 38, borderRadius: 10, flexShrink: 0,
-                  background: 'rgba(108,142,245,.18)',
-                  color: '#6C8EF5',
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  fontWeight: 800, fontSize: 16,
-                }}>{idx + 1}</div>
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-secondary)', marginBottom: 2 }}>
-                    {c.category} · {c.level}
-                  </div>
-                  <div style={{ fontSize: 15, fontWeight: 700, lineHeight: 1.4 }}>{c.title}</div>
-                  <div style={{ fontSize: 12, color: 'var(--text-secondary)', marginTop: 4, lineHeight: 1.5 }}>
-                    {c.description}
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
-
-      <div className="feedback-card" style={{ marginTop: 'var(--s-3)' }}>
-        <div className="feedback-head">
-          <div className="feedback-check"><CheckIcon /></div>
-          <div className="feedback-title">診断完了！</div>
+      {/* ── 詳細診断コメント ───────────────────── */}
+      <section className="card">
+        <div className="eyebrow" style={{ marginBottom: 'var(--s-2)' }}>診断コメント</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          {diagnosisLines.map((line, i) => (
+            <p key={i} style={{ fontSize: 14, lineHeight: 1.75, margin: 0 }}>{line}</p>
+          ))}
         </div>
-        <div className="feedback-text">
-          偏差値 {dev} でランキングに登録されました。プロフィールから全国ランキングを確認できます。
-        </div>
-      </div>
+      </section>
 
-      <Button variant="primary" size="lg" block onClick={onContinue} style={{ marginTop: 'var(--s-3)' }}>
-        詳細結果を見る
+      <Button variant="primary" size="lg" block onClick={handleFinish} style={{ marginTop: 'var(--s-3)' }}>
+        終了する
         <ArrowRightIcon width={16} height={16} />
       </Button>
-    </div>
-  )
-}
-
-function AxisRow({ num, title, desc }: { num: string; title: string; desc: string }) {
-  return (
-    <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
-      <div style={{
-        width: 24, height: 24, borderRadius: 6,
-        background: 'rgba(108,142,245,.16)', color: '#6C8EF5',
-        display: 'flex', alignItems: 'center', justifyContent: 'center',
-        fontWeight: 800, fontSize: 12, flexShrink: 0,
-      }}>{num}</div>
-      <div style={{ minWidth: 0 }}>
-        <div style={{ fontWeight: 700 }}>{title}</div>
-        <div style={{ fontSize: 12, color: 'var(--text-secondary)', marginTop: 1 }}>{desc}</div>
-      </div>
     </div>
   )
 }

--- a/src/screens/RoadmapScreenV3.tsx
+++ b/src/screens/RoadmapScreenV3.tsx
@@ -12,6 +12,7 @@ import { getAllLessonsFlat } from '../lessonData'
 import type { LessonData } from '../lessonData'
 import { getCompletedLessons } from '../stats'
 import { getCoursesByCategory, getCoursesByGroup, COURSES, COURSE_GROUPS, type Course } from '../courseData'
+import { loadPersonalCourse, axisLabel } from '../placementData'
 
 const IMG = '/images/v3'
 
@@ -212,6 +213,8 @@ function extractSnippet(text: string, nq: string, ctx = 30): string {
 interface RoadmapScreenV3Props {
   onOpenLesson: (id: number) => void
   onOpenCategory: (cat: string) => void
+  onOpenPersonalCourse?: () => void
+  onOpenPlacementTest?: () => void
   initialCategory?: string
   onBack?: () => void
 }
@@ -296,7 +299,11 @@ export function RoadmapScreenV3(props: RoadmapScreenV3Props) {
           <div style={{ fontSize: 22, fontWeight: 700, lineHeight: 1.45, letterSpacing: '-.005em' }}>今日、どのスキルを<br />鍛える？</div>
         </div>
 
-
+        {/* パーソナルコース（診断結果から自動生成）— 一番上 */}
+        <PersonalCourseBanner
+          onOpenPersonalCourse={props.onOpenPersonalCourse}
+          onOpenPlacementTest={props.onOpenPlacementTest}
+        />
 
         {/* グループ別コース一覧 — 5グループ × 全21コース */}
         {COURSE_GROUPS.map(group => {
@@ -809,4 +816,101 @@ function CategoryDetailView({ category, onOpenLesson, onBack }: { category: stri
   )
 }
 
+// ──────── パーソナルコース誘導バナー（トレーニング画面トップ） ────────
+function PersonalCourseBanner({
+  onOpenPersonalCourse,
+  onOpenPlacementTest,
+}: {
+  onOpenPersonalCourse?: () => void
+  onOpenPlacementTest?: () => void
+}) {
+  const course = loadPersonalCourse()
+  const flat = getAllLessonsFlat()
+  const completed = new Set(getCompletedLessons())
+
+  // 診断未受検 → 「実力診断テスト」誘導カード
+  if (!course) {
+    if (!onOpenPlacementTest) return null
+    return (
+      <div
+        onClick={onOpenPlacementTest}
+        style={{
+          background: v3.color.card,
+          borderRadius: 16,
+          padding: '14px 16px',
+          boxShadow: v3.shadow.card,
+          border: `1.5px dashed ${v3.color.accent}50`,
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+        }}
+      >
+        <div style={{
+          width: 40, height: 40, borderRadius: 12, flexShrink: 0,
+          background: v3.color.accentSoft, color: v3.color.accent,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
+            <circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/>
+          </svg>
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 14, fontWeight: 700, color: v3.color.text }}>あなた専用コースを作成</div>
+          <div style={{ fontSize: 12, color: v3.color.text2, marginTop: 2, lineHeight: 1.5 }}>
+            実力診断（10問・約5分）で弱点を特定し、専用コースを自動生成します。
+          </div>
+        </div>
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={v3.color.text3} strokeWidth="2" strokeLinecap="round"><polyline points="9 18 15 12 9 6"/></svg>
+      </div>
+    )
+  }
+
+  if (!onOpenPersonalCourse) return null
+
+  const lessons = course.lessonIds.map(id => flat[id]).filter((l): l is LessonData => !!l)
+  const completedCount = course.lessonIds.filter(id => completed.has(`lesson-${id}`)).length
+  const total = lessons.length || course.lessonIds.length
+  const allDone = total > 0 && completedCount >= total
+  const weakest = course.axisOrder[0]
+
+  return (
+    <div
+      onClick={onOpenPersonalCourse}
+      style={{
+        background: `linear-gradient(135deg, ${v3.color.accent}f5, ${v3.color.accent}c0)`,
+        borderRadius: 16,
+        padding: '16px 18px',
+        boxShadow: v3.shadow.card,
+        cursor: 'pointer',
+        color: '#fff',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+        <div style={{ fontSize: 10, fontWeight: 800, letterSpacing: '.1em', background: 'rgba(255,255,255,0.18)', padding: '2px 8px', borderRadius: 6 }}>YOUR COURSE</div>
+        {allDone && (
+          <div style={{ fontSize: 10, fontWeight: 800, letterSpacing: '.1em', background: 'rgba(255,255,255,0.22)', padding: '2px 8px', borderRadius: 6 }}>完了</div>
+        )}
+      </div>
+      <div style={{ fontSize: 16, fontWeight: 800, lineHeight: 1.35, marginBottom: 4 }}>{course.title}</div>
+      <div style={{ fontSize: 12, opacity: 0.92, lineHeight: 1.55, marginBottom: 10 }}>
+        {weakest ? `「${axisLabel(weakest).label}」を最優先に` : '弱点を最優先に'} ・ {total}レッスン構成
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <div style={{ flex: 1, height: 4, background: 'rgba(255,255,255,0.25)', borderRadius: 2, overflow: 'hidden' }}>
+          <div style={{ height: '100%', width: `${(completedCount / Math.max(1, total)) * 100}%`, background: '#fff', borderRadius: 2, transition: 'width .3s' }} />
+        </div>
+        <div style={{ fontSize: 12, fontWeight: 700 }}>{completedCount}/{total}</div>
+      </div>
+      <div style={{ marginTop: 10, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ fontSize: 12, fontWeight: 700, opacity: 0.95 }}>
+          {allDone ? 'もう一度進める' : completedCount > 0 ? '続きから進める' : 'コースを進める'}
+        </div>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><polyline points="9 18 15 12 9 6"/></svg>
+      </div>
+    </div>
+  )
+}
 


### PR DESCRIPTION
## Summary

- 「診断を受ける」押下で即1問目が始まる導線へ。5軸説明・ニックネーム入力・スキップを廃止
- 選択肢タップで即次の問題へ自動遷移（解説・正答ハイライトはなし）。Phase B で再レンダーごとに問題が抽選し直される不具合も修正
- 偏差値・5段階レベルを厳しめに調整し、レーダーチャートを「卓越/上級/中級/基礎/入門」の言葉ラベルに変更
- 結果画面から「診断完了！」カードと「あなたへのおすすめコース」を削除。診断コメントを総合評価・強み・伸びしろ・バランス・次の一手の複数行で詳細化
- 「詳細結果を見る」を「終了する」に変更。押下時にユーザー専用パーソナルコース（弱い軸を優先した既存レッスンの組み合わせ）を自動生成・保存
- 新設の `PersonalCourseScreen` で「コースを進める」プライマリ＋下に控えめな「終了する」を併設
- トレーニングメニュー画面の最上部にパーソナルコース誘導カード（未受検時は実力診断テストへの誘導）を追加

## Test plan

- [ ] ホーム/プロフィールから「診断を受ける」をタップ → イントロを経ずに1問目が表示される
- [ ] 各問題で選択肢をタップ → 即次の問題に進む（解説・正答色は出ない）
- [ ] 6問目以降で連打しても問題が変わらない（Phase Bのキャッシュ修正）
- [ ] 10問完了 → 結果画面に偏差値・言葉ラベルのレーダー・詳細コメントが表示される
- [ ] 結果画面に「診断完了！」「あなたへのおすすめコース」が無い
- [ ] 「終了する」押下 → パーソナルコース画面に遷移し、「コースを進める」と控えめな「終了する」が表示される
- [ ] 「コースを進める」で先頭の未完了レッスンが開く
- [ ] トレーニングメニュー最上部にパーソナルコース誘導カードが表示される（未受検時は診断テスト誘導）

https://claude.ai/code/session_0189HcTCtJwxGSwfiX6T3LDM

---
_Generated by [Claude Code](https://claude.ai/code/session_0189HcTCtJwxGSwfiX6T3LDM)_