### PR TITLE
Phase 2 99%: 残存 #6C8EF5 を M3 var に統一

### DIFF
--- a/src/components/TutorialOverlay.tsx
+++ b/src/components/TutorialOverlay.tsx
@@ -6,7 +6,7 @@ const TUTORIAL_KEY = 'logic-tutorial-done-v2'
 // ── SVGアイコン ──────────────────────────────────────
 const Icons = {
   fermi: (
-    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#6C8EF5" strokeWidth="1.8" strokeLinecap="round">
+    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--md-sys-color-primary)" strokeWidth="1.8" strokeLinecap="round">
       <circle cx="12" cy="12" r="10"/>
       <path d="M12 8v4l3 3"/>
     </svg>
@@ -362,7 +362,7 @@ export function TutorialFAB({ onClick, onHide }: { onClick: () => void; onHide: 
         style={{
           width: 56, height: 56,
           borderRadius: '50%',
-          background: 'linear-gradient(135deg, #6C8EF5, #8B6EF5)',
+          background: 'linear-gradient(135deg, var(--md-sys-color-primary), #8B6EF5)',
           border: 'none',
           boxShadow: '0 6px 20px rgba(168,192,255,0.5)',
           cursor: 'pointer',

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -73,12 +73,12 @@ const SLIDES = [
     accentColor: 'var(--md-sys-color-primary)',
     icon: (
       <svg width="72" height="72" viewBox="0 0 80 80" fill="none">
-        <circle cx="40" cy="40" r="36" stroke="#6C8EF5" strokeWidth="1.5" strokeDasharray="6 4" opacity="0.4"/>
-        <circle cx="40" cy="40" r="24" fill="rgba(168,192,255,0.12)" stroke="#6C8EF5" strokeWidth="1.5"/>
-        <path d="M28 40h8l4-10 4 20 4-10h4" stroke="#6C8EF5" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
-        <circle cx="40" cy="18" r="3" fill="#6C8EF5" opacity="0.8"/>
+        <circle cx="40" cy="40" r="36" stroke="var(--md-sys-color-primary)" strokeWidth="1.5" strokeDasharray="6 4" opacity="0.4"/>
+        <circle cx="40" cy="40" r="24" fill="rgba(168,192,255,0.12)" stroke="var(--md-sys-color-primary)" strokeWidth="1.5"/>
+        <path d="M28 40h8l4-10 4 20 4-10h4" stroke="var(--md-sys-color-primary)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+        <circle cx="40" cy="18" r="3" fill="var(--md-sys-color-primary)" opacity="0.8"/>
         <circle cx="58" cy="28" r="2" fill="#8BA8FF" opacity="0.6"/>
-        <circle cx="62" cy="48" r="2.5" fill="#6C8EF5" opacity="0.5"/>
+        <circle cx="62" cy="48" r="2.5" fill="var(--md-sys-color-primary)" opacity="0.5"/>
         <circle cx="22" cy="56" r="2" fill="#8BA8FF" opacity="0.7"/>
       </svg>
     ),

--- a/src/screens/PlacementTestScreen.tsx
+++ b/src/screens/PlacementTestScreen.tsx
@@ -383,11 +383,11 @@ function ReviewItem({ index, ans }: { index: number; ans: PlacementAnswer }) {
 
       <div style={{
         background: 'rgba(168,192,255,.06)',
-        borderLeft: '3px solid var(--brand, #6C8EF5)',
+        borderLeft: '3px solid var(--brand, #A8C0FF)',
         borderRadius: 8,
         padding: '10px 12px',
       }}>
-        <div className="eyebrow" style={{ marginBottom: 4, color: 'var(--brand, #6C8EF5)' }}>解説</div>
+        <div className="eyebrow" style={{ marginBottom: 4, color: 'var(--brand, #A8C0FF)' }}>解説</div>
         <p style={{ fontSize: 13, lineHeight: 1.7, margin: 0 }}>{q.explanation}</p>
       </div>
     </section>
@@ -425,7 +425,7 @@ function CreatingView({ result, onSaved }: { result: PlacementResult; onSaved: (
           height: 56px;
           border-radius: 50%;
           border: 4px solid rgba(168,192,255,0.18);
-          border-top-color: #6C8EF5;
+          border-top-color: var(--md-sys-color-primary);
           animation: placement-spin 0.85s linear infinite;
         }
         @keyframes placement-spin {

--- a/src/screens/RoadmapScreenV3.tsx
+++ b/src/screens/RoadmapScreenV3.tsx
@@ -117,7 +117,7 @@ const CATEGORY_VISUAL: Record<string, CategoryVisual> = {
     routeKey: '経営戦略',
   },
   'フェルミ推定': {
-    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#6C8EF5" strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/></svg>,
+    icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--md-sys-color-primary)" strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/></svg>,
     iconBg: 'rgba(168,192,255,.14)',
     image: `${IMG}/fermi-card.png`,
     routeKey: 'フェルミ推定',


### PR DESCRIPTION
## Summary
設計書 (#72) Phase 2 を 99% まで進める PR。前回 (#78) の続編。

## 変更内容 (4 files / +11 / -11)

### ハードコード色 sweep round 5 — `#6C8EF5` 完全除去
旧 brand color literal `#6C8EF5` の SVG/CSS-in-JS 残存箇所を `var(--md-sys-color-primary)` に統一:

- **OnboardingScreen.tsx**: スライド SVG の `stroke`/`fill` 5 箇所
- **RoadmapScreenV3.tsx**: フェルミ推定カテゴリアイコン
- **TutorialOverlay.tsx**: グラデーション開始色
- **PlacementTestScreen.tsx**: スピナー `border-top-color` + ローダー fallback

これでコードベースから旧 brand color literal `#6C8EF5` が消滅:
- grep `#6C8EF5` 残存件数 = **0**
- JS文字列 `tokensV3.color.accent` 経由 (= `'#A8C0FF'`) のみ残存

## 検証
- ✅ `npm run build`
- ✅ `npx cap sync` 10 plugins

## 残タスク (今後 PR で扱う)
- 全 px → rem 化 (~6h, font-size 275 件)
- 残ハードコード色値 (カテゴリ色 + その他装飾色 約 200 件)
- index.css の dead patch selectors (130 件)
- iOS 環境構築 + PrivacyInfo / StoreKit / Sign in with Apple

https://claude.ai/code/session_01AuRtcLqKpGz2m4LrueCcfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuRtcLqKpGz2m4LrueCcfd)_