### PR TITLE
TS lint error 28 → 11 件 (-17): V3 画面の React hooks 違反を解消

### DIFF
--- a/src/screens/HomeScreenV3.tsx
+++ b/src/screens/HomeScreenV3.tsx
@@ -3,7 +3,7 @@
  * 仕様: docs/DESIGN_V3.md §3.1
  * モックアップ: lv3-home.html
  */
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import { getDailyFermi } from '../fermiData'
 import { getCardStats } from '../flashcardData'
 import { v3 } from '../styles/tokensV3'
@@ -86,7 +86,7 @@ export function HomeScreenV3(props: HomeScreenV3Props) {
   const isLargeTablet = width >= BREAKPOINTS.lg
 
   // ランダムレッスン・フェルミ問題（マウント時に1回決定）
-  const recommendedLesson = useRef(getRandomLesson()).current
+  const [recommendedLesson] = useState(getRandomLesson)
   const dailyFermi = getDailyFermi()
   const fermiQuestion = dailyFermi.question
   const cardStats = getCardStats()

--- a/src/screens/LessonScreen.tsx
+++ b/src/screens/LessonScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect, useRef } from 'react'
+import { useMemo, useState, useEffect } from 'react'
 import { allLessons, type LessonStep } from '../lessonData'
 import { FlameIcon } from '../icons'
 import { recordCompletion, getCompletedCount, getStreak, getStudyDates, addXp } from '../stats'
@@ -43,7 +43,7 @@ export function LessonScreen({ lessonId, onBack, onComplete, onNextLesson, onRep
   const [animClass, setAnimClass] = useState<'answer-bounce' | 'answer-shake' | ''>('')
   const [showCelebration, setShowCelebration] = useState(false)
   // streak演出用: 完了前後のストリーク差分
-  const streakBefore = useRef(0)
+  const [streakBefore, setStreakBefore] = useState(0)
 
   useEffect(() => {
     if (!animClass) return
@@ -79,7 +79,7 @@ export function LessonScreen({ lessonId, onBack, onComplete, onNextLesson, onRep
 
   const handleNext = () => {
     if (isLast) {
-      streakBefore.current = getStreak()
+      setStreakBefore(getStreak())
       recordCompletion(`lesson-${lesson.id}`)
       addXp('lesson')
       setShowCelebration(true)
@@ -99,7 +99,7 @@ export function LessonScreen({ lessonId, onBack, onComplete, onNextLesson, onRep
     return (
       <CelebrationScreen
         lessonTitle={lesson.title}
-        streakBefore={streakBefore.current}
+        streakBefore={streakBefore}
         onComplete={onComplete}
         onNextLesson={onNextLesson}
       />
@@ -303,7 +303,7 @@ function QuizStep({ step, catLabel, accent, selected, submitted, isLast, onSelec
           let badgeBg = 'transparent'
           let badgeBorder = '#E2E8FF'
           let badgeColor = '#7A849E'
-          let textColor = '#0F1523'
+          const textColor = '#0F1523'
 
           if (submitted && correct) {
             bg = '#ECFDF3'; border = '1.5px solid #12B76A'

--- a/src/screens/LessonStoriesScreen.tsx
+++ b/src/screens/LessonStoriesScreen.tsx
@@ -31,11 +31,14 @@ export function LessonStoriesScreen(props: LessonStoriesScreenProps) {
   const [reportDetail, setReportDetail] = useState('')
 
   // ── タッチガード: スライド遷移後 280ms は全タッチを無視 ──
-  const slideEnteredAt = useRef<number>(Date.now())
+  const slideEnteredAt = useRef<number>(0)
   const isGuarded = () => Date.now() - slideEnteredAt.current < 280
   useEffect(() => {
     slideEnteredAt.current = Date.now()
   }, [index])
+
+  // ===== Swipe 用 touchRef（早期 return より前で確保し Hooks 順を固定） =====
+  const touchRef = useRef<{ x: number; y: number; t: number } | null>(null)
 
   const slides: LessonSlide[] = useMemo(() => {
     if (!lesson) return []
@@ -79,7 +82,6 @@ export function LessonStoriesScreen(props: LessonStoriesScreenProps) {
   }
 
   // ===== Swipe 対応 =====
-  const touchRef = useRef<{ x: number; y: number; t: number } | null>(null)
   const onTouchStart = (e: React.TouchEvent) => {
     const t = e.touches[0]
     touchRef.current = { x: t.clientX, y: t.clientY, t: Date.now() }
@@ -336,15 +338,17 @@ function SlideContent({ slide, quizAnswered, multiSelected, onToggleMulti, onSub
     )
   }
   if (slide.kind === 'concept' || slide.kind === 'intro') {
+    const tag = slide.kind === 'concept' ? slide.tag : slide.tag
+    const example = slide.kind === 'concept' ? slide.example : undefined
     return (
       <>
-        {slide.kind === 'concept' && (slide as any).tag && <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, background: v3.color.accentSoft, borderRadius: 99, padding: '6px 12px', fontSize: 11, fontWeight: 600, color: v3.color.accent, marginBottom: 24, marginTop: 24 }}>{(slide as any).tag}</span>}
-        <h1 style={{ fontFamily: 'Noto Sans JP', fontSize: 28, fontWeight: 700, lineHeight: 1.4, marginBottom: 20, marginTop: (slide as any).tag ? 0 : 32, letterSpacing: '.005em', color: v3.color.text }}>{slide.title}</h1>
+        {slide.kind === 'concept' && tag && <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, background: v3.color.accentSoft, borderRadius: 99, padding: '6px 12px', fontSize: 11, fontWeight: 600, color: v3.color.accent, marginBottom: 24, marginTop: 24 }}>{tag}</span>}
+        <h1 style={{ fontFamily: 'Noto Sans JP', fontSize: 28, fontWeight: 700, lineHeight: 1.4, marginBottom: 20, marginTop: tag ? 0 : 32, letterSpacing: '.005em', color: v3.color.text }}>{slide.title}</h1>
         <p style={{ fontSize: 17, lineHeight: 1.85, fontWeight: 400, color: v3.color.text, marginBottom: 20 }} dangerouslySetInnerHTML={{ __html: slide.body }}></p>
-        {(slide as any).example && (
+        {example && (
           <div style={{ background: v3.color.card, borderRadius: 16, padding: 18 }}>
             <div style={{ fontSize: 11, fontWeight: 700, color: v3.color.accent, letterSpacing: '.08em', marginBottom: 8 }}>EXAMPLE</div>
-            <div style={{ fontSize: 15, lineHeight: 1.6, color: v3.color.text }}>{(slide as any).example}</div>
+            <div style={{ fontSize: 15, lineHeight: 1.6, color: v3.color.text }}>{example}</div>
           </div>
         )}
       </>

--- a/src/screens/PricingScreen.tsx
+++ b/src/screens/PricingScreen.tsx
@@ -99,8 +99,8 @@ export function PricingScreen({ onBack }: PricingScreenProps) {
       : { main: `¥${prePrice.toLocaleString()}`, sub: '/月' }
   }
 
-  // CTAボタン
-  function PlanCTA({ plan }: { plan: PlanKey }) {
+  // CTAボタン: コンポーネント化せずインライン関数で JSX を返す（render 中の component 定義回避）
+  const renderPlanCTA = (plan: PlanKey) => {
     if (plan === 'free') {
       return isCurrentFree
         ? <div style={{ textAlign: 'center', fontSize: 13, color: v3.color.text3, fontWeight: 700, padding: '14px 0' }}>現在のプラン</div>
@@ -196,7 +196,7 @@ export function PricingScreen({ onBack }: PricingScreenProps) {
             <div style={{ fontSize: 12, color: '#FF6B35', fontWeight: 700, marginBottom: 8 }}>キャンペーン適用で ¥1,980 / 年</div>
           )}
           <div style={{ marginTop: 16 }}>
-            <PlanCTA plan={activePlan} />
+            {renderPlanCTA(activePlan)}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
V3 主要画面の React hooks 違反系 lint error を解消。28 → 11 件（-17）。

- **LessonStoriesScreen**
  - `useRef(Date.now())` → `useRef(0)` + `useEffect` 初期化（react-hooks/purity）
  - 早期 return より前で `touchRef` を確保（rules-of-hooks）
  - `(slide as any).tag` / `.example` → 判別共用体ナローイングで型安全に（-5 `any`）
- **LessonScreen**
  - `streakBefore` を `useRef` → `useState` 化（render 中の `.current` 参照を解消）
  - `textColor` `let` → `const`
- **HomeScreenV3**
  - `useRef(getRandomLesson()).current` → `useState(getRandomLesson)` で per-mount 安定値に
- **PricingScreen**
  - render 中の `PlanCTA` コンポーネント定義 → `renderPlanCTA` 関数化（react-hooks/static-components）

## Test plan
- [x] `npm run build` OK
- [x] `npx tsc --noEmit` OK
- [x] `npx eslint src` 28 → 11 errors
- [ ] 残 11 件は legacy 系（`set-state-in-effect` / `purity` / `immutability`）で別 PR 対応

https://claude.ai/code/session_015ePxvxgnGwHoowsFQT8aof

---
_Generated by [Claude Code](https://claude.ai/code/session_015ePxvxgnGwHoowsFQT8aof)_