### PR TITLE
Phase 4 続: V3 画面の最後の div onClick を button 化

### DIFF
--- a/src/screens/LessonGrid.tsx
+++ b/src/screens/LessonGrid.tsx
@@ -28,9 +28,20 @@ export function LessonGridSection({ onOpenCategory, columns: overrideColumns }: 
   )
 }
 
-function LessonGridCard({ lesson, onOpen }: { lesson: any; onOpen: () => void }) {
+interface LessonInfo {
+  cat: string
+  name: string
+  meta: string
+  progress: number
+  accent: string
+  image: string
+}
+
+function LessonGridCard({ lesson, onOpen }: { lesson: LessonInfo; onOpen: () => void }) {
   return (
-    <div onClick={onOpen} style={{ background: v3.color.cardSoft, borderRadius: v3.radius.card, overflow: 'hidden', cursor: 'pointer', boxShadow: v3.shadow.card }}>
+    <button type="button" onClick={onOpen}
+      aria-label={`${lesson.name.replace('\n', '')}: ${lesson.meta} (${lesson.progress}% 完了)`}
+      style={{ background: v3.color.cardSoft, borderRadius: v3.radius.card, overflow: 'hidden', cursor: 'pointer', boxShadow: v3.shadow.card, border: 'none', color: 'inherit', font: 'inherit', textAlign: 'left', padding: 0, width: '100%' }}>
       <div style={{ height: 100, overflow: 'hidden', background: v3.color.cardSoft }}>
         <img src={lesson.image} alt="" loading="lazy" style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
       </div>
@@ -41,6 +52,6 @@ function LessonGridCard({ lesson, onOpen }: { lesson: any; onOpen: () => void })
           <div style={{ height: '100%', width: `${lesson.progress}%`, background: lesson.accent, borderRadius: 99 }}></div>
         </div>
       </div>
-    </div>
+    </button>
   )
 }

--- a/src/screens/PricingScreen.tsx
+++ b/src/screens/PricingScreen.tsx
@@ -206,10 +206,11 @@ export function PricingScreen({ onBack }: PricingScreenProps) {
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 80px 80px 80px', padding: '12px 16px', borderBottom: `1px solid ${v3.color.line}` }}>
             <div style={{ fontSize: 11, fontWeight: 700, color: v3.color.text3 }}>機能</div>
             {plans.map(plan => (
-              <div key={plan} onClick={() => setActivePlan(plan)}
-                style={{ textAlign: 'center', fontSize: 11, fontWeight: 800, color: activePlan === plan ? PLAN_META[plan].color : v3.color.text3, cursor: 'pointer', letterSpacing: '.06em' }}>
+              <button type="button" key={plan} onClick={() => setActivePlan(plan)}
+                aria-pressed={activePlan === plan}
+                style={{ textAlign: 'center', fontSize: 11, fontWeight: 800, color: activePlan === plan ? PLAN_META[plan].color : v3.color.text3, cursor: 'pointer', letterSpacing: '.06em', background: 'transparent', border: 'none', padding: 4, font: 'inherit' }}>
                 {PLAN_META[plan].en}
-              </div>
+              </button>
             ))}
           </div>
           {/* 機能行 */}

--- a/src/screens/RankingScreen.tsx
+++ b/src/screens/RankingScreen.tsx
@@ -176,9 +176,12 @@ export function RankingScreen({ onTakeTest }: RankingScreenProps) {
           {/* タブ */}
           <div style={{ display: 'flex', background: '#E8EEFF', borderRadius: 10, padding: 3, gap: 3 }}>
             {(['week', 'all'] as const).map((tab) => (
-              <div key={tab} onClick={() => setRankTab(tab)} style={{ flex: 1, textAlign: 'center', padding: 7, fontSize: 14, fontWeight: 700, cursor: 'pointer', borderRadius: 6, background: rankTab === tab ? '#fff' : 'transparent', color: rankTab === tab ? 'var(--md-sys-color-primary)' : '#7A849E', boxShadow: rankTab === tab ? '0 1px 3px rgba(15,21,35,.08)' : 'none', transition: 'all .15s' }}>
+              <button type="button" key={tab} onClick={() => setRankTab(tab)}
+                role="tab"
+                aria-selected={rankTab === tab}
+                style={{ flex: 1, textAlign: 'center', padding: 7, fontSize: 14, fontWeight: 700, cursor: 'pointer', borderRadius: 6, background: rankTab === tab ? '#fff' : 'transparent', color: rankTab === tab ? 'var(--md-sys-color-primary)' : '#7A849E', boxShadow: rankTab === tab ? '0 1px 3px rgba(15,21,35,.08)' : 'none', transition: 'all .15s', border: 'none', font: 'inherit' }}>
                 {tab === 'week' ? '週間' : '全期間'}
-              </div>
+              </button>
             ))}
           </div>
 


### PR DESCRIPTION
## Summary
V3 系画面（AppV3 で実際に表示される画面）の `<div onClick>` を完全除去する PR。

## 変更内容 (3 files / +23 / -8)

### `<div onClick>` → `<button>` 化
- **RankingScreen** (週間/全期間 タブ): `role="tab"` + `aria-selected`
- **PricingScreen** (機能比較表のプラン列見出し): `aria-pressed`
- **LessonGrid** (`LessonGridCard`): `aria-label` 付加 + `lesson` 引数の `any` を `LessonInfo` interface に置換

これで **V3 系画面の `<div onClick>` が完全に消滅**。残る `<div onClick>` は legacy App.tsx 系のみ (HomeScreen 5 件、Profile 等)。

## 検証
- ✅ `npm run build`
- ✅ `npx cap sync`
- ✅ `npm run lint`: warning 144 → 142、error 55 → 54

https://claude.ai/code/session_01AuRtcLqKpGz2m4LrueCcfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuRtcLqKpGz2m4LrueCcfd)_