### PR TITLE
Phase 4 続: pre-existing TS lint error 19 件解消

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -38,7 +38,6 @@ test.describe('App shell', () => {
 test.describe('Tab navigation', () => {
   test('Home tab is active by default', async ({ page }) => {
     await goto(page)
-    const homeBtn = page.locator('[data-tab="home"], .tab, .sidebar-nav-item').first()
     // Home screen content visible
     await expect(page.locator('h1')).toBeVisible()
   })
@@ -93,7 +92,7 @@ test.describe('Home screen', () => {
     await expect(page.locator('text=Categories')).toBeVisible()
   })
 
-  test('category tile navigates to lesson', async ({ page, isMobile }) => {
+  test('category tile navigates to lesson', async ({ page, isMobile: _isMobile }) => {
     await goto(page)
     const tile = page.locator('.cat-tile, .cat-card').first()
     await tile.click()
@@ -207,7 +206,7 @@ test.describe('Lesson screen', () => {
     await page.locator('section').filter({ hasText: 'レッスン一覧' }).locator('.cat-tile').first().click()
   })
 
-  test('back button returns to lessons tab', async ({ page, isMobile }) => {
+  test('back button returns to lessons tab', async ({ page, isMobile: _isMobile }) => {
     const backBtn = page.locator('button[aria-label="Back"], button', { hasText: '戻る' }).first()
     if (await backBtn.isVisible()) {
       await backBtn.click()

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,13 @@ export default defineConfig([
       globals: globals.browser,
     },
     rules: {
+      // 「intentionally unused」を示す `_foo` 命名規約を尊重 (Phase 2 で多用)
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      }],
+
       // jsx-a11y curated rules — focus on screen-reader and keyboard a11y.
       // Full recommended set produces too many false positives on existing code;
       // these are the high-signal rules from docs/HIG_MATERIAL_AUDIT_20260504.md §6.

--- a/server/index.ts
+++ b/server/index.ts
@@ -63,9 +63,9 @@ app.set('trust proxy', 1)
 function parseCorsOrigins(raw: string | undefined): string[] {
   const fallback = ['http://localhost:5173']
   if (!raw) return fallback
-  // eslint-disable-next-line no-control-regex
   const cleaned = raw
     .split(',')
+    // eslint-disable-next-line no-control-regex
     .map(s => s.replace(/[\x00-\x1f\x7f"']/g, '').trim())
     .filter(Boolean)
   if (cleaned.length === 0) {

--- a/src/Onboarding.tsx
+++ b/src/Onboarding.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { useState } from 'react'
 import { t } from './i18n'
 import './Onboarding.css'

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { StrictMode, lazy, Suspense } from 'react'
 import { createRoot } from 'react-dom/client'
 import './styles/tokens-m3.css'

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -453,7 +453,7 @@ function HomeDesktop({
   onOpenDeviation,
   onOpenRanking,
   onOpenRoleplay,
-  onOpenFlashcards: _onOpenFlashcards, // eslint-disable-line @typescript-eslint/no-unused-vars
+  onOpenFlashcards: _onOpenFlashcards,
   onOpenAIGen,
   onOpenFeedback,
   data,

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -5,7 +5,6 @@ export function initSentry() {
   // no-op
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function captureException(_err: unknown, _ctx?: Record<string, unknown>) {
   // no-op stub — @sentry/react not installed
 }

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -43,7 +43,7 @@ export async function loginWithGoogle(): Promise<{ user: User | null; error?: st
       if (error) return { user: null, error: error.message }
       return { user: null }
     }
-  } catch (error) {
+  } catch (_error) {
     return { user: null, error: 'ログインに失敗しました' }
   }
 }

--- a/src/tutorial/coachmark.tsx
+++ b/src/tutorial/coachmark.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { useEffect, useState } from 'react'
 import { tutorial } from './tutorialStorage'
 

--- a/src/tutorial/dailyGuide.tsx
+++ b/src/tutorial/dailyGuide.tsx
@@ -4,7 +4,12 @@ import { tutorial } from './tutorialStorage'
 /**
  * 今日の1問（デイリーフェルミ）インラインガイド
  * 初回のみ各要素にパルスアニメ＋ラベルを表示。入力開始で全消え。
+ *
+ * NOTE: コンポーネントと custom hook を同居しているため Fast Refresh
+ * 警告を file 全体で disable する。
  */
+
+/* eslint-disable react-refresh/only-export-components */
 
 const pulseKeyframes = `
 @keyframes tut-pulse {

--- a/src/tutorial/placementCard.tsx
+++ b/src/tutorial/placementCard.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { useState } from 'react'
 import { tutorial } from './tutorialStorage'
 import { v3 } from '../styles/tokensV3'


### PR DESCRIPTION
## Summary
Phase 4 で導入した CI (#80) を long-term green にするための pre-existing lint error 解消 PR。

## 変更内容 (11 files / +21 / -7)

### 1. ESLint 設定強化
`@typescript-eslint/no-unused-vars` に `argsIgnorePattern: '^_'` 等を追加。「intentionally unused」を示す `_foo` 命名規約を尊重するように。

### 2. react-refresh/only-export-components 解消 (5 files)
コンポーネントと hook/helper を同居しているファイルに file-level `eslint-disable` comment を追加:
- `src/Onboarding.tsx`
- `src/main.tsx` (lazy import + side effect の同居)
- `src/tutorial/coachmark.tsx`
- `src/tutorial/dailyGuide.tsx`
- `src/tutorial/placementCard.tsx`

### 3. @typescript-eslint/no-unused-vars 解消
- `e2e/app.spec.ts`: 未使用 `homeBtn` 削除、`isMobile` → `_isMobile`
- `src/supabase.ts`: `catch (error)` → `catch (_error)`

### 4. dead eslint-disable directive 削除
- `src/sentry.ts`: `_err` は新ルールで自動許可されるため不要に
- `src/screens/HomeScreen.tsx`: 同上
- `server/index.ts`: `no-control-regex` の disable comment を対象行 (regex) の直前に移動

## 検証
- ✅ `npm run build` (TypeScript + Vite)
- ✅ `npx cap sync` 10 plugins
- ✅ `npm run lint` **74 → 55 errors (19 件解消)**

## 残タスク
残 55 errors の内訳:
- `@typescript-eslint/no-explicit-any` (~30 件) — 型推論を要する、Phase 3 で画面ごと
- `react-hooks/*` (~17 件) — hook 順序や setState in effect、要検証
- `no-constant-condition` 等 (~8 件) — 個別判断

これらは個別 PR で順次解消する。

https://claude.ai/code/session_01AuRtcLqKpGz2m4LrueCcfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuRtcLqKpGz2m4LrueCcfd)_