### PR TITLE
6コース分のサムネイルSVGを追加

### DIFF
--- a/docs/THUMBNAILS_MANIFEST.md
+++ b/docs/THUMBNAILS_MANIFEST.md
@@ -1,0 +1,81 @@
+# コースサムネイル生成マニフェスト
+
+Logicアプリのコース・レッスン用サムネイル画像生成の進捗を記録するマニフェスト。
+
+## 生成済みサムネイル
+
+すべてPixa（Ideogram v3、16:9、1312×736 PNG）で生成。スタイル：シンプル・モダン、内容に沿ったコンセプト。
+
+### Notion DB
+
+「Logic素材」DB: <https://www.notion.so/38555f3f86db4fa0b4aff5d907af5395>
+
+### 完了済み（13コース・17ファイル）
+
+| コースID | コース名 | カテゴリ | Asset ID | ファイル名 |
+|---|---|---|---|---|
+| logic-01 | ロジカルに考えて、整理する | 論理的に考える | asset_6e18deace7b04e0096430058a8abf219 | logic_logic-01_1.png |
+| logic-01 | ロジカルに考えて、整理する | 論理的に考える | asset_497a89a4f9874b1893fc55d3ed581d9b | logic_logic-01_2.png |
+| logic-01 | ロジカルに考えて、整理する | 論理的に考える | asset_b1388f5678ec4dc3a1168aa68e88f392 | logic_logic-01_3.png |
+| logic-01 | ロジカルに考えて、整理する | 論理的に考える | asset_accaed58e9904a8f9a901400ac539f2f | logic_logic-01_4.png |
+| logic-01 | ロジカルに考えて、整理する | 論理的に考える | asset_b7215a8fabd64d488d51f705a9611ce3 | logic_logic-01_5.png |
+| logic-02 | 論理を組み立て、相手を動かす | 論理的に考える | asset_bd6013eb7b2146ed9d29b962337481b2 | logic_logic-02_1.png |
+| critical-01 | 思い込みを疑い、正しく判断する | 論理的に考える | asset_1438749ac21a45f9bf1361911d4b2abf | logic_critical-01_1.png |
+| critical-02 | バイアスを外し、客観的に見る | 論理的に考える | asset_7c20b71d6e6b49db81f01c955fc839d3 | logic_critical-02_1.png |
+| hypothesis-01 | 仮説を立ててから、調べる | 課題を解決する | asset_105a6ae2b3eb405a80774ed50a5d4c30 | logic_hypothesis-01_1.png |
+| problem-01 | 本当の問題を見極め、定義する | 課題を解決する | asset_533cdf99e9534beb8d0b536a4148df20 | logic_problem-01_1.png |
+| design-01 | ユーザーの本音を掘り下げ、解決する | 課題を解決する | asset_59be76ec8dda45ce8caa8a1f6e1efbfa | logic_design-01_1.png |
+| systems-01 | 全体を俯瞰し、根本から変える | 課題を解決する | asset_a500fbd9d76a4086af2d2ff02c359a2f | logic_systems-01_1.png |
+| lateral-01 | 常識を疑い、突破口を開く | 発想を広げる | asset_cbc1fb86472a4049983ac4405017cdac | logic_lateral-01_1.png |
+| analogy-01 | 別分野の知恵を借りて、応用する | 発想を広げる | asset_3f3c9bb7aff2453db7a5ac8e9488c595 | logic_analogy-01_1.png |
+| philosophy-01 | 哲学の問いで、思考を深める | 論理的に考える | asset_de2b5d185d784e129595ad78dce9ed85 | logic_philosophy-01_1.png |
+| eastern-01 | 古代中国思想で、人と組織を見る | 論理的に考える | asset_2759c8368b924c65a9f2ebc6db43df69 | logic_eastern-01_1.png |
+| eastern-02 | 古代中国思想で、戦略と決断を見る | 論理的に考える | asset_06d6acccde944a3eab33ed0c52eec51f | logic_eastern-02_1.png |
+
+合計: 12コース x 1枚 + logic-01 x 5枚 = 17ファイル（消費306クレジット）
+
+## 未生成（10コース）
+
+Pixaクレジット不足により以下が未生成。クレジット追加後に生成予定。
+
+| コースID | コース名 | カテゴリ |
+|---|---|---|
+| proposal-01 | 相手が動く提案をつくる | 相手を動かす |
+| proposal-course-01 | 仮説と検証で、提案書を仕上げる | 相手を動かす |
+| client-01 | 数字で状況を素早く読み解く | 現場で実践する |
+| client-02 | 論点を定め、深く引き出す | 相手を動かす |
+| client-03 | 未経験の業界で、短期間で立ち上がる | 現場で実践する |
+| case-01 | ケース面接で、論理力を証明する | 相手を動かす |
+| strategy-01 | 戦略の源流と競争戦略を学ぶ | 現場で実践する |
+| strategy-02 | 資源・能力・共進化の戦略へ | 現場で実践する |
+| fermi-01 | 概算で、世界の規模を掴む | 現場で実践する |
+| numeracy-01 | 数字に強くなる | 現場で実践する |
+
+## レッスン用画像（未着手）
+
+各レッスンの最初の画像（合計約119レッスン分）。コース全件完了後に着手予定。
+
+## ダウンロード手順
+
+ネットワーク制限（`assets.pixelcut.app`がClaudeのallowlist外）のため、現状はリポジトリに画像ファイルを保存できない。手順：
+
+1. Notion DB「Logic素材」の各レコードの「ダウンロードURL」から画像をダウンロード
+2. `public/images/v3/` に上記「ファイル名」で保存
+3. `src/courseData.ts` の各コース定義に `image: '/images/v3/logic_<id>_1.png'` を追加
+
+または、Claudeのネットワーク許可ホストに `assets.pixelcut.app` と `mcp.pixa.com` を追加すれば、自動でダウンロード・コード反映が可能。
+
+## 生成プロンプトの方針
+
+各コースのテーマ・キーワードを反映。パステル系ソフトカラー、フラットデザイン、テキストなし、16:9。
+
+例：
+- **logic-01**: ロジックツリー / MECE / 整理された脳 / 散らかり→整理 / ピラミッド階層
+- **systems-01**: 氷山モデル + フィードバックループ
+- **eastern-01**: 中国の巻物 + 階層的人物 + 朱と墨
+
+## 関連リソース
+
+- コース定義: `src/courseData.ts`
+- 既存サムネイル: `public/images/v3/course-*.{svg,webp}`
+- Notion DB: 「Logic素材」（38555f3f-86db-4fa0-b4af-f5d907af5395）

--- a/public/images/v3/course-case-01.svg
+++ b/public/images/v3/course-case-01.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-cs1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-cs1" cx="0.5" cy="0.4" r="0.45">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="figure-cs1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3B5BBF"/>
+      <stop offset="100%" stop-color="#1B2954"/>
+    </linearGradient>
+    <linearGradient id="figure-cs1b" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7A2E2E"/>
+      <stop offset="100%" stop-color="#3F1717"/>
+    </linearGradient>
+    <linearGradient id="paper-cs1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F4ECC4"/>
+      <stop offset="100%" stop-color="#D8C898"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-cs1)"/>
+  <circle cx="400" cy="160" r="240" fill="url(#glow-cs1)"/>
+
+  <!-- 机（俯瞰風で大きく） -->
+  <g transform="translate(400,260)">
+    <ellipse cx="0" cy="40" rx="320" ry="60" fill="#3F2E0F"/>
+    <ellipse cx="0" cy="36" rx="312" ry="56" fill="#5A4214"/>
+    <ellipse cx="0" cy="32" rx="300" ry="50" fill="#7A5A1F" opacity="0.7"/>
+  </g>
+
+  <!-- 紙（ロジックツリー） -->
+  <g transform="translate(400,250)">
+    <rect x="-110" y="-50" width="220" height="100" rx="2" fill="url(#paper-cs1)"/>
+    <!-- 構造化フレームワーク -->
+    <g stroke="#3F2E0F" stroke-width="1.2" fill="none" opacity="0.85">
+      <rect x="-92" y="-40" width="40" height="14" rx="1" fill="#3B5BBF" stroke="none" opacity="0.85"/>
+      <rect x="-30" y="-40" width="40" height="14" rx="1" fill="none"/>
+      <rect x="32" y="-40" width="40" height="14" rx="1" fill="none"/>
+      <rect x="-92" y="-14" width="40" height="14" rx="1" fill="none"/>
+      <rect x="-30" y="-14" width="40" height="14" rx="1" fill="#FFD566" stroke="none" opacity="0.9"/>
+      <rect x="32" y="-14" width="40" height="14" rx="1" fill="none"/>
+      <line x1="-72" y1="-26" x2="-72" y2="-14"/>
+      <line x1="-10" y1="-26" x2="-10" y2="-14"/>
+      <line x1="52" y1="-26" x2="52" y2="-14"/>
+      <line x1="-92" y1="-7" x2="-30" y2="-7" opacity="0"/>
+    </g>
+    <!-- 下半分の書き込み -->
+    <g stroke="#3F2E0F" stroke-width="1" opacity="0.5">
+      <line x1="-90" y1="14" x2="80" y2="14"/>
+      <line x1="-90" y1="28" x2="60" y2="28"/>
+      <line x1="-90" y1="42" x2="80" y2="42"/>
+    </g>
+  </g>
+
+  <!-- 面接官（左、ジャケット） -->
+  <g transform="translate(160,170)">
+    <ellipse cx="0" cy="100" rx="50" ry="8" fill="#0B1424" opacity="0.7"/>
+    <path d="M -40 100 Q -42 30 -22 -8 Q -10 -16 0 -16 Q 10 -16 22 -8 Q 42 30 40 100 Z" fill="url(#figure-cs1)"/>
+    <circle cx="0" cy="-30" r="16" fill="#E7ECF7"/>
+    <path d="M -16 -36 Q 0 -48 16 -36 L 16 -28 L -16 -28 Z" fill="#1A2540"/>
+    <!-- ネクタイ -->
+    <polygon points="-4,-12 4,-12 6,30 0,46 -6,30" fill="#7A2E2E"/>
+  </g>
+
+  <!-- 候補者（右、メモを取る） -->
+  <g transform="translate(640,170)">
+    <ellipse cx="0" cy="100" rx="50" ry="8" fill="#0B1424" opacity="0.7"/>
+    <path d="M -40 100 Q -42 30 -22 -8 Q -10 -16 0 -16 Q 10 -16 22 -8 Q 42 30 40 100 Z" fill="url(#figure-cs1b)"/>
+    <circle cx="0" cy="-30" r="16" fill="#E7ECF7"/>
+    <path d="M -18 -36 Q 0 -50 18 -36 L 18 -26 L -18 -26 Z" fill="#1A2540"/>
+    <!-- 腕（前方に） -->
+    <path d="M -22 -8 Q -36 18 -28 50" fill="none" stroke="url(#figure-cs1b)" stroke-width="11" stroke-linecap="round"/>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="80" cy="50" r="1.4"/>
+    <circle cx="220" cy="38" r="1.2"/>
+    <circle cx="660" cy="50" r="1.4"/>
+    <circle cx="740" cy="80" r="1.0"/>
+  </g>
+</svg>

--- a/public/images/v3/course-client-01.svg
+++ b/public/images/v3/course-client-01.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-c1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-c1" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.34"/>
+      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="screen-c1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0E1E3C"/>
+      <stop offset="100%" stop-color="#0A1428"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-c1)"/>
+  <circle cx="400" cy="200" r="260" fill="url(#glow-c1)"/>
+
+  <!-- 机面 -->
+  <rect x="0" y="320" width="800" height="80" fill="#0E1424"/>
+  <line x1="0" y1="320" x2="800" y2="320" stroke="#2A3656" stroke-width="1" opacity="0.5"/>
+
+  <!-- ダッシュボード（中央モニター） -->
+  <g transform="translate(400,180)">
+    <ellipse cx="0" cy="148" rx="220" ry="10" fill="#0B1424" opacity="0.65"/>
+    <!-- 枠 -->
+    <rect x="-200" y="-130" width="400" height="260" rx="6" fill="#1A2540" stroke="#3B5BBF" stroke-width="1.5"/>
+    <rect x="-188" y="-118" width="376" height="236" rx="3" fill="url(#screen-c1)"/>
+    <!-- スタンド -->
+    <rect x="-30" y="118" width="60" height="14" fill="#1A2540"/>
+    <rect x="-50" y="130" width="100" height="6" rx="2" fill="#1A2540"/>
+
+    <!-- 大きな数字（KPI） -->
+    <text x="-160" y="-60" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="38" font-weight="700" fill="#FFD566">¥1.24M</text>
+    <text x="-160" y="-38" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="11" fill="#7AAEFF" opacity="0.85">月次売上</text>
+
+    <text x="40" y="-60" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="22" font-weight="700" fill="#7AAEFF">+27%</text>
+    <text x="40" y="-38" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="11" fill="#7AAEFF" opacity="0.7">前年比</text>
+
+    <!-- 棒グラフ -->
+    <g transform="translate(-160,40)">
+      <line x1="0" y1="0" x2="0" y2="60" stroke="#3B5BBF" stroke-width="1" opacity="0.5"/>
+      <line x1="0" y1="60" x2="320" y2="60" stroke="#3B5BBF" stroke-width="1" opacity="0.5"/>
+      <rect x="20" y="34" width="22" height="26" fill="#3B5BBF" opacity="0.7"/>
+      <rect x="60" y="20" width="22" height="40" fill="#3B5BBF" opacity="0.85"/>
+      <rect x="100" y="28" width="22" height="32" fill="#3B5BBF" opacity="0.75"/>
+      <rect x="140" y="14" width="22" height="46" fill="#3B5BBF" opacity="0.9"/>
+      <rect x="180" y="8" width="22" height="52" fill="#FFD566"/>
+      <!-- 折れ線 -->
+      <polyline points="31,34 71,20 111,28 151,14 191,8" stroke="#FFD566" stroke-width="1.6" fill="none" stroke-linecap="round"/>
+    </g>
+  </g>
+
+  <!-- 電卓（左下） -->
+  <g transform="translate(120,310)">
+    <rect x="-48" y="-30" width="96" height="60" rx="6" fill="#1A2540" stroke="#3B5BBF" stroke-width="1.2"/>
+    <rect x="-40" y="-22" width="80" height="14" rx="2" fill="#0E1E3C"/>
+    <text x="36" y="-11" text-anchor="end" font-family="'Courier New', monospace" font-size="11" fill="#FFD566">1240</text>
+    <g fill="#3B5BBF" opacity="0.85">
+      <rect x="-38" y="-2" width="14" height="10" rx="1"/>
+      <rect x="-20" y="-2" width="14" height="10" rx="1"/>
+      <rect x="-2" y="-2" width="14" height="10" rx="1"/>
+      <rect x="16" y="-2" width="14" height="10" rx="1"/>
+      <rect x="-38" y="12" width="14" height="10" rx="1"/>
+      <rect x="-20" y="12" width="14" height="10" rx="1"/>
+      <rect x="-2" y="12" width="14" height="10" rx="1"/>
+      <rect x="16" y="12" width="14" height="10" rx="1"/>
+    </g>
+  </g>
+
+  <!-- 円グラフ（右下） -->
+  <g transform="translate(680,310)">
+    <circle cx="0" cy="0" r="34" fill="#1A2540" stroke="#3B5BBF" stroke-width="1.2"/>
+    <path d="M 0 0 L 0 -34 A 34 34 0 0 1 32.3 -10.5 Z" fill="#FFD566"/>
+    <path d="M 0 0 L 32.3 -10.5 A 34 34 0 0 1 20 27.5 Z" fill="#3B5BBF"/>
+    <path d="M 0 0 L 20 27.5 A 34 34 0 0 1 -34 0 Z" fill="#7AAEFF" opacity="0.7"/>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="60" cy="50" r="1.4"/>
+    <circle cx="180" cy="36" r="1.2"/>
+    <circle cx="720" cy="80" r="1.2"/>
+  </g>
+</svg>

--- a/public/images/v3/course-fermi-01.svg
+++ b/public/images/v3/course-fermi-01.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-f1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="globe-f1" cx="0.4" cy="0.35" r="0.65">
+      <stop offset="0%" stop-color="#7AAEFF"/>
+      <stop offset="60%" stop-color="#3B5BBF"/>
+      <stop offset="100%" stop-color="#1B2954"/>
+    </radialGradient>
+    <radialGradient id="glow-f1" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-f1)"/>
+  <circle cx="400" cy="200" r="280" fill="url(#glow-f1)"/>
+
+  <!-- 地球（中央） -->
+  <g transform="translate(400,210)">
+    <!-- 影 -->
+    <ellipse cx="0" cy="124" rx="124" ry="14" fill="#0B1424" opacity="0.7"/>
+    <!-- 本体 -->
+    <circle cx="0" cy="0" r="118" fill="url(#globe-f1)"/>
+    <!-- 経緯線 -->
+    <g fill="none" stroke="#7AAEFF" stroke-width="1" opacity="0.5">
+      <ellipse cx="0" cy="0" rx="118" ry="40"/>
+      <ellipse cx="0" cy="0" rx="118" ry="80"/>
+      <ellipse cx="0" cy="0" rx="40" ry="118"/>
+      <ellipse cx="0" cy="0" rx="80" ry="118"/>
+      <line x1="-118" y1="0" x2="118" y2="0"/>
+    </g>
+    <!-- 大陸（簡略化） -->
+    <g fill="#C49A3C" opacity="0.7">
+      <path d="M -50 -40 Q -40 -50 -20 -45 Q -10 -38 -20 -25 Q -40 -22 -55 -30 Z"/>
+      <path d="M 10 -10 Q 30 -20 50 -10 Q 60 5 50 18 Q 30 22 15 14 Z"/>
+      <path d="M -30 30 Q -10 28 0 40 Q -8 56 -28 52 Q -42 44 -38 36 Z"/>
+      <path d="M 60 -50 Q 78 -52 84 -42 Q 80 -34 66 -38 Z"/>
+    </g>
+    <!-- ハイライト -->
+    <ellipse cx="-40" cy="-50" rx="40" ry="30" fill="#F4ECC4" opacity="0.18"/>
+  </g>
+
+  <!-- 浮かぶ概算式（吹き出し） -->
+  <g font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-weight="700">
+    <!-- 左上：人口 -->
+    <g transform="translate(140,90)">
+      <rect x="-58" y="-22" width="116" height="44" rx="6" fill="#1A2540" stroke="#FFD566" stroke-width="1.4"/>
+      <text x="0" y="-3" text-anchor="middle" font-size="11" fill="#7AAEFF" opacity="0.85">人口</text>
+      <text x="0" y="14" text-anchor="middle" font-size="14" fill="#FFD566">1.25 億</text>
+    </g>
+    <!-- 右上：1人あたり -->
+    <g transform="translate(660,90)">
+      <rect x="-58" y="-22" width="116" height="44" rx="6" fill="#1A2540" stroke="#FFD566" stroke-width="1.4"/>
+      <text x="0" y="-3" text-anchor="middle" font-size="11" fill="#7AAEFF" opacity="0.85">1人/年</text>
+      <text x="0" y="14" text-anchor="middle" font-size="14" fill="#FFD566">¥ 50万</text>
+    </g>
+    <!-- 下：合計 -->
+    <g transform="translate(400,360)">
+      <rect x="-90" y="-22" width="180" height="44" rx="6" fill="#1A2540" stroke="#C49A3C" stroke-width="1.6"/>
+      <text x="0" y="-3" text-anchor="middle" font-size="11" fill="#C49A3C" opacity="0.85">≒ 市場規模</text>
+      <text x="0" y="14" text-anchor="middle" font-size="16" fill="#FFD566">¥ 62.5 兆</text>
+    </g>
+  </g>
+
+  <!-- 接続線 -->
+  <g stroke="#FFD566" stroke-width="1" stroke-dasharray="4 3" fill="none" opacity="0.6">
+    <line x1="200" y1="100" x2="304" y2="172"/>
+    <line x1="600" y1="100" x2="496" y2="172"/>
+    <line x1="400" y1="328" x2="400" y2="338"/>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.55">
+    <circle cx="60" cy="50" r="1.4"/>
+    <circle cx="240" cy="40" r="1.0"/>
+    <circle cx="560" cy="40" r="1.2"/>
+    <circle cx="740" cy="60" r="1.4"/>
+    <circle cx="120" cy="220" r="1.0"/>
+    <circle cx="700" cy="220" r="1.2"/>
+  </g>
+</svg>

--- a/public/images/v3/course-proposal-01.svg
+++ b/public/images/v3/course-proposal-01.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-p1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-p1" cx="0.55" cy="0.45" r="0.45">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.32"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="paper-p1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F4ECC4"/>
+      <stop offset="100%" stop-color="#D8C898"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-p1)"/>
+
+  <g stroke="#2A3656" stroke-width="1" opacity="0.25">
+    <line x1="0" y1="100" x2="800" y2="100"/>
+    <line x1="0" y1="200" x2="800" y2="200"/>
+    <line x1="0" y1="300" x2="800" y2="300"/>
+  </g>
+
+  <circle cx="440" cy="180" r="240" fill="url(#glow-p1)"/>
+
+  <!-- 提案書（中央） -->
+  <g transform="translate(280,90)">
+    <rect x="0" y="0" width="220" height="260" rx="4" fill="url(#paper-p1)"/>
+    <rect x="0" y="0" width="220" height="36" fill="#3B5BBF" opacity="0.9"/>
+    <line x1="20" y1="58" x2="200" y2="58" stroke="#3F2E0F" stroke-width="2.4" opacity="0.85"/>
+    <g stroke="#3F2E0F" stroke-width="1.2" opacity="0.55">
+      <line x1="20" y1="80" x2="195" y2="80"/>
+      <line x1="20" y1="100" x2="180" y2="100"/>
+      <line x1="20" y1="120" x2="200" y2="120"/>
+      <line x1="20" y1="140" x2="170" y2="140"/>
+      <line x1="20" y1="170" x2="195" y2="170"/>
+      <line x1="20" y1="190" x2="185" y2="190"/>
+      <line x1="20" y1="210" x2="200" y2="210"/>
+      <line x1="20" y1="230" x2="160" y2="230"/>
+    </g>
+    <!-- アクセントの強調行 -->
+    <rect x="20" y="138" width="150" height="6" fill="#C49A3C" opacity="0.85"/>
+  </g>
+
+  <!-- 矢印（提案→決断） -->
+  <g stroke="#FFD566" stroke-width="3.5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 520 220 Q 580 200 620 220"/>
+    <polyline points="612,210 622,222 612,232"/>
+  </g>
+
+  <!-- 決断（チェックマーク+円） -->
+  <g transform="translate(680,220)">
+    <circle cx="0" cy="0" r="42" fill="#1A2540" stroke="#FFD566" stroke-width="2.5"/>
+    <polyline points="-18,2 -4,16 20,-12" stroke="#FFD566" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <!-- 床の影 -->
+  <ellipse cx="390" cy="358" rx="160" ry="10" fill="#0B1424" opacity="0.6"/>
+  <ellipse cx="680" cy="280" rx="50" ry="6" fill="#0B1424" opacity="0.5"/>
+
+  <!-- 細かい星 -->
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="80" cy="60" r="1.4"/>
+    <circle cx="180" cy="40" r="1.2"/>
+    <circle cx="260" cy="60" r="1.0"/>
+    <circle cx="660" cy="60" r="1.4"/>
+    <circle cx="740" cy="90" r="1.2"/>
+    <circle cx="100" cy="320" r="1.2"/>
+  </g>
+</svg>

--- a/public/images/v3/course-proposal-course-01.svg
+++ b/public/images/v3/course-proposal-course-01.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-pc1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-pc1" cx="0.55" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.34"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="paper-pc1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F4ECC4"/>
+      <stop offset="100%" stop-color="#D8C898"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-pc1)"/>
+
+  <circle cx="500" cy="200" r="260" fill="url(#glow-pc1)"/>
+
+  <!-- 下書きの紙（散らばる、左奥） -->
+  <g transform="translate(160,210) rotate(-12)" opacity="0.7">
+    <rect x="-90" y="-60" width="180" height="120" rx="2" fill="url(#paper-pc1)" opacity="0.8"/>
+    <g stroke="#3F2E0F" stroke-width="1" opacity="0.4">
+      <line x1="-78" y1="-40" x2="78" y2="-40"/>
+      <line x1="-78" y1="-20" x2="60" y2="-20"/>
+      <line x1="-78" y1="0" x2="70" y2="0"/>
+      <line x1="-78" y1="20" x2="50" y2="20"/>
+    </g>
+    <!-- 修正線 -->
+    <line x1="-60" y1="-22" x2="20" y2="-18" stroke="#7A2E2E" stroke-width="2" opacity="0.7"/>
+  </g>
+
+  <g transform="translate(220,270) rotate(8)" opacity="0.85">
+    <rect x="-90" y="-60" width="180" height="120" rx="2" fill="url(#paper-pc1)" opacity="0.9"/>
+    <g stroke="#3F2E0F" stroke-width="1" opacity="0.45">
+      <line x1="-78" y1="-40" x2="78" y2="-40"/>
+      <line x1="-78" y1="-20" x2="65" y2="-20"/>
+      <line x1="-78" y1="0" x2="70" y2="0"/>
+      <line x1="-78" y1="20" x2="55" y2="20"/>
+    </g>
+    <!-- チェックと書き込み -->
+    <polyline points="-50,4 -42,12 -28,-2" stroke="#3B5BBF" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <!-- 仕上げの一冊（中央、光沢） -->
+  <g transform="translate(490,200)">
+    <ellipse cx="0" cy="138" rx="140" ry="10" fill="#0B1424" opacity="0.65"/>
+    <rect x="-110" y="-130" width="220" height="270" rx="4" fill="url(#paper-pc1)"/>
+    <!-- ヘッダ -->
+    <rect x="-110" y="-130" width="220" height="40" fill="#1A2540"/>
+    <rect x="-110" y="-130" width="220" height="40" fill="url(#glow-pc1)" opacity="0.5"/>
+    <line x1="-90" y1="-110" x2="60" y2="-110" stroke="#FFD566" stroke-width="2"/>
+    <!-- 本文行 -->
+    <g stroke="#3F2E0F" stroke-width="1.3" opacity="0.6">
+      <line x1="-90" y1="-70" x2="80" y2="-70"/>
+      <line x1="-90" y1="-50" x2="60" y2="-50"/>
+      <line x1="-90" y1="-30" x2="80" y2="-30"/>
+      <line x1="-90" y1="-10" x2="40" y2="-10"/>
+    </g>
+    <!-- 仮説→検証の矢印（中段） -->
+    <g stroke="#3B5BBF" stroke-width="2" fill="none" stroke-linecap="round">
+      <circle cx="-70" cy="30" r="6" fill="#3B5BBF" opacity="0.85"/>
+      <circle cx="0" cy="30" r="6" fill="#C49A3C"/>
+      <circle cx="70" cy="30" r="6" fill="#3B5BBF" opacity="0.85"/>
+      <line x1="-60" y1="30" x2="-10" y2="30"/>
+      <line x1="10" y1="30" x2="60" y2="30"/>
+    </g>
+    <g stroke="#3F2E0F" stroke-width="1.3" opacity="0.5">
+      <line x1="-90" y1="60" x2="80" y2="60"/>
+      <line x1="-90" y1="80" x2="50" y2="80"/>
+      <line x1="-90" y1="100" x2="80" y2="100"/>
+    </g>
+  </g>
+
+  <!-- 万年筆 -->
+  <g transform="translate(630,300) rotate(-25)">
+    <line x1="0" y1="0" x2="56" y2="0" stroke="#1A1F2E" stroke-width="6" stroke-linecap="round"/>
+    <line x1="56" y1="0" x2="76" y2="0" stroke="#C49A3C" stroke-width="6" stroke-linecap="round"/>
+    <polygon points="76,0 86,-2 86,2" fill="#1A1F2E"/>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="60" cy="50" r="1.4"/>
+    <circle cx="160" cy="40" r="1.2"/>
+    <circle cx="700" cy="60" r="1.4"/>
+    <circle cx="730" cy="100" r="1.0"/>
+  </g>
+</svg>

--- a/public/images/v3/course-strategy-01.svg
+++ b/public/images/v3/course-strategy-01.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-s1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-s1" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#C49A3C" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#C49A3C" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="board-light" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F4ECC4"/>
+      <stop offset="100%" stop-color="#C9B57A"/>
+    </linearGradient>
+    <linearGradient id="board-dark" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3F2E0F"/>
+      <stop offset="100%" stop-color="#1A1306"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-s1)"/>
+  <circle cx="400" cy="200" r="280" fill="url(#glow-s1)"/>
+
+  <!-- 床の影 -->
+  <ellipse cx="400" cy="350" rx="240" ry="14" fill="#0B1424" opacity="0.7"/>
+
+  <!-- チェス盤（俯瞰風、台形にゆがませる） -->
+  <g transform="translate(400,250)">
+    <!-- 外枠 -->
+    <polygon points="-220,80 220,80 160,-60 -160,-60" fill="#1A2540" stroke="#C49A3C" stroke-width="2"/>
+    <!-- 8x8 マス（簡略化4x4で配置感） -->
+    <g>
+      <polygon points="-160,-60 -80,-60 -100,-25 -180,-25" fill="url(#board-light)"/>
+      <polygon points="-80,-60 0,-60 0,-25 -100,-25" fill="url(#board-dark)"/>
+      <polygon points="0,-60 80,-60 100,-25 0,-25" fill="url(#board-light)"/>
+      <polygon points="80,-60 160,-60 180,-25 100,-25" fill="url(#board-dark)"/>
+
+      <polygon points="-180,-25 -100,-25 -120,10 -200,10" fill="url(#board-dark)"/>
+      <polygon points="-100,-25 0,-25 0,10 -120,10" fill="url(#board-light)"/>
+      <polygon points="0,-25 100,-25 120,10 0,10" fill="url(#board-dark)"/>
+      <polygon points="100,-25 180,-25 200,10 120,10" fill="url(#board-light)"/>
+
+      <polygon points="-200,10 -120,10 -140,45 -210,45" fill="url(#board-light)"/>
+      <polygon points="-120,10 0,10 0,45 -140,45" fill="url(#board-dark)"/>
+      <polygon points="0,10 120,10 140,45 0,45" fill="url(#board-light)"/>
+      <polygon points="120,10 200,10 210,45 140,45" fill="url(#board-dark)"/>
+
+      <polygon points="-210,45 -140,45 -160,80 -220,80" fill="url(#board-dark)"/>
+      <polygon points="-140,45 0,45 0,80 -160,80" fill="url(#board-light)"/>
+      <polygon points="0,45 140,45 160,80 0,80" fill="url(#board-dark)"/>
+      <polygon points="140,45 220,45 220,80 160,80" fill="url(#board-light)"/>
+    </g>
+  </g>
+
+  <!-- 駒（簡略化シルエット） -->
+  <!-- キング（中央） -->
+  <g transform="translate(400,210)" fill="#FFD566">
+    <ellipse cx="0" cy="28" rx="18" ry="4" fill="#0B1424" opacity="0.7"/>
+    <rect x="-12" y="6" width="24" height="20" rx="2"/>
+    <ellipse cx="0" cy="6" rx="14" ry="4"/>
+    <rect x="-8" y="-12" width="16" height="20"/>
+    <rect x="-3" y="-22" width="6" height="14"/>
+    <rect x="-8" y="-18" width="16" height="4"/>
+  </g>
+
+  <!-- ナイト（左後） -->
+  <g transform="translate(310,170)" fill="#3B5BBF">
+    <ellipse cx="0" cy="22" rx="15" ry="3.5" fill="#0B1424" opacity="0.7"/>
+    <rect x="-10" y="2" width="20" height="20" rx="2"/>
+    <path d="M -8 0 Q -8 -18 6 -18 Q 14 -18 14 -8 L 14 4 L -8 4 Z"/>
+    <circle cx="6" cy="-10" r="1.5" fill="#1A2540"/>
+  </g>
+
+  <!-- ルーク（右後） -->
+  <g transform="translate(490,170)" fill="#7A2E2E">
+    <ellipse cx="0" cy="22" rx="15" ry="3.5" fill="#0B1424" opacity="0.7"/>
+    <rect x="-10" y="0" width="20" height="22" rx="2"/>
+    <rect x="-12" y="-12" width="24" height="14"/>
+    <rect x="-12" y="-16" width="6" height="6"/>
+    <rect x="-3" y="-16" width="6" height="6"/>
+    <rect x="6" y="-16" width="6" height="6"/>
+  </g>
+
+  <!-- ポーン（前列） -->
+  <g fill="#3B5BBF">
+    <g transform="translate(330,260)">
+      <ellipse cx="0" cy="14" rx="9" ry="2.5" fill="#0B1424" opacity="0.7"/>
+      <rect x="-6" y="-2" width="12" height="14" rx="1"/>
+      <circle cx="0" cy="-6" r="6"/>
+    </g>
+    <g transform="translate(370,260)">
+      <ellipse cx="0" cy="14" rx="9" ry="2.5" fill="#0B1424" opacity="0.7"/>
+      <rect x="-6" y="-2" width="12" height="14" rx="1"/>
+      <circle cx="0" cy="-6" r="6"/>
+    </g>
+    <g transform="translate(430,260)">
+      <ellipse cx="0" cy="14" rx="9" ry="2.5" fill="#0B1424" opacity="0.7"/>
+      <rect x="-6" y="-2" width="12" height="14" rx="1"/>
+      <circle cx="0" cy="-6" r="6"/>
+    </g>
+    <g transform="translate(470,260)">
+      <ellipse cx="0" cy="14" rx="9" ry="2.5" fill="#0B1424" opacity="0.7"/>
+      <rect x="-6" y="-2" width="12" height="14" rx="1"/>
+      <circle cx="0" cy="-6" r="6"/>
+    </g>
+  </g>
+
+  <!-- タイムライン（古典戦略の系譜） -->
+  <g transform="translate(400,80)" stroke="#FFD566" stroke-width="1.4" fill="#FFD566" opacity="0.85">
+    <line x1="-260" y1="0" x2="260" y2="0" stroke-width="1"/>
+    <circle cx="-260" cy="0" r="3"/>
+    <circle cx="-130" cy="0" r="3"/>
+    <circle cx="0" cy="0" r="3"/>
+    <circle cx="130" cy="0" r="3"/>
+    <circle cx="260" cy="0" r="3"/>
+    <text x="-260" y="-10" font-family="'Cormorant Garamond', serif" font-size="11" text-anchor="middle">Taylor</text>
+    <text x="-130" y="-10" font-family="'Cormorant Garamond', serif" font-size="11" text-anchor="middle">Ford</text>
+    <text x="0" y="-10" font-family="'Cormorant Garamond', serif" font-size="11" text-anchor="middle">Ansoff</text>
+    <text x="130" y="-10" font-family="'Cormorant Garamond', serif" font-size="11" text-anchor="middle">PPM</text>
+    <text x="260" y="-10" font-family="'Cormorant Garamond', serif" font-size="11" text-anchor="middle">Porter</text>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="80" cy="40" r="1.4"/>
+    <circle cx="160" cy="50" r="1.0"/>
+    <circle cx="700" cy="50" r="1.4"/>
+    <circle cx="730" cy="80" r="1.0"/>
+  </g>
+</svg>

--- a/src/courseData.ts
+++ b/src/courseData.ts
@@ -183,6 +183,7 @@ export const COURSES: Course[] = [
     lessonIds: [72, 73, 74, 75, 76],
     level: '中級',
     description: '読み手の判断基準から逆算し、決断を引き出す提案書の構造を習得する。',
+    image: '/images/v3/course-proposal-01.svg',
   },
 
   // ── 提案書作成 ──────────────────────────────────────
@@ -194,6 +195,7 @@ export const COURSES: Course[] = [
     lessonIds: [82, 83, 84, 86, 87],
     level: '上級',
     description: 'コンサル的アプローチで仮説を立て、検証しながら説得力のある提案書を完成させる。',
+    image: '/images/v3/course-proposal-course-01.svg',
   },
 
   // ── クライアントワーク ──────────────────────────────
@@ -205,6 +207,7 @@ export const COURSES: Course[] = [
     lessonIds: [89, 90, 91, 92, 97],
     level: '中級',
     description: '桁感覚と概算力を鍛え、クライアントの場でも即座に数字を扱えるようになる。',
+    image: '/images/v3/course-client-01.svg',
   },
   {
     id: 'client-02',
@@ -236,6 +239,7 @@ export const COURSES: Course[] = [
     lessonIds: [28, 29, 35, 36, 316],
     level: '上級',
     description: '利益構造の分解から市場参入まで、ケース面接の頻出テーマを体系的に攻略する。',
+    image: '/images/v3/course-case-01.svg',
   },
 
   // ── 経営戦略 ────────────────────────────────────────
@@ -247,6 +251,7 @@ export const COURSES: Course[] = [
     lessonIds: [320, 321, 322, 323, 324],
     level: '上級',
     description: 'テイラー・フォードからアンゾフ、PPM、ポーターまで。経営戦略の古典理論を通史的に押さえる。',
+    image: '/images/v3/course-strategy-01.svg',
   },
   {
     id: 'strategy-02',
@@ -268,6 +273,7 @@ export const COURSES: Course[] = [
     lessonIds: [200, 201, 202, 203, 204],
     level: '中級',
     description: '数式を立てて分解し、正確さより「だいたい正しい」答えを素早く出す力を鍛える。',
+    image: '/images/v3/course-fermi-01.svg',
   },
 
   // ── 数字に強くなる ──────────────────────────────────


### PR DESCRIPTION
## Summary

- Logicコース23件中、未着手だった6コースのサムネイルSVGを新規作成（既存スタイルと統一）
- `courseData.ts` から新規SVGを参照するように更新
- 並行して、Pixaで生成した13コース・17ファイル分のサムネイルをNotion「Logic素材」DBに登録
- 進捗管理用に `docs/THUMBNAILS_MANIFEST.md` を追加

## 新規作成SVG（6件）

| コース | コンセプト |
|---|---|
| `course-proposal-01.svg` | 提案書 → 矢印 → 決断のチェックマーク |
| `course-proposal-course-01.svg` | 散らばる下書き → 仕上がりの本提案書 + 仮説/検証サイクル |
| `course-client-01.svg` | KPIダッシュボード + 電卓 + 円グラフ |
| `course-case-01.svg` | 面接テーブル俯瞰、構造化フレームワーク用紙 |
| `course-strategy-01.svg` | 立体チェス盤 + 古典戦略タイムライン |
| `course-fermi-01.svg` | 地球 + 浮遊する概算式吹き出し |

すべて既存SVGと同じ作風（800×400、ダーク背景 #1F2942→#101729、暖色スポット光、シーン構成、控えめな星）で統一。

## Test plan

- [ ] `npm run dev` でコース一覧画面を表示し、6コースに新規サムネイルが表示されることを確認
- [ ] 各サムネイルが800×400で適切にスケールすること（カード表示時の見え方）を確認
- [ ] 既存14コース（カスタムSVG・カテゴリフォールバック）に影響がないこと

## 残課題

- 9コース（logic-01, critical-01, hypothesis-01, problem-01, design-01, systems-01, lateral-01, analogy-01, philosophy-01）はPixa生成済みでNotion登録のみ。リポジトリ反映には別途SVG化またはホストallowlist追加によるDLが必要
- レッスン約119件分の最初の画像差し替えは未着手

https://claude.ai/code/session_01L6wDEdj49p5XZo4daHzkVs

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6wDEdj49p5XZo4daHzkVs)_