### PR TITLE
index.css: M3 と矛盾する legacy patch を整理 (brand 色 regression fix)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -478,11 +478,12 @@ h1, h2, h3, h4, h5, h6 {
   color: var(--text-primary);
 }
 
-/* Inline brand-blue solid backgrounds → mint */
+/* M3 移行後: --accent は var(--md-sys-color-primary) の alias。
+   patch を残すと色は同じだが accent-fg を強制してテキスト色が壊れる。
+   on-primary を直接当てたい場合のみ生存。 */
 [style*="background: var(--md-sys-color-primary)"],
 [style*="background:var(--md-sys-color-primary)"] {
-  background: var(--accent) !important;
-  color: var(--accent-fg) !important;
+  color: var(--md-sys-color-on-primary) !important;
 }
 
 /* Light blue page backgrounds (#F0F4FF / #F8FAFF) → bg */
@@ -501,11 +502,11 @@ h1, h2, h3, h4, h5, h6 {
   border-color: var(--border) !important;
 }
 
-/* Brand blue text → mint */
-[style*="color: var(--md-sys-color-primary)"],
-[style*="color:var(--md-sys-color-primary)"],
+/* M3 移行後: var(--md-sys-color-primary) を直接使えば足りるため、
+   無意味な !important 上書き (var(--accent) → 同じ値) は削除。
+   旧 RGB rgb(59, 91, 219) は保険として残す。 */
 [style*="color: rgb(59, 91, 219)"] {
-  color: var(--accent) !important;
+  color: var(--md-sys-color-primary) !important;
 }
 
 /* Dark blue/black text → primary text white
@@ -554,13 +555,8 @@ h1, h2, h3, h4, h5, h6 {
 /* HomeScreen v3 image placeholders fix when inside .card */
 .card img { display: block; }
 
-/* Buttons inline gradient */
-[style*="linear-gradient(135deg, var(--md-sys-color-primary)"],
-[style*="linear-gradient(135deg,var(--md-sys-color-primary)"],
-[style*="linear-gradient(180deg, var(--md-sys-color-primary)"] {
-  background: var(--accent) !important;
-  color: var(--accent-fg) !important;
-}
+/* M3 移行後: M3 primary を含むグラデーションを solid color に潰すと
+   元のデザイン意図 (グラデーション) が失われるため、patch 削除。 */
 
 /* Override brand gradient to Slate Blue */
 .mode-dark, body {
@@ -673,21 +669,11 @@ h1, h2, h3, h4, h5, h6 {
   color: var(--accent-fg) !important;
 }
 
-/* Common indigo/purple gradient buttons → mint */
-[style*="linear-gradient(135deg, #6366F1"],
-[style*="linear-gradient(135deg,#6366F1"],
-[style*="linear-gradient(135deg, #4F46E5"],
-[style*="linear-gradient(135deg, var(--md-sys-color-primary)"],
-[style*="linear-gradient(180deg, var(--md-sys-color-primary)"] {
-  background: linear-gradient(135deg, #70D8BD 0%, #A5E8D5 100%) !important;
-  color: var(--accent-fg) !important;
-}
+/* legacy mint override は M3 brand 移行に矛盾するため削除。
+   旧 #6366F1 / #4F46E5 (indigo) は近代化済みで残存リテラルはほぼ無し。 */
 
-/* Override --accent in mode-dark to Slate Blue (catches any class-based use) */
-.mode-dark {
-  --brand: #6C8EF5 !important;
-  --brand-grad: linear-gradient(135deg, #6C8EF5 0%, #9BB3FA 100%) !important;
-}
+/* `--brand` は tokens-m3.css で var(--md-sys-color-primary) (#A8C0FF) に
+   alias されているため、ここで個別上書きしない (旧 #6C8EF5 を再注入しない) */
 
 /* RGB form catch */
 [style*="background: rgb(59, 91, 219)"],


### PR DESCRIPTION
## Summary
M3 migration と矛盾する `index.css` の legacy patch selectors を整理する重要 PR。色 regression 1 件と循環 alias 2 件を修正。

## 重要 fix: `.mode-dark { --brand: #6C8EF5 !important }` 削除
- `tokens-m3.css` で `--brand: var(--md-sys-color-primary)` (= `#A8C0FF`) と alias
- しかし `.mode-dark { --brand: #6C8EF5 !important }` が dark mode 時に旧色を再注入
- → **dark mode で M3 brand 色が `#6C8EF5` (旧) になる regression** が発生していた
- この override を削除し、M3 alias が正しく resolve するように修正

## 副次的整理
旧 `#6C8EF5` を `var(--md-sys-color-primary)` に sed-replace した結果、いくつかの patch selector が新 var() を捕まえるようになり問題化:

1. **`background: var(--md-sys-color-primary)` patch** — `var(--accent)` (= 同じ値) で再 alias する循環 → 簡素化し on-primary テキスト色強制のみに
2. **`color: var(--md-sys-color-primary)` patch** — 同上の循環 → 削除、旧 RGB のみ残す
3. **M3 primary を含む `linear-gradient` patch (2 ヶ所)** — gradient を solid mint に潰す patch があったため削除（デザイン意図破壊のため）

## 変更量
1 file (index.css) / +14 / **-28** (ネット 14 行削除)

## 検証
- ✅ `npm run build`
- ✅ `npx cap sync` 10 plugins

## 影響
- dark mode の brand 色が **正しい M3 primary `#A8C0FF`** に復帰
- 一部 button/カードのグラデーションが意図通り表示される

https://claude.ai/code/session_01AuRtcLqKpGz2m4LrueCcfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuRtcLqKpGz2m4LrueCcfd)_