### PR TITLE
TS lint error 31 → 28 件 (AppV3 as any 削除)

### DIFF
--- a/src/AppV3.tsx
+++ b/src/AppV3.tsx
@@ -379,7 +379,7 @@ function AppV3() {
           onOpenLesson={handleOpenLesson}
           onOpenCategory={(cat) => {
             if (cat === 'fermi') navigate({ type: 'daily-fermi' })
-            else navigate({ type: 'roadmap', category: cat as any })
+            else navigate({ type: 'roadmap', category: cat })
           }}
           onOpenRank={() => navigate({ type: 'rank' })}
           onOpenStats={() => navigate({ type: 'profile' }, true)}
@@ -396,7 +396,7 @@ function AppV3() {
       {screen.type === 'lessons' && (
         <RoadmapScreenV3
           onOpenLesson={handleOpenLesson}
-          onOpenCategory={(cat) => navigate({ type: 'roadmap', category: cat as any })}
+          onOpenCategory={(cat) => navigate({ type: 'roadmap', category: cat })}
           onOpenPersonalCourse={() => navigate({ type: 'personal-course' })}
           onOpenPlacementTest={() => navigate({ type: 'placement-test' })}
         />
@@ -405,7 +405,7 @@ function AppV3() {
       {screen.type === 'roadmap' && (
         <RoadmapScreenV3
           onOpenLesson={handleOpenLesson}
-          onOpenCategory={(cat) => navigate({ type: 'roadmap', category: cat as any })}
+          onOpenCategory={(cat) => navigate({ type: 'roadmap', category: cat })}
           initialCategory={screen.category}
           onBack={handleBack}
         />


### PR DESCRIPTION
## Summary
`AppV3.tsx` の不要な `as any` キャスト 3 箇所を削除。受け取り側 `onOpenCategory` は `(cat: string) => void`、`Screen.category` も `string` 型なので as any は不要だった。

## 検証
- ✅ `npm run build`
- ✅ `npx cap sync`
- ✅ `npm run lint`: **90 → 87 problems** (errors **31 → 28**, -3 件)

残 28 errors は legacy App.tsx の react-hooks 系 (`Date.now` in `useRef`, `setState` in effect 等) で動作変更を伴うため別 PR 対応とする。

https://claude.ai/code/session_01AuRtcLqKpGz2m4LrueCcfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuRtcLqKpGz2m4LrueCcfd)_