### PR TITLE
Phase 2 83%: 15画面の Header 統一

### DIFF
--- a/docs/HIG_MATERIAL_AUDIT_20260504.md
+++ b/docs/HIG_MATERIAL_AUDIT_20260504.md
@@ -14,7 +14,7 @@
 |---|---|---|---|
 | **Phase 0** リリースブロッカー | 8h | ~7h 相当 | ✅ ほぼ完了（PR #73） |
 | **Phase 1** デザインシステム土台 | 32h | ~24h 相当 | ✅ ほぼ完了（PR #73） |
-| **Phase 2** 全画面 HIG/M3 適合 | 60h | ~42h 相当 | 🟡 70%（5画面 Header 統一、5旧画面削除、12画面 触覚、Switch、ローディング、ブランド色 第2 sweep） |
+| **Phase 2** 全画面 HIG/M3 適合 | 60h | ~50h 相当 | 🟡 83%（15画面 Header 統一、5旧画面削除、12画面 触覚、Switch、ローディング、ブランド色 sweep） |
 | **Phase 3** 個別最適化 | 80h | 0h | ⚪ 未着手（次セッション以降） |
 | **Phase 4** 仕上げ・検証 | 24h | ~3h 相当（build/lint/cap sync 通過） | 🟡 自動チェックのみ |
 
@@ -81,8 +81,11 @@
   - WorksheetScreen `handleSubmit` → `haptic.light()`
   - FeedbackScreen `handleSubmit` → `haptic.light()`
 
-- ✅ Header コンポーネント統一 (5 画面)
-  - LanguageScreen, RankScreen, StreakScreen, CompletedLessonsScreen, StudyTimeScreen
+- ✅ Header コンポーネント統一 (15 画面累計)
+  - LanguageScreen, RankScreen, StreakScreen, CompletedLessonsScreen, StudyTimeScreen,
+    FlashcardsScreen, SettingsScreen, RoleplayChatScreen, FeedbackScreen, JournalInputScreen,
+    ReportProblemScreen, AIProblemScreen, DailyFermiScreen, DailyProblemScreen, DeviationScreen,
+    WorksheetScreen, FermiScreen (Mobile/Desktop), PlacementTestScreen
   - `screen-header` div + IconButton+ArrowLeftIcon パターン → `<Header title onBack>` に
 - ✅ 旧画面削除 (5 ファイル, ~1700 行削減)
   - `RoadmapScreen.tsx` / `ProfileScreen.tsx` / `StatsScreen.tsx` / `PricingV3.tsx` / `ThemeSettingsScreen.tsx`
@@ -92,7 +95,7 @@
   - `'#F87171'` / `'#FCA5A5'` / `'#DC2626'` (red) → `'var(--md-sys-color-error)'`
 
 ### Phase 2 残（次セッション以降）
-- 残 30 画面の Header 統一
+- 残 ~15 画面の Header 統一（V3画面のカスタムヘッダー含む）
 - 全 px → rem 化 (font-size 275 件)
 - ハードコード色値 残 500+ 件の CSS 変数化（カテゴリ色は意図的に残す）
 - 既存 `<select>` を `<ActionSheet>` 系に置換

--- a/src/screens/AIProblemScreen.tsx
+++ b/src/screens/AIProblemScreen.tsx
@@ -2,10 +2,10 @@ import { useState } from 'react'
 import type { AIProblemSet } from '../aiProblemStore'
 import type { QuizStep } from '../lessonData'
 import { recordCompletion } from '../stats'
-import { ArrowLeftIcon, ArrowRightIcon, CheckIcon, XIcon } from '../icons'
+import { ArrowRightIcon, CheckIcon, XIcon } from '../icons'
 import { Button } from '../components/Button'
 import { haptic } from '../platform/haptics'
-import { IconButton } from '../components/IconButton'
+import { Header } from '../components/platform/Header'
 import { t } from '../i18n'
 
 interface AIProblemScreenProps {
@@ -52,10 +52,7 @@ export function AIProblemScreen({ problem, onBack, onReport }: AIProblemScreenPr
     const pct = steps.length > 0 ? Math.round((correctCount / steps.length) * 100) : 0
     return (
       <div className="stack">
-        <div className="screen-header">
-          <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
-          <div className="progress-text">結果</div>
-        </div>
+        <Header title="結果" onBack={onBack} />
         <div className="eyebrow accent">AI 問題の結果</div>
         <h1 style={{ fontSize: 30, letterSpacing: '-0.025em' }}>{problem.title}</h1>
         <section className="profile-hero" style={{ textAlign: 'center' }}>
@@ -81,9 +78,7 @@ export function AIProblemScreen({ problem, onBack, onReport }: AIProblemScreenPr
   if (!step) {
     return (
       <div className="stack">
-        <div className="screen-header">
-          <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
-        </div>
+        <Header onBack={onBack} />
         <div className="card">問題が見つかりません</div>
       </div>
     )
@@ -91,10 +86,7 @@ export function AIProblemScreen({ problem, onBack, onReport }: AIProblemScreenPr
 
   return (
     <div className="stack">
-      <div className="screen-header">
-        <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
-        <div className="progress-text"><b>{stepIdx + 1}</b> / {steps.length}</div>
-      </div>
+      <Header title={`${stepIdx + 1} / ${steps.length}`} onBack={onBack} />
 
       <div className="progress">
         <div className="progress-fill" style={{ width: `${progress}%` }} />

--- a/src/screens/DailyFermiScreen.tsx
+++ b/src/screens/DailyFermiScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react'
-import { ArrowLeftIcon, LightbulbIcon, BarChartIcon, MicIcon } from '../icons'
-import { IconButton } from '../components/IconButton'
+import { LightbulbIcon, BarChartIcon, MicIcon } from '../icons'
+import { Header } from '../components/platform/Header'
 import { Button } from '../components/Button'
 import { API_BASE } from './apiBase'
 import { getDailyFermi, getDailyFermiIndex, FERMI_POOL, getDailyFermiStats } from '../fermiData'
@@ -387,12 +387,7 @@ export function DailyFermiScreen({ onBack, onReport }: DailyFermiScreenProps) {
         />
       )}
 
-      <div className="screen-header">
-        <IconButton aria-label={t('common.back')} onClick={onBack}>
-          <ArrowLeftIcon />
-        </IconButton>
-        <div className="progress-text">{t('dailyFermi.title')}</div>
-      </div>
+      <Header title={t('dailyFermi.title')} onBack={onBack} />
 
       <div className="eyebrow accent">デイリーフェルミ</div>
       <h1 style={{ fontSize: 26, fontWeight: 800, letterSpacing: '-0.02em', lineHeight: 1.3 }}>

--- a/src/screens/DailyProblemScreen.tsx
+++ b/src/screens/DailyProblemScreen.tsx
@@ -3,9 +3,9 @@ import { generateTodayProblem, isDailyCompleted, markDailyCompleted } from '../d
 import type { AIProblemSet } from '../aiProblemStore'
 import type { QuizStep } from '../lessonData'
 import { recordCompletion } from '../stats'
-import { ArrowLeftIcon, ArrowRightIcon, CheckIcon, XIcon } from '../icons'
+import { ArrowRightIcon, CheckIcon, XIcon } from '../icons'
 import { Button } from '../components/Button'
-import { IconButton } from '../components/IconButton'
+import { Header } from '../components/platform/Header'
 import { haptic } from '../platform/haptics'
 import { t } from '../i18n'
 
@@ -35,10 +35,7 @@ export function DailyProblemScreen({ onBack }: DailyProblemScreenProps) {
   if (state === 'loading') {
     return (
       <div className="stack">
-        <div className="screen-header">
-          <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
-          <div className="progress-text">今日の問題</div>
-        </div>
+        <Header title="今日の問題" onBack={onBack} />
         <div style={{ textAlign: 'center', padding: 'var(--s-8) 0', color: 'var(--text-muted)' }}>
           <div style={{ fontSize: 16 }}>今日の問題を生成中…</div>
         </div>
@@ -49,10 +46,7 @@ export function DailyProblemScreen({ onBack }: DailyProblemScreenProps) {
   if (state === 'error') {
     return (
       <div className="stack">
-        <div className="screen-header">
-          <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
-          <div className="progress-text">今日の問題</div>
-        </div>
+        <Header title="今日の問題" onBack={onBack} />
         <div className="card" style={{ background: 'rgba(220,38,38,0.06)', borderColor: 'var(--danger)', color: 'var(--danger)' }}>
           {error}
         </div>
@@ -64,10 +58,7 @@ export function DailyProblemScreen({ onBack }: DailyProblemScreenProps) {
   if (state === 'done') {
     return (
       <div className="stack">
-        <div className="screen-header">
-          <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
-          <div className="progress-text">今日の問題</div>
-        </div>
+        <Header title="今日の問題" onBack={onBack} />
         <div className="eyebrow accent">{t('label.todaysChallenge')}</div>
         <h1 style={{ fontSize: 30, letterSpacing: '-0.025em' }}>今日の問題</h1>
         <div className="feedback-card">
@@ -89,10 +80,7 @@ export function DailyProblemScreen({ onBack }: DailyProblemScreenProps) {
     const pct = steps.length > 0 ? Math.round((correctCount / steps.length) * 100) : 0
     return (
       <div className="stack">
-        <div className="screen-header">
-          <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
-          <div className="progress-text">結果</div>
-        </div>
+        <Header title="結果" onBack={onBack} />
         <div className="eyebrow accent">{t('label.todaysResult')}</div>
         <h1 style={{ fontSize: 30, letterSpacing: '-0.025em' }}>結果</h1>
         <section className="profile-hero" style={{ textAlign: 'center' }}>
@@ -138,10 +126,7 @@ export function DailyProblemScreen({ onBack }: DailyProblemScreenProps) {
 
   return (
     <div className="stack">
-      <div className="screen-header">
-        <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
-        <div className="progress-text"><b>{stepIdx + 1}</b> / {steps.length}</div>
-      </div>
+      <Header title={`${stepIdx + 1} / ${steps.length}`} onBack={onBack} />
 
       <div className="progress">
         <div className="progress-fill" style={{ width: `${stepProgress}%` }} />

--- a/src/screens/DeviationScreen.tsx
+++ b/src/screens/DeviationScreen.tsx
@@ -9,9 +9,8 @@ import {
   type AxisScore,
 } from '../placementData'
 import { getAllLessonsFlat } from '../lessonData'
-import { ArrowLeftIcon } from '../icons'
 import { Button } from '../components/Button'
-import { IconButton } from '../components/IconButton'
+import { Header } from '../components/platform/Header'
 import { RadarChart } from '../components/RadarChart'
 
 
@@ -28,12 +27,7 @@ export function DeviationScreen({ onBack, onRetakeTest, onStartLesson }: Deviati
   if (!result || result.totalCount === 0) {
     return (
       <div className="stack">
-        <div className="screen-header">
-          <IconButton aria-label="Back" onClick={onBack}>
-            <ArrowLeftIcon />
-          </IconButton>
-          <div className="progress-text">実力診断</div>
-        </div>
+        <Header title="実力診断" onBack={onBack} />
         <div className="card empty">
           <h3 style={{ fontSize: 20, marginBottom: 'var(--s-2)' }}>
             実力診断テスト未受検
@@ -83,12 +77,7 @@ export function DeviationScreen({ onBack, onRetakeTest, onStartLesson }: Deviati
 
   return (
     <div className="stack">
-      <div className="screen-header">
-        <IconButton aria-label="Back" onClick={onBack}>
-          <ArrowLeftIcon />
-        </IconButton>
-        <div className="progress-text">実力診断</div>
-      </div>
+      <Header title="実力診断" onBack={onBack} />
 
       <div className="eyebrow accent">あなたの結果</div>
 

--- a/src/screens/FeedbackScreen.tsx
+++ b/src/screens/FeedbackScreen.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
-import { ArrowLeftIcon, CheckIcon } from '../icons'
+import { CheckIcon } from '../icons'
 import { Button } from '../components/Button'
-import { IconButton } from '../components/IconButton'
+import { Header } from '../components/platform/Header'
 import { API_BASE } from './apiBase'
 import { getLocale } from '../i18n'
 import { haptic } from '../platform/haptics'
@@ -44,10 +44,7 @@ export function FeedbackScreen({ onBack }: FeedbackScreenProps) {
   if (sent) {
     return (
       <div className="stack">
-        <div className="screen-header">
-          <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
-          <div className="progress-text">フィードバック</div>
-        </div>
+        <Header title="フィードバック" onBack={onBack} />
         <div style={{ marginTop: 40, textAlign: 'center' }}>
           <div style={{
             width: 64, height: 64, borderRadius: '50%',
@@ -71,10 +68,7 @@ export function FeedbackScreen({ onBack }: FeedbackScreenProps) {
 
   return (
     <div className="stack">
-      <div className="screen-header">
-        <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
-        <div className="progress-text">フィードバック</div>
-      </div>
+      <Header title="フィードバック" onBack={onBack} />
 
       <div>
         <div className="eyebrow accent">ベータ版</div>

--- a/src/screens/FermiScreen.tsx
+++ b/src/screens/FermiScreen.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import { recordCompletion } from '../stats'
-import { ArrowLeftIcon, ArrowRightIcon, CheckIcon, LightbulbIcon } from '../icons'
+import { ArrowRightIcon, CheckIcon, LightbulbIcon } from '../icons'
 import { Button } from '../components/Button'
-import { IconButton } from '../components/IconButton'
+import { Header } from '../components/platform/Header'
 import { useIsDesktop } from '../hooks/useMediaQuery'
 import { API_BASE } from './apiBase'
 import { t } from '../i18n'
@@ -149,12 +149,7 @@ function FermiMobile({ onBack, state, onReport }: { onBack: () => void; state: F
 
   return (
     <div className="stack">
-      <div className="screen-header">
-        <IconButton aria-label="Back" onClick={onBack}>
-          <ArrowLeftIcon />
-        </IconButton>
-        <div className="progress-text">{t('label.fermi')}</div>
-      </div>
+      <Header title={t('label.fermi')} onBack={onBack} />
 
       <div className="eyebrow accent">{t('label.fermi')}</div>
       <h1 className="lesson-question">{question.question}</h1>
@@ -205,11 +200,8 @@ function FermiDesktop({ onBack, state, onReport }: { onBack: () => void; state: 
 
   return (
     <div className="lesson-main">
-      <div className="screen-header" style={{ marginBottom: 32 }}>
-        <IconButton aria-label="Back" onClick={onBack}>
-          <ArrowLeftIcon />
-        </IconButton>
-        <div className="progress-text">{t('label.fermi')}</div>
+      <div style={{ marginBottom: 32 }}>
+        <Header title={t('label.fermi')} onBack={onBack} />
       </div>
 
       <div className="progress" style={{ marginBottom: 56 }}>

--- a/src/screens/FlashcardsScreen.tsx
+++ b/src/screens/FlashcardsScreen.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState } from 'react'
 import { getDueCards, getWeakCards, reviewCard, type Flashcard } from '../flashcardData'
-import { ArrowLeftIcon, CheckIcon, SparklesIcon } from '../icons'
+import { CheckIcon, SparklesIcon } from '../icons'
 import { Button } from '../components/Button'
-import { IconButton } from '../components/IconButton'
+import { Header } from '../components/platform/Header'
 import { haptic } from '../platform/haptics'
 import { t } from '../i18n'
 
@@ -33,20 +33,7 @@ export function FlashcardsScreen({ onBack, mode = 'due' }: FlashcardsScreenProps
 
   return (
     <div className="stack">
-      <div className="screen-header">
-        <IconButton aria-label="Back" onClick={onBack}>
-          <ArrowLeftIcon />
-        </IconButton>
-        <div className="progress-text">
-          {done ? (
-            <span className="muted">完了</span>
-          ) : (
-            <>
-              <b>{Math.min(idx + 1, total)}</b> / {total}
-            </>
-          )}
-        </div>
-      </div>
+      <Header title={done ? '完了' : `${Math.min(idx + 1, total)} / ${total}`} onBack={onBack} />
 
       {total > 0 && !done && (
         <div className="progress" style={{ marginBottom: 'var(--s-5)' }}>

--- a/src/screens/JournalInputScreen.tsx
+++ b/src/screens/JournalInputScreen.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
 import { recordCompletion } from '../stats'
-import { ArrowLeftIcon, ArrowRightIcon, CheckIcon, XIcon } from '../icons'
+import { ArrowRightIcon, CheckIcon, XIcon } from '../icons'
 import { Button } from '../components/Button'
-import { IconButton } from '../components/IconButton'
+import { Header } from '../components/platform/Header'
 
 interface JournalInputScreenProps {
   onBack: () => void
@@ -130,10 +130,7 @@ export function JournalInputScreen({ onBack }: JournalInputScreenProps) {
     const passed = pct >= 70
     return (
       <div className="stack">
-        <div className="screen-header">
-          <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
-          <div className="progress-text">結果</div>
-        </div>
+        <Header title="結果" onBack={onBack} />
         <div className="eyebrow accent">ドリル結果</div>
         <h1 style={{ fontSize: 32, letterSpacing: '-0.025em' }}>仕訳ドリル結果</h1>
         <section className="profile-hero" style={{ textAlign: 'center' }}>
@@ -170,10 +167,7 @@ export function JournalInputScreen({ onBack }: JournalInputScreenProps) {
 
   return (
     <div className="stack">
-      <div className="screen-header">
-        <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
-        <div className="progress-text"><b>{current + 1}</b> / {problems.length}</div>
-      </div>
+      <Header title={`${current + 1} / ${problems.length}`} onBack={onBack} />
 
       <div className="progress">
         <div className="progress-fill" style={{ width: `${progress}%` }} />

--- a/src/screens/PlacementTestScreen.tsx
+++ b/src/screens/PlacementTestScreen.tsx
@@ -19,9 +19,9 @@ import {
   type PlacementAnswer,
 } from '../placementData'
 import { getGuestId, getNickname, defaultNickname } from '../guestId'
-import { ArrowLeftIcon, ArrowRightIcon, CheckIcon } from '../icons'
+import { ArrowRightIcon, CheckIcon } from '../icons'
 import { Button } from '../components/Button'
-import { IconButton } from '../components/IconButton'
+import { Header } from '../components/platform/Header'
 import { RadarChart } from '../components/RadarChart'
 import { LoadingIndicator } from '../components/LoadingIndicator'
 import { haptic } from '../platform/haptics'
@@ -121,10 +121,7 @@ export function PlacementTestScreen({ onComplete, onBack }: PlacementTestScreenP
 
   return (
     <div className="stack">
-      <div className="screen-header">
-        {onBack && <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>}
-        <div className="progress-text"><b>{session.cursor + 1}</b> / {TOTAL_QUESTIONS}</div>
-      </div>
+      <Header title={`${session.cursor + 1} / ${TOTAL_QUESTIONS}`} onBack={onBack} />
       <div className="progress">
         <div className="progress-fill" style={{ width: `${progress}%` }} />
       </div>
@@ -206,10 +203,7 @@ function ResultView({
 
   return (
     <div className="stack">
-      <div className="screen-header">
-        {onBack && <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>}
-        <div className="progress-text">診断結果</div>
-      </div>
+      <Header title="診断結果" onBack={onBack} />
 
       <div className="eyebrow accent">SKILL ASSESSMENT</div>
       <h1 style={{ fontSize: 28, letterSpacing: '-0.025em' }}>あなたの実力診断結果</h1>
@@ -291,10 +285,7 @@ function ReviewView({ result, onBack }: { result: PlacementResult; onBack: () =>
   const answers = result.answers
   return (
     <div className="stack">
-      <div className="screen-header">
-        <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
-        <div className="progress-text">問題の解説</div>
-      </div>
+      <Header title="問題の解説" onBack={onBack} />
 
       <div className="eyebrow accent">REVIEW</div>
       <h1 style={{ fontSize: 24, letterSpacing: '-0.025em' }}>全{answers.length}問の回答と解説</h1>

--- a/src/screens/ReportProblemScreen.tsx
+++ b/src/screens/ReportProblemScreen.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
-import { ArrowLeftIcon, CheckIcon } from '../icons'
-import { IconButton } from '../components/IconButton'
+import { CheckIcon } from '../icons'
+import { Header } from '../components/platform/Header'
 import { Button } from '../components/Button'
 import { API_BASE } from './apiBase'
 import { t } from '../i18n'
@@ -61,12 +61,7 @@ export function ReportProblemScreen({ context, onBack }: ReportProblemScreenProp
   if (done) {
     return (
       <div className="stack">
-        <div className="screen-header">
-          <IconButton aria-label={t('common.back')} onClick={onBack}>
-            <ArrowLeftIcon />
-          </IconButton>
-          <div className="progress-text">{t('report.title')}</div>
-        </div>
+        <Header title={t('report.title')} onBack={onBack} />
         <div className="feedback-card" style={{ animation: 'scale-in 0.2s ease-out both' }}>
           <div className="feedback-head">
             <div className="feedback-check"><CheckIcon /></div>
@@ -83,12 +78,7 @@ export function ReportProblemScreen({ context, onBack }: ReportProblemScreenProp
 
   return (
     <div className="stack">
-      <div className="screen-header">
-        <IconButton aria-label={t('common.back')} onClick={onBack}>
-          <ArrowLeftIcon />
-        </IconButton>
-        <div className="progress-text">{t('report.title')}</div>
-      </div>
+      <Header title={t('report.title')} onBack={onBack} />
 
       <div className="eyebrow">{t('report.eyebrow')}</div>
       <h1 style={{ fontSize: 26, fontWeight: 800, letterSpacing: '-0.02em' }}>

--- a/src/screens/RoleplayChatScreen.tsx
+++ b/src/screens/RoleplayChatScreen.tsx
@@ -5,6 +5,7 @@ import { incrementRoleplayUsage } from '../roleplayUsage'
 import { localeBody } from '../i18n'
 import { ArrowLeftIcon, CheckIcon, ThumbsUpIcon, LightbulbIcon } from '../icons'
 import { IconButton } from '../components/IconButton'
+import { Header } from '../components/platform/Header'
 import { haptic } from '../platform/haptics'
 import { API_BASE } from './apiBase'
 import { v3 } from '../styles/tokensV3'
@@ -120,11 +121,7 @@ export function RoleplayChatScreen({ situationId, onBack }: RoleplayChatScreenPr
   if (!situation) {
     return (
       <div className="stack">
-        <div className="screen-header">
-          <IconButton aria-label="Back" onClick={onBack}>
-            <ArrowLeftIcon />
-          </IconButton>
-        </div>
+        <Header onBack={onBack} />
         <div className="card empty">シナリオが見つかりません</div>
       </div>
     )

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useLayoutEffect } from 'react'
-import { ArrowLeftIcon, ChevronRightIcon, SparklesIcon } from '../icons'
-import { IconButton } from '../components/IconButton'
+import { ChevronRightIcon, SparklesIcon } from '../icons'
+import { Header } from '../components/platform/Header'
 import { getLocale, t } from '../i18n'
 import {
   loadReminderPref, saveReminderPref, scheduleDailyReminder,
@@ -123,12 +123,7 @@ export function SettingsScreen({ onBack, onOpenLanguage, onOpenLogin, currentUse
 
   return (
     <div className="stack">
-      <div className="screen-header">
-        <IconButton aria-label={t('common.back')} onClick={onBack}>
-          <ArrowLeftIcon />
-        </IconButton>
-        <div className="progress-text">{t('settings.title')}</div>
-      </div>
+      <Header title={t('settings.title')} onBack={onBack} />
 
       {/* ── アカウント ── */}
       <div style={{ transition: 'background 0.3s', borderRadius: 12, background: highlightSection === 'account' ? 'rgba(59,91,219,0.08)' : 'transparent' }}>

--- a/src/screens/WorksheetScreen.tsx
+++ b/src/screens/WorksheetScreen.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
 import { recordCompletion } from '../stats'
-import { ArrowLeftIcon, ArrowRightIcon, CheckIcon } from '../icons'
+import { ArrowRightIcon, CheckIcon } from '../icons'
 import { Button } from '../components/Button'
-import { IconButton } from '../components/IconButton'
+import { Header } from '../components/platform/Header'
 import { haptic } from '../platform/haptics'
 
 interface WorksheetScreenProps {
@@ -126,10 +126,7 @@ export function WorksheetScreen({ onBack }: WorksheetScreenProps) {
     const pct = totalCells > 0 ? Math.round((correctCells / totalCells) * 100) : 0
     return (
       <div className="stack">
-        <div className="screen-header">
-          <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
-          <div className="progress-text">結果</div>
-        </div>
+        <Header title="結果" onBack={onBack} />
         <div className="eyebrow accent">ドリル結果</div>
         <h1 style={{ fontSize: 32, letterSpacing: '-0.025em' }}>精算表ドリル結果</h1>
         <section className="profile-hero" style={{ textAlign: 'center' }}>
@@ -157,10 +154,7 @@ export function WorksheetScreen({ onBack }: WorksheetScreenProps) {
 
   return (
     <div className="stack">
-      <div className="screen-header">
-        <IconButton aria-label="Back" onClick={onBack}><ArrowLeftIcon /></IconButton>
-        <div className="progress-text"><b>{current + 1}</b> / {problems.length}</div>
-      </div>
+      <Header title={`${current + 1} / ${problems.length}`} onBack={onBack} />
 
       <div className="progress">
         <div className="progress-fill" style={{ width: `${progress}%` }} />


### PR DESCRIPTION
## Summary
設計書 (#72) Phase 2 を 83% まで進める PR。前回 (#75) の続編。10 画面の Header を `<Header>` コンポーネントに統一。

## 変更内容 (14 files / +59 / -161)

### `<Header>` 統一 — 10 画面追加 (累計 15 画面)
今回置換した画面:
- **FlashcardsScreen** (フラッシュカード復習)
- **SettingsScreen** (設定)
- **RoleplayChatScreen** (空状態のみ; メイン画面はカスタムヘッダーで残置)
- **FeedbackScreen** (送信後 / 入力中)
- **JournalInputScreen** (結果 / 入力中)
- **ReportProblemScreen** (送信後 / 入力中)
- **AIProblemScreen** (結果 / エラー / 出題中)
- **DailyFermiScreen** (出題中)
- **DailyProblemScreen** (ローディング / エラー / 完了 / 結果 / 出題中)
- **DeviationScreen** (空状態 / 結果)
- **WorksheetScreen** (結果 / 出題中)
- **FermiScreen** (Mobile / Desktop 両方)
- **PlacementTestScreen** (出題中 / 結果 / 解説)

`screen-header` div + IconButton+ArrowLeftIcon → `<Header title onBack>` に。
プラットフォーム分岐（iOS chevron 細線中央 / Android arrow 太線左寄せ）+ haptic + 44/48dp tap target + safe-area が自動適用される。

## 検証
- ✅ `npm run build` (TypeScript + Vite)
- ✅ `npx cap sync` 10 plugins
- ✅ 不要になった `ArrowLeftIcon` / `IconButton` import を削除

## 残タスク (将来 PR)
- 残 ~15 画面の Header 統一 (V3 画面のカスタムヘッダー含む)
- 全 px → rem 化 (~6h)
- ハードコード色値 残 500+ 件 (~10h)
- iOS リリース直前: PrivacyInfo / StoreKit / Sign in with Apple

https://claude.ai/code/session_01AuRtcLqKpGz2m4LrueCcfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuRtcLqKpGz2m4LrueCcfd)_