### PR TITLE
診断のコース生成中ローディングを2.5秒に延長

### DIFF
--- a/src/screens/PlacementTestScreen.tsx
+++ b/src/screens/PlacementTestScreen.tsx
@@ -410,7 +410,7 @@ function CreatingView({ result, onSaved }: { result: PlacementResult; onSaved: (
     const personal = buildPersonalCourse(axisScores, dev)
     savePersonalCourse(personal)
     const elapsed = Date.now() - start
-    const remaining = Math.max(0, 1600 - elapsed)
+    const remaining = Math.max(0, 2500 - elapsed)
     const t = setTimeout(onSaved, remaining)
     return () => clearTimeout(t)
   }, [result, onSaved])


### PR DESCRIPTION
## Summary

- 「終了する」押下後の「あなた専用のコースを作成しています」ローディング表示時間を 1.6 秒 → 2.5 秒 に延長
- 生成エフェクトをしっかり見せるためのUI調整

https://claude.ai/code/session_0189HcTCtJwxGSwfiX6T3LDM

---
_Generated by [Claude Code](https://claude.ai/code/session_0189HcTCtJwxGSwfiX6T3LDM)_