### PR TITLE
診断結果に「問題の解説を見る」一覧と、終了時のコース生成エフェクトを追加

### DIFF
--- a/src/placementData.ts
+++ b/src/placementData.ts
@@ -31,6 +31,8 @@ export type PlacementAnswer = {
   axis: SkillAxis
   difficulty: Difficulty
   correct: boolean
+  /** ユーザーが選択した選択肢のインデックス（旧データでは undefined） */
+  selectedIndex?: number
 }
 
 export type AxisScore = {
@@ -650,10 +652,15 @@ export function recordAnswer(session: PlacementSession, q: PlacementQuestion, op
   const correct = q.options[optionIndex]?.correct === true
   const next: PlacementSession = {
     ...session,
-    answers: [...session.answers, { questionId: q.id, axis: q.axis, difficulty: q.difficulty, correct }],
+    answers: [...session.answers, { questionId: q.id, axis: q.axis, difficulty: q.difficulty, correct, selectedIndex: optionIndex }],
     cursor: session.cursor + 1,
   }
   return next
+}
+
+// 問題IDから問題定義を取得（解説表示用）
+export function getQuestionById(id: string): PlacementQuestion | undefined {
+  return getQuestionPool().find(q => q.id === id)
 }
 
 // ───────────────────────────────────────────────────────────────

--- a/src/screens/PlacementTestScreen.tsx
+++ b/src/screens/PlacementTestScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   startSession,
   getCurrentQuestion,
@@ -13,11 +13,13 @@ import {
   savePersonalCourse,
   detailedDiagnosis,
   levelLabel,
+  getQuestionById,
   type PlacementSession,
   type PlacementResult,
+  type PlacementAnswer,
 } from '../placementData'
 import { getGuestId, getNickname, defaultNickname } from '../guestId'
-import { ArrowLeftIcon, ArrowRightIcon } from '../icons'
+import { ArrowLeftIcon, ArrowRightIcon, CheckIcon } from '../icons'
 import { Button } from '../components/Button'
 import { IconButton } from '../components/IconButton'
 import { RadarChart } from '../components/RadarChart'
@@ -25,12 +27,17 @@ import { API_BASE } from './apiBase'
 import { getXp } from '../stats'
 
 interface PlacementTestScreenProps {
-  /** 「終了する」を押下した直後（パーソナルコース生成完了時）に呼び出される */
+  /** 「終了する」を押下し、パーソナルコース生成完了時に呼び出される */
   onComplete: () => void
   onBack?: () => void
 }
 
 const TOTAL_QUESTIONS = 10
+const DIFF_LABEL: Record<'easy' | 'medium' | 'hard', string> = {
+  easy: '基礎',
+  medium: '応用',
+  hard: '発展',
+}
 
 async function submitPlacement(deviation: number, correctCount: number, totalCount: number, nickname: string) {
   try {
@@ -42,9 +49,11 @@ async function submitPlacement(deviation: number, correctCount: number, totalCou
   } catch { /* silent */ }
 }
 
+type Step = 'quiz' | 'result' | 'review' | 'creating' | 'created'
+
 export function PlacementTestScreen({ onComplete, onBack }: PlacementTestScreenProps) {
   // 「診断を受ける」をクリック → 即1問目スタートにするためイントロは廃止
-  const [step, setStep] = useState<'quiz' | 'result'>('quiz')
+  const [step, setStep] = useState<Step>('quiz')
   const [session, setSession] = useState<PlacementSession>(() => startSession())
   const [result, setResult] = useState<PlacementResult | null>(null)
 
@@ -66,9 +75,36 @@ export function PlacementTestScreen({ onComplete, onBack }: PlacementTestScreenP
     }
   }
 
+  // ── Loading: パーソナルコース作成中 ──────────────────
+  if (step === 'creating' && result) {
+    return (
+      <CreatingView
+        result={result}
+        onSaved={() => setStep('created')}
+      />
+    )
+  }
+
+  // ── Created: 作成完了！ ─────────────────────────────
+  if (step === 'created') {
+    return <CreatedView onContinue={onComplete} />
+  }
+
+  // ── Review: 全問題と解説の一覧 ──────────────────────
+  if (step === 'review' && result) {
+    return <ReviewView result={result} onBack={() => setStep('result')} />
+  }
+
   // ── Result ──────────────────────────────────────────
   if (step === 'result' && result) {
-    return <ResultView result={result} onComplete={onComplete} onBack={onBack} />
+    return (
+      <ResultView
+        result={result}
+        onShowReview={() => setStep('review')}
+        onFinish={() => setStep('creating')}
+        onBack={onBack}
+      />
+    )
   }
 
   // ── Quiz ────────────────────────────────────────────
@@ -135,11 +171,13 @@ export function PlacementTestScreen({ onComplete, onBack }: PlacementTestScreenP
 // ── 結果ビュー ────────────────────────────────────────────
 function ResultView({
   result,
-  onComplete,
+  onShowReview,
+  onFinish,
   onBack,
 }: {
   result: PlacementResult
-  onComplete: () => void
+  onShowReview: () => void
+  onFinish: () => void
   onBack?: () => void
 }) {
   const rank = rankLabel(result.deviation)
@@ -162,13 +200,6 @@ function ResultView({
     () => detailedDiagnosis(axisScores, dev),
     [axisScores, dev],
   )
-
-  // 「終了する」押下 → パーソナルコースを生成・保存し、画面遷移
-  const handleFinish = () => {
-    const personal = buildPersonalCourse(axisScores, dev)
-    savePersonalCourse(personal)
-    onComplete()
-  }
 
   return (
     <div className="stack">
@@ -238,10 +269,217 @@ function ResultView({
         </div>
       </section>
 
-      <Button variant="primary" size="lg" block onClick={handleFinish} style={{ marginTop: 'var(--s-3)' }}>
+      {/* ── 問題の解説を見る ───────────────────── */}
+      <Button variant="default" size="lg" block onClick={onShowReview} style={{ marginTop: 'var(--s-2)' }}>
+        問題の解説を見る
+        <ArrowRightIcon width={16} height={16} />
+      </Button>
+
+      <Button variant="primary" size="lg" block onClick={onFinish} style={{ marginTop: 'var(--s-2)' }}>
         終了する
         <ArrowRightIcon width={16} height={16} />
       </Button>
+    </div>
+  )
+}
+
+// ── 全問題の解説一覧 ─────────────────────────────────────
+function ReviewView({ result, onBack }: { result: PlacementResult; onBack: () => void }) {
+  const answers = result.answers
+  return (
+    <div className="stack">
+      <div className="screen-header">
+        <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
+        <div className="progress-text">問題の解説</div>
+      </div>
+
+      <div className="eyebrow accent">REVIEW</div>
+      <h1 style={{ fontSize: 24, letterSpacing: '-0.025em' }}>全{answers.length}問の回答と解説</h1>
+      <p style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.6, marginTop: 'var(--s-1)' }}>
+        各問題の正答・あなたの回答・解説を確認できます。
+      </p>
+
+      <div className="stack-sm" style={{ marginTop: 'var(--s-3)' }}>
+        {answers.map((ans, idx) => (
+          <ReviewItem key={`${ans.questionId}-${idx}`} index={idx} ans={ans} />
+        ))}
+      </div>
+
+      <Button variant="default" size="lg" block onClick={onBack} style={{ marginTop: 'var(--s-4)' }}>
+        診断結果に戻る
+      </Button>
+    </div>
+  )
+}
+
+function ReviewItem({ index, ans }: { index: number; ans: PlacementAnswer }) {
+  const q = getQuestionById(ans.questionId)
+  if (!q) return null
+  const correctIdx = q.options.findIndex(o => o.correct)
+  const userIdx = typeof ans.selectedIndex === 'number' ? ans.selectedIndex : -1
+
+  return (
+    <section className="card" style={{ padding: 'var(--s-3) var(--s-3)' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8, flexWrap: 'wrap' }}>
+        <div style={{
+          fontSize: 11, fontWeight: 800,
+          color: ans.correct ? '#10B981' : '#DC2626',
+          background: ans.correct ? 'rgba(16,185,129,.12)' : 'rgba(220,38,38,.12)',
+          padding: '3px 8px', borderRadius: 6,
+        }}>
+          Q{index + 1} · {ans.correct ? '正解' : '不正解'}
+        </div>
+        <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-secondary)', background: 'rgba(108,142,245,.12)', padding: '3px 8px', borderRadius: 6 }}>
+          {axisLabel(q.axis).label}
+        </div>
+        <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-secondary)', background: 'var(--bg-card-soft, rgba(0,0,0,0.04))', padding: '3px 8px', borderRadius: 6 }}>
+          {DIFF_LABEL[q.difficulty]} · {q.topic}
+        </div>
+      </div>
+
+      <h3 style={{ fontSize: 15, lineHeight: 1.55, margin: '0 0 10px', whiteSpace: 'pre-wrap', fontWeight: 700 }}>
+        {q.question}
+      </h3>
+
+      <div className="stack-sm" style={{ marginBottom: 10 }}>
+        {q.options.map((opt, i) => {
+          const isUser = i === userIdx
+          const isCorrect = i === correctIdx
+          const bg = isCorrect
+            ? 'rgba(16,185,129,0.08)'
+            : isUser
+              ? 'rgba(220,38,38,0.06)'
+              : undefined
+          const borderColor = isCorrect
+            ? 'var(--success, #10B981)'
+            : isUser
+              ? 'var(--danger, #DC2626)'
+              : 'var(--border, rgba(0,0,0,0.08))'
+          return (
+            <div
+              key={i}
+              style={{
+                display: 'flex', alignItems: 'flex-start', gap: 10,
+                padding: '8px 10px',
+                borderRadius: 10,
+                background: bg,
+                border: `1px solid ${borderColor}`,
+                fontSize: 13, lineHeight: 1.55,
+              }}
+            >
+              <span style={{
+                width: 22, height: 22, borderRadius: 999, flexShrink: 0,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                fontSize: 11, fontWeight: 700,
+                background: isCorrect ? '#10B981' : isUser ? '#DC2626' : 'transparent',
+                color: isCorrect || isUser ? '#fff' : 'var(--text-secondary)',
+                border: isCorrect || isUser ? 'none' : '1.2px solid var(--text-muted, rgba(0,0,0,0.2))',
+              }}>
+                {String.fromCharCode(65 + i)}
+              </span>
+              <span style={{ flex: 1 }}>{opt.label}</span>
+              <span style={{ flexShrink: 0, fontSize: 10, fontWeight: 800, alignSelf: 'center' }}>
+                {isCorrect && <span style={{ color: '#10B981' }}>正答</span>}
+                {!isCorrect && isUser && <span style={{ color: '#DC2626' }}>あなた</span>}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+
+      <div style={{
+        background: 'rgba(108,142,245,.06)',
+        borderLeft: '3px solid var(--brand, #6C8EF5)',
+        borderRadius: 8,
+        padding: '10px 12px',
+      }}>
+        <div className="eyebrow" style={{ marginBottom: 4, color: 'var(--brand, #6C8EF5)' }}>解説</div>
+        <p style={{ fontSize: 13, lineHeight: 1.7, margin: 0 }}>{q.explanation}</p>
+      </div>
+    </section>
+  )
+}
+
+// ── パーソナルコース生成中ローディング ───────────────────
+function CreatingView({ result, onSaved }: { result: PlacementResult; onSaved: () => void }) {
+  useEffect(() => {
+    // 体感のため最低でも 1.6 秒は表示
+    const start = Date.now()
+    const axisScores = result.axisScores.length ? result.axisScores : computeAxisScores(result.answers)
+    const dev = result.deviation || calcDeviation(result.answers)
+    const personal = buildPersonalCourse(axisScores, dev)
+    savePersonalCourse(personal)
+    const elapsed = Date.now() - start
+    const remaining = Math.max(0, 1600 - elapsed)
+    const t = setTimeout(onSaved, remaining)
+    return () => clearTimeout(t)
+  }, [result, onSaved])
+
+  return (
+    <div className="stack" style={{ minHeight: 'calc(100dvh - 80px)', justifyContent: 'center', alignItems: 'center', padding: 'var(--s-6) var(--s-4)' }}>
+      <div className="placement-spinner" style={{ marginBottom: 24 }} />
+      <h2 style={{ fontSize: 20, fontWeight: 800, textAlign: 'center', letterSpacing: '-0.01em', margin: 0 }}>
+        あなた専用のコースを作成しています
+      </h2>
+      <p style={{ fontSize: 13, color: 'var(--text-secondary)', textAlign: 'center', marginTop: 10, lineHeight: 1.7 }}>
+        診断結果から最適なレッスンを選定中…<br />
+        弱点を優先したカリキュラムを構成しています。
+      </p>
+      <style>{`
+        .placement-spinner {
+          width: 56px;
+          height: 56px;
+          border-radius: 50%;
+          border: 4px solid rgba(108,142,245,0.18);
+          border-top-color: #6C8EF5;
+          animation: placement-spin 0.85s linear infinite;
+        }
+        @keyframes placement-spin {
+          to { transform: rotate(360deg); }
+        }
+      `}</style>
+    </div>
+  )
+}
+
+// ── 「作成しました！」サクセス画面 ──────────────────────
+function CreatedView({ onContinue }: { onContinue: () => void }) {
+  useEffect(() => {
+    const t = setTimeout(onContinue, 1100)
+    return () => clearTimeout(t)
+  }, [onContinue])
+
+  return (
+    <div className="stack" style={{ minHeight: 'calc(100dvh - 80px)', justifyContent: 'center', alignItems: 'center', padding: 'var(--s-6) var(--s-4)' }}>
+      <div className="placement-success-check" style={{ marginBottom: 22 }}>
+        <CheckIcon width={36} height={36} />
+      </div>
+      <h2 style={{ fontSize: 24, fontWeight: 800, textAlign: 'center', letterSpacing: '-0.01em', margin: 0 }}>
+        作成しました！
+      </h2>
+      <p style={{ fontSize: 14, color: 'var(--text-secondary)', textAlign: 'center', marginTop: 10, lineHeight: 1.7 }}>
+        あなた専用のパーソナルコースが完成しました。<br />
+        早速はじめましょう。
+      </p>
+      <style>{`
+        .placement-success-check {
+          width: 80px;
+          height: 80px;
+          border-radius: 50%;
+          background: linear-gradient(135deg, #10B981, #059669);
+          color: #fff;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          box-shadow: 0 12px 30px rgba(16,185,129,0.32);
+          animation: placement-pop 0.45s cubic-bezier(.18,.89,.32,1.28) both;
+        }
+        @keyframes placement-pop {
+          0% { transform: scale(0.4); opacity: 0; }
+          70% { transform: scale(1.08); opacity: 1; }
+          100% { transform: scale(1); opacity: 1; }
+        }
+      `}</style>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- 診断結果ページに **「問題の解説を見る」** ボタンを追加。タップで全10問の正答・自分の回答・解説を一覧表示するレビューページへ遷移
- `PlacementAnswer` に `selectedIndex` を追加し、ユーザーが選んだ選択肢を後から復元できるようにする（旧データは optional 扱い）
- **「終了する」押下後のエフェクト**を追加：
  1. ローディング画面「あなた専用のコースを作成しています」（スピナー、最低1.6秒）
  2. サクセス画面「作成しました！」（チェックマークがポップアップアニメ）
  3. パーソナルコース画面へ自動遷移

## Test plan

- [ ] 診断完了 → 結果画面に「問題の解説を見る」ボタンが表示
- [ ] タップ → 全10問のカードが並び、各問題で正答・自分の回答・解説が確認できる
- [ ] 不正解の問題は「あなた」マーカーが赤、正解の選択肢は緑で表示される
- [ ] 「診断結果に戻る」で結果画面に戻る
- [ ] 「終了する」タップ → スピナー画面 → 「作成しました！」 → パーソナルコース画面の順で遷移
- [ ] 各遷移に違和感のないアニメーションが効いている

https://claude.ai/code/session_0189HcTCtJwxGSwfiX6T3LDM

---
_Generated by [Claude Code](https://claude.ai/code/session_0189HcTCtJwxGSwfiX6T3LDM)_