### PR TITLE
残り9コース分のサムネイルSVGを追加し全コース対応完了

### DIFF
--- a/docs/THUMBNAILS_MANIFEST.md
+++ b/docs/THUMBNAILS_MANIFEST.md
@@ -1,0 +1,81 @@
+# コースサムネイル生成マニフェスト
+
+Logicアプリのコース・レッスン用サムネイル画像生成の進捗を記録するマニフェスト。
+
+## 生成済みサムネイル
+
+すべてPixa（Ideogram v3、16:9、1312×736 PNG）で生成。スタイル：シンプル・モダン、内容に沿ったコンセプト。
+
+### Notion DB
+
+「Logic素材」DB: <https://www.notion.so/38555f3f86db4fa0b4aff5d907af5395>
+
+### 完了済み（13コース・17ファイル）
+
+| コースID | コース名 | カテゴリ | Asset ID | ファイル名 |
+|---|---|---|---|---|
+| logic-01 | ロジカルに考えて、整理する | 論理的に考える | asset_6e18deace7b04e0096430058a8abf219 | logic_logic-01_1.png |
+| logic-01 | ロジカルに考えて、整理する | 論理的に考える | asset_497a89a4f9874b1893fc55d3ed581d9b | logic_logic-01_2.png |
+| logic-01 | ロジカルに考えて、整理する | 論理的に考える | asset_b1388f5678ec4dc3a1168aa68e88f392 | logic_logic-01_3.png |
+| logic-01 | ロジカルに考えて、整理する | 論理的に考える | asset_accaed58e9904a8f9a901400ac539f2f | logic_logic-01_4.png |
+| logic-01 | ロジカルに考えて、整理する | 論理的に考える | asset_b7215a8fabd64d488d51f705a9611ce3 | logic_logic-01_5.png |
+| logic-02 | 論理を組み立て、相手を動かす | 論理的に考える | asset_bd6013eb7b2146ed9d29b962337481b2 | logic_logic-02_1.png |
+| critical-01 | 思い込みを疑い、正しく判断する | 論理的に考える | asset_1438749ac21a45f9bf1361911d4b2abf | logic_critical-01_1.png |
+| critical-02 | バイアスを外し、客観的に見る | 論理的に考える | asset_7c20b71d6e6b49db81f01c955fc839d3 | logic_critical-02_1.png |
+| hypothesis-01 | 仮説を立ててから、調べる | 課題を解決する | asset_105a6ae2b3eb405a80774ed50a5d4c30 | logic_hypothesis-01_1.png |
+| problem-01 | 本当の問題を見極め、定義する | 課題を解決する | asset_533cdf99e9534beb8d0b536a4148df20 | logic_problem-01_1.png |
+| design-01 | ユーザーの本音を掘り下げ、解決する | 課題を解決する | asset_59be76ec8dda45ce8caa8a1f6e1efbfa | logic_design-01_1.png |
+| systems-01 | 全体を俯瞰し、根本から変える | 課題を解決する | asset_a500fbd9d76a4086af2d2ff02c359a2f | logic_systems-01_1.png |
+| lateral-01 | 常識を疑い、突破口を開く | 発想を広げる | asset_cbc1fb86472a4049983ac4405017cdac | logic_lateral-01_1.png |
+| analogy-01 | 別分野の知恵を借りて、応用する | 発想を広げる | asset_3f3c9bb7aff2453db7a5ac8e9488c595 | logic_analogy-01_1.png |
+| philosophy-01 | 哲学の問いで、思考を深める | 論理的に考える | asset_de2b5d185d784e129595ad78dce9ed85 | logic_philosophy-01_1.png |
+| eastern-01 | 古代中国思想で、人と組織を見る | 論理的に考える | asset_2759c8368b924c65a9f2ebc6db43df69 | logic_eastern-01_1.png |
+| eastern-02 | 古代中国思想で、戦略と決断を見る | 論理的に考える | asset_06d6acccde944a3eab33ed0c52eec51f | logic_eastern-02_1.png |
+
+合計: 12コース x 1枚 + logic-01 x 5枚 = 17ファイル（消費306クレジット）
+
+## 未生成（10コース）
+
+Pixaクレジット不足により以下が未生成。クレジット追加後に生成予定。
+
+| コースID | コース名 | カテゴリ |
+|---|---|---|
+| proposal-01 | 相手が動く提案をつくる | 相手を動かす |
+| proposal-course-01 | 仮説と検証で、提案書を仕上げる | 相手を動かす |
+| client-01 | 数字で状況を素早く読み解く | 現場で実践する |
+| client-02 | 論点を定め、深く引き出す | 相手を動かす |
+| client-03 | 未経験の業界で、短期間で立ち上がる | 現場で実践する |
+| case-01 | ケース面接で、論理力を証明する | 相手を動かす |
+| strategy-01 | 戦略の源流と競争戦略を学ぶ | 現場で実践する |
+| strategy-02 | 資源・能力・共進化の戦略へ | 現場で実践する |
+| fermi-01 | 概算で、世界の規模を掴む | 現場で実践する |
+| numeracy-01 | 数字に強くなる | 現場で実践する |
+
+## レッスン用画像（未着手）
+
+各レッスンの最初の画像（合計約119レッスン分）。コース全件完了後に着手予定。
+
+## ダウンロード手順
+
+ネットワーク制限（`assets.pixelcut.app`がClaudeのallowlist外）のため、現状はリポジトリに画像ファイルを保存できない。手順：
+
+1. Notion DB「Logic素材」の各レコードの「ダウンロードURL」から画像をダウンロード
+2. `public/images/v3/` に上記「ファイル名」で保存
+3. `src/courseData.ts` の各コース定義に `image: '/images/v3/logic_<id>_1.png'` を追加
+
+または、Claudeのネットワーク許可ホストに `assets.pixelcut.app` と `mcp.pixa.com` を追加すれば、自動でダウンロード・コード反映が可能。
+
+## 生成プロンプトの方針
+
+各コースのテーマ・キーワードを反映。パステル系ソフトカラー、フラットデザイン、テキストなし、16:9。
+
+例：
+- **logic-01**: ロジックツリー / MECE / 整理された脳 / 散らかり→整理 / ピラミッド階層
+- **systems-01**: 氷山モデル + フィードバックループ
+- **eastern-01**: 中国の巻物 + 階層的人物 + 朱と墨
+
+## 関連リソース
+
+- コース定義: `src/courseData.ts`
+- 既存サムネイル: `public/images/v3/course-*.{svg,webp}`
+- Notion DB: 「Logic素材」（38555f3f-86db-4fa0-b4af-f5d907af5395）

--- a/public/images/v3/course-analogy-01.svg
+++ b/public/images/v3/course-analogy-01.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-an1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-an1" cx="0.5" cy="0.45" r="0.5">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="trunk-an1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7A5A1F"/>
+      <stop offset="100%" stop-color="#3F2E0F"/>
+    </linearGradient>
+    <linearGradient id="leaf-an1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#5FA37A"/>
+      <stop offset="100%" stop-color="#2C6244"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-an1)"/>
+  <circle cx="400" cy="200" r="260" fill="url(#glow-an1)"/>
+
+  <ellipse cx="200" cy="358" rx="120" ry="10" fill="#0B1424" opacity="0.6"/>
+  <ellipse cx="600" cy="358" rx="120" ry="10" fill="#0B1424" opacity="0.6"/>
+
+  <!-- 左：木 -->
+  <g transform="translate(200,210)">
+    <!-- 葉 -->
+    <ellipse cx="0" cy="-60" rx="100" ry="80" fill="url(#leaf-an1)"/>
+    <ellipse cx="-50" cy="-50" rx="40" ry="36" fill="#5FA37A" opacity="0.7"/>
+    <ellipse cx="40" cy="-30" rx="34" ry="32" fill="#5FA37A" opacity="0.7"/>
+    <!-- 幹 -->
+    <rect x="-12" y="0" width="24" height="120" fill="url(#trunk-an1)"/>
+    <!-- 枝（分岐構造を強調） -->
+    <g fill="none" stroke="url(#trunk-an1)" stroke-width="6" stroke-linecap="round">
+      <line x1="0" y1="20" x2="-50" y2="-10"/>
+      <line x1="0" y1="40" x2="60" y2="20"/>
+      <line x1="-50" y1="-10" x2="-78" y2="-30"/>
+      <line x1="-50" y1="-10" x2="-40" y2="-44"/>
+      <line x1="60" y1="20" x2="80" y2="-4"/>
+      <line x1="60" y1="20" x2="78" y2="40"/>
+    </g>
+    <!-- 葉のドット -->
+    <g fill="#FFD566" opacity="0.6">
+      <circle cx="-30" cy="-90" r="3"/>
+      <circle cx="40" cy="-100" r="3"/>
+      <circle cx="0" cy="-130" r="3"/>
+      <circle cx="-70" cy="-50" r="3"/>
+    </g>
+  </g>
+
+  <!-- 右：回路基板 -->
+  <g transform="translate(600,210)">
+    <rect x="-110" y="-110" width="220" height="220" rx="6" fill="#1A2540" stroke="#3B5BBF" stroke-width="1.6"/>
+    <!-- グリッド -->
+    <g stroke="#3B5BBF" stroke-width="0.5" opacity="0.3">
+      <line x1="-110" y1="-50" x2="110" y2="-50"/>
+      <line x1="-110" y1="0" x2="110" y2="0"/>
+      <line x1="-110" y1="50" x2="110" y2="50"/>
+      <line x1="-50" y1="-110" x2="-50" y2="110"/>
+      <line x1="0" y1="-110" x2="0" y2="110"/>
+      <line x1="50" y1="-110" x2="50" y2="110"/>
+    </g>
+    <!-- 回路（同じ分岐構造） -->
+    <g fill="none" stroke="#FFD566" stroke-width="2.4" stroke-linecap="round">
+      <line x1="-90" y1="80" x2="-90" y2="40"/>
+      <line x1="-90" y1="40" x2="0" y2="40"/>
+      <line x1="0" y1="40" x2="0" y2="-30"/>
+      <line x1="0" y1="-30" x2="-50" y2="-30"/>
+      <line x1="0" y1="-30" x2="60" y2="-30"/>
+      <line x1="-50" y1="-30" x2="-50" y2="-80"/>
+      <line x1="-50" y1="-30" x2="-90" y2="-30"/>
+      <line x1="60" y1="-30" x2="60" y2="-80"/>
+      <line x1="60" y1="-30" x2="90" y2="0"/>
+    </g>
+    <!-- 抵抗とチップ -->
+    <g fill="#7A2E2E">
+      <rect x="-60" y="-86" width="20" height="10" rx="2"/>
+      <rect x="50" y="-86" width="20" height="10" rx="2"/>
+      <rect x="-100" y="-36" width="20" height="10" rx="2"/>
+    </g>
+    <g fill="#3F8C5F">
+      <circle cx="0" cy="40" r="6"/>
+      <circle cx="-90" cy="80" r="6"/>
+      <circle cx="90" cy="0" r="6"/>
+    </g>
+  </g>
+
+  <!-- 構造的類似性を示す3本の点線 -->
+  <g stroke="#FFD566" stroke-width="1.4" stroke-dasharray="5 4" fill="none" opacity="0.7">
+    <line x1="280" y1="120" x2="490" y2="120"/>
+    <line x1="280" y1="200" x2="490" y2="200"/>
+    <line x1="280" y1="280" x2="490" y2="280"/>
+  </g>
+
+  <!-- 中央のラベル -->
+  <g transform="translate(400,200)">
+    <rect x="-44" y="-16" width="88" height="32" rx="16" fill="#1A2540" stroke="#FFD566" stroke-width="1.4"/>
+    <text x="0" y="6" text-anchor="middle" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="11" font-weight="700" fill="#FFD566">≈ 構造</text>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="80" cy="50" r="1.4"/>
+    <circle cx="220" cy="36" r="1.0"/>
+    <circle cx="720" cy="60" r="1.4"/>
+  </g>
+</svg>

--- a/public/images/v3/course-case-01.svg
+++ b/public/images/v3/course-case-01.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-cs1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-cs1" cx="0.5" cy="0.4" r="0.45">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="figure-cs1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3B5BBF"/>
+      <stop offset="100%" stop-color="#1B2954"/>
+    </linearGradient>
+    <linearGradient id="figure-cs1b" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7A2E2E"/>
+      <stop offset="100%" stop-color="#3F1717"/>
+    </linearGradient>
+    <linearGradient id="paper-cs1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F4ECC4"/>
+      <stop offset="100%" stop-color="#D8C898"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-cs1)"/>
+  <circle cx="400" cy="160" r="240" fill="url(#glow-cs1)"/>
+
+  <!-- 机（俯瞰風で大きく） -->
+  <g transform="translate(400,260)">
+    <ellipse cx="0" cy="40" rx="320" ry="60" fill="#3F2E0F"/>
+    <ellipse cx="0" cy="36" rx="312" ry="56" fill="#5A4214"/>
+    <ellipse cx="0" cy="32" rx="300" ry="50" fill="#7A5A1F" opacity="0.7"/>
+  </g>
+
+  <!-- 紙（ロジックツリー） -->
+  <g transform="translate(400,250)">
+    <rect x="-110" y="-50" width="220" height="100" rx="2" fill="url(#paper-cs1)"/>
+    <!-- 構造化フレームワーク -->
+    <g stroke="#3F2E0F" stroke-width="1.2" fill="none" opacity="0.85">
+      <rect x="-92" y="-40" width="40" height="14" rx="1" fill="#3B5BBF" stroke="none" opacity="0.85"/>
+      <rect x="-30" y="-40" width="40" height="14" rx="1" fill="none"/>
+      <rect x="32" y="-40" width="40" height="14" rx="1" fill="none"/>
+      <rect x="-92" y="-14" width="40" height="14" rx="1" fill="none"/>
+      <rect x="-30" y="-14" width="40" height="14" rx="1" fill="#FFD566" stroke="none" opacity="0.9"/>
+      <rect x="32" y="-14" width="40" height="14" rx="1" fill="none"/>
+      <line x1="-72" y1="-26" x2="-72" y2="-14"/>
+      <line x1="-10" y1="-26" x2="-10" y2="-14"/>
+      <line x1="52" y1="-26" x2="52" y2="-14"/>
+      <line x1="-92" y1="-7" x2="-30" y2="-7" opacity="0"/>
+    </g>
+    <!-- 下半分の書き込み -->
+    <g stroke="#3F2E0F" stroke-width="1" opacity="0.5">
+      <line x1="-90" y1="14" x2="80" y2="14"/>
+      <line x1="-90" y1="28" x2="60" y2="28"/>
+      <line x1="-90" y1="42" x2="80" y2="42"/>
+    </g>
+  </g>
+
+  <!-- 面接官（左、ジャケット） -->
+  <g transform="translate(160,170)">
+    <ellipse cx="0" cy="100" rx="50" ry="8" fill="#0B1424" opacity="0.7"/>
+    <path d="M -40 100 Q -42 30 -22 -8 Q -10 -16 0 -16 Q 10 -16 22 -8 Q 42 30 40 100 Z" fill="url(#figure-cs1)"/>
+    <circle cx="0" cy="-30" r="16" fill="#E7ECF7"/>
+    <path d="M -16 -36 Q 0 -48 16 -36 L 16 -28 L -16 -28 Z" fill="#1A2540"/>
+    <!-- ネクタイ -->
+    <polygon points="-4,-12 4,-12 6,30 0,46 -6,30" fill="#7A2E2E"/>
+  </g>
+
+  <!-- 候補者（右、メモを取る） -->
+  <g transform="translate(640,170)">
+    <ellipse cx="0" cy="100" rx="50" ry="8" fill="#0B1424" opacity="0.7"/>
+    <path d="M -40 100 Q -42 30 -22 -8 Q -10 -16 0 -16 Q 10 -16 22 -8 Q 42 30 40 100 Z" fill="url(#figure-cs1b)"/>
+    <circle cx="0" cy="-30" r="16" fill="#E7ECF7"/>
+    <path d="M -18 -36 Q 0 -50 18 -36 L 18 -26 L -18 -26 Z" fill="#1A2540"/>
+    <!-- 腕（前方に） -->
+    <path d="M -22 -8 Q -36 18 -28 50" fill="none" stroke="url(#figure-cs1b)" stroke-width="11" stroke-linecap="round"/>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="80" cy="50" r="1.4"/>
+    <circle cx="220" cy="38" r="1.2"/>
+    <circle cx="660" cy="50" r="1.4"/>
+    <circle cx="740" cy="80" r="1.0"/>
+  </g>
+</svg>

--- a/public/images/v3/course-client-01.svg
+++ b/public/images/v3/course-client-01.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-c1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-c1" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.34"/>
+      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="screen-c1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0E1E3C"/>
+      <stop offset="100%" stop-color="#0A1428"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-c1)"/>
+  <circle cx="400" cy="200" r="260" fill="url(#glow-c1)"/>
+
+  <!-- 机面 -->
+  <rect x="0" y="320" width="800" height="80" fill="#0E1424"/>
+  <line x1="0" y1="320" x2="800" y2="320" stroke="#2A3656" stroke-width="1" opacity="0.5"/>
+
+  <!-- ダッシュボード（中央モニター） -->
+  <g transform="translate(400,180)">
+    <ellipse cx="0" cy="148" rx="220" ry="10" fill="#0B1424" opacity="0.65"/>
+    <!-- 枠 -->
+    <rect x="-200" y="-130" width="400" height="260" rx="6" fill="#1A2540" stroke="#3B5BBF" stroke-width="1.5"/>
+    <rect x="-188" y="-118" width="376" height="236" rx="3" fill="url(#screen-c1)"/>
+    <!-- スタンド -->
+    <rect x="-30" y="118" width="60" height="14" fill="#1A2540"/>
+    <rect x="-50" y="130" width="100" height="6" rx="2" fill="#1A2540"/>
+
+    <!-- 大きな数字（KPI） -->
+    <text x="-160" y="-60" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="38" font-weight="700" fill="#FFD566">¥1.24M</text>
+    <text x="-160" y="-38" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="11" fill="#7AAEFF" opacity="0.85">月次売上</text>
+
+    <text x="40" y="-60" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="22" font-weight="700" fill="#7AAEFF">+27%</text>
+    <text x="40" y="-38" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="11" fill="#7AAEFF" opacity="0.7">前年比</text>
+
+    <!-- 棒グラフ -->
+    <g transform="translate(-160,40)">
+      <line x1="0" y1="0" x2="0" y2="60" stroke="#3B5BBF" stroke-width="1" opacity="0.5"/>
+      <line x1="0" y1="60" x2="320" y2="60" stroke="#3B5BBF" stroke-width="1" opacity="0.5"/>
+      <rect x="20" y="34" width="22" height="26" fill="#3B5BBF" opacity="0.7"/>
+      <rect x="60" y="20" width="22" height="40" fill="#3B5BBF" opacity="0.85"/>
+      <rect x="100" y="28" width="22" height="32" fill="#3B5BBF" opacity="0.75"/>
+      <rect x="140" y="14" width="22" height="46" fill="#3B5BBF" opacity="0.9"/>
+      <rect x="180" y="8" width="22" height="52" fill="#FFD566"/>
+      <!-- 折れ線 -->
+      <polyline points="31,34 71,20 111,28 151,14 191,8" stroke="#FFD566" stroke-width="1.6" fill="none" stroke-linecap="round"/>
+    </g>
+  </g>
+
+  <!-- 電卓（左下） -->
+  <g transform="translate(120,310)">
+    <rect x="-48" y="-30" width="96" height="60" rx="6" fill="#1A2540" stroke="#3B5BBF" stroke-width="1.2"/>
+    <rect x="-40" y="-22" width="80" height="14" rx="2" fill="#0E1E3C"/>
+    <text x="36" y="-11" text-anchor="end" font-family="'Courier New', monospace" font-size="11" fill="#FFD566">1240</text>
+    <g fill="#3B5BBF" opacity="0.85">
+      <rect x="-38" y="-2" width="14" height="10" rx="1"/>
+      <rect x="-20" y="-2" width="14" height="10" rx="1"/>
+      <rect x="-2" y="-2" width="14" height="10" rx="1"/>
+      <rect x="16" y="-2" width="14" height="10" rx="1"/>
+      <rect x="-38" y="12" width="14" height="10" rx="1"/>
+      <rect x="-20" y="12" width="14" height="10" rx="1"/>
+      <rect x="-2" y="12" width="14" height="10" rx="1"/>
+      <rect x="16" y="12" width="14" height="10" rx="1"/>
+    </g>
+  </g>
+
+  <!-- 円グラフ（右下） -->
+  <g transform="translate(680,310)">
+    <circle cx="0" cy="0" r="34" fill="#1A2540" stroke="#3B5BBF" stroke-width="1.2"/>
+    <path d="M 0 0 L 0 -34 A 34 34 0 0 1 32.3 -10.5 Z" fill="#FFD566"/>
+    <path d="M 0 0 L 32.3 -10.5 A 34 34 0 0 1 20 27.5 Z" fill="#3B5BBF"/>
+    <path d="M 0 0 L 20 27.5 A 34 34 0 0 1 -34 0 Z" fill="#7AAEFF" opacity="0.7"/>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="60" cy="50" r="1.4"/>
+    <circle cx="180" cy="36" r="1.2"/>
+    <circle cx="720" cy="80" r="1.2"/>
+  </g>
+</svg>

--- a/public/images/v3/course-critical-01.svg
+++ b/public/images/v3/course-critical-01.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-cr1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-cr1" cx="0.5" cy="0.4" r="0.5">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="paper-cr1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F4ECC4"/>
+      <stop offset="100%" stop-color="#D8C898"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-cr1)"/>
+  <circle cx="400" cy="200" r="260" fill="url(#glow-cr1)"/>
+
+  <ellipse cx="400" cy="350" rx="220" ry="12" fill="#0B1424" opacity="0.6"/>
+
+  <!-- 中央の文書 -->
+  <g transform="translate(400,210)">
+    <rect x="-150" y="-110" width="300" height="220" rx="4" fill="url(#paper-cr1)"/>
+    <rect x="-150" y="-110" width="300" height="34" fill="#7A2E2E"/>
+    <line x1="-130" y1="-90" x2="80" y2="-90" stroke="#F4ECC4" stroke-width="2" opacity="0.85"/>
+
+    <!-- 本文行 -->
+    <g stroke="#3F2E0F" stroke-width="1.2" opacity="0.55">
+      <line x1="-130" y1="-50" x2="130" y2="-50"/>
+      <line x1="-130" y1="-30" x2="100" y2="-30"/>
+      <line x1="-130" y1="-10" x2="120" y2="-10"/>
+      <line x1="-130" y1="10" x2="80" y2="10"/>
+      <line x1="-130" y1="30" x2="120" y2="30"/>
+      <line x1="-130" y1="50" x2="90" y2="50"/>
+      <line x1="-130" y1="70" x2="110" y2="70"/>
+      <line x1="-130" y1="90" x2="60" y2="90"/>
+    </g>
+
+    <!-- 怪しい主張に取り消し線 -->
+    <line x1="-100" y1="10" x2="60" y2="10" stroke="#7A2E2E" stroke-width="2.5" opacity="0.85"/>
+    <line x1="-100" y1="50" x2="50" y2="50" stroke="#7A2E2E" stroke-width="2.5" opacity="0.85"/>
+
+    <!-- チェックマーク（正しい論証） -->
+    <g stroke="#3F8C5F" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="-128,-30 -118,-22 -100,-38"/>
+      <polyline points="-128,30 -118,38 -100,22"/>
+      <polyline points="-128,90 -118,98 -100,82"/>
+    </g>
+  </g>
+
+  <!-- 虫眼鏡（右上から覗き込む） -->
+  <g transform="translate(560,150) rotate(20)">
+    <circle cx="0" cy="0" r="64" fill="#7AAEFF" fill-opacity="0.18" stroke="#FFD566" stroke-width="6"/>
+    <circle cx="0" cy="0" r="64" fill="none" stroke="#1A2540" stroke-width="2" opacity="0.8"/>
+    <line x1="46" y1="46" x2="92" y2="92" stroke="#FFD566" stroke-width="14" stroke-linecap="round"/>
+    <line x1="46" y1="46" x2="92" y2="92" stroke="#1A2540" stroke-width="3" stroke-linecap="round"/>
+    <!-- 虫眼鏡内のクエスチョン → チェック -->
+    <text x="-22" y="14" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="42" font-weight="700" fill="#7A2E2E">?</text>
+    <polyline points="6,4 14,14 28,-6" stroke="#3F8C5F" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <!-- 浮かぶ クエスチョンマーク -->
+  <g font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-weight="700" fill="#FFD566" opacity="0.85">
+    <text x="120" y="130" font-size="38">?</text>
+    <text x="160" y="80" font-size="22" opacity="0.6">?</text>
+    <text x="700" y="320" font-size="32" opacity="0.7">?</text>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="80" cy="50" r="1.4"/>
+    <circle cx="220" cy="36" r="1.0"/>
+    <circle cx="700" cy="60" r="1.4"/>
+  </g>
+</svg>

--- a/public/images/v3/course-design-01.svg
+++ b/public/images/v3/course-design-01.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-d1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-d1" cx="0.4" cy="0.45" r="0.5">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.32"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="figure-d1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7A2E2E"/>
+      <stop offset="100%" stop-color="#3F1717"/>
+    </linearGradient>
+    <linearGradient id="paper-d1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F4ECC4"/>
+      <stop offset="100%" stop-color="#D8C898"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-d1)"/>
+  <circle cx="320" cy="200" r="260" fill="url(#glow-d1)"/>
+
+  <!-- 机面 -->
+  <rect x="0" y="320" width="800" height="80" fill="#0E1424"/>
+  <line x1="0" y1="320" x2="800" y2="320" stroke="#2A3656" stroke-width="1" opacity="0.5"/>
+
+  <!-- ユーザー（左、シルエット） -->
+  <g transform="translate(220,210)">
+    <ellipse cx="0" cy="100" rx="50" ry="8" fill="#0B1424" opacity="0.7"/>
+    <path d="M -38 100 Q -42 30 -22 -8 Q -10 -16 0 -16 Q 10 -16 22 -8 Q 42 30 38 100 Z" fill="url(#figure-d1)"/>
+    <circle cx="0" cy="-30" r="16" fill="#E7ECF7"/>
+    <path d="M -16 -38 Q 0 -50 18 -38 L 18 -28 L -16 -28 Z" fill="#1A2540"/>
+  </g>
+
+  <!-- 思考の吹き出し（ユーザーの本音） -->
+  <g transform="translate(280,140)">
+    <ellipse cx="0" cy="0" rx="86" ry="58" fill="#F4ECC4" stroke="#FFD566" stroke-width="1.6"/>
+    <circle cx="-66" cy="44" r="8" fill="#F4ECC4" stroke="#FFD566" stroke-width="1.4"/>
+    <circle cx="-78" cy="56" r="4.5" fill="#F4ECC4" stroke="#FFD566" stroke-width="1.2"/>
+    <!-- ハート + 困りマーク -->
+    <g transform="translate(-30,-2)" fill="#7A2E2E">
+      <path d="M 0 4 Q -10 -8 -16 0 Q -16 10 0 18 Q 16 10 16 0 Q 10 -8 0 4 Z"/>
+    </g>
+    <text x="20" y="6" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="22" font-weight="700" fill="#7A2E2E">…?</text>
+  </g>
+
+  <!-- プロトタイプ（右、机の上） -->
+  <g transform="translate(580,260)">
+    <ellipse cx="0" cy="60" rx="120" ry="10" fill="#0B1424" opacity="0.7"/>
+    <!-- A4 紙 -->
+    <rect x="-100" y="-60" width="160" height="120" rx="2" fill="url(#paper-d1)" transform="rotate(-6)"/>
+    <!-- 上 -->
+    <rect x="-80" y="-50" width="120" height="100" rx="3" fill="#1A2540" stroke="#FFD566" stroke-width="1.2" transform="rotate(-2 -20 0)"/>
+    <!-- ワイヤフレーム要素（白いボックス） -->
+    <g transform="translate(-22,-2)" fill="#F4ECC4">
+      <rect x="-50" y="-40" width="100" height="14" rx="2" opacity="0.85"/>
+      <rect x="-50" y="-20" width="60" height="40" rx="2" opacity="0.65"/>
+      <rect x="14" y="-20" width="36" height="18" rx="2" opacity="0.7"/>
+      <rect x="14" y="0" width="36" height="18" rx="2" opacity="0.7"/>
+      <rect x="-50" y="26" width="100" height="10" rx="2" fill="#FFD566"/>
+    </g>
+  </g>
+
+  <!-- ペン -->
+  <g transform="translate(440,300) rotate(-30)">
+    <line x1="0" y1="0" x2="50" y2="0" stroke="#1A1F2E" stroke-width="6" stroke-linecap="round"/>
+    <line x1="50" y1="0" x2="68" y2="0" stroke="#C49A3C" stroke-width="6" stroke-linecap="round"/>
+    <polygon points="68,0 78,-2 78,2" fill="#1A1F2E"/>
+  </g>
+
+  <!-- 矢印：ユーザーの本音 → プロトタイプへ -->
+  <g stroke="#FFD566" stroke-width="2" fill="none" stroke-linecap="round" stroke-dasharray="5 4" opacity="0.7">
+    <path d="M 360 180 Q 460 200 540 230"/>
+    <polyline points="528,222 542,232 530,240"/>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="80" cy="50" r="1.4"/>
+    <circle cx="200" cy="36" r="1.0"/>
+    <circle cx="720" cy="80" r="1.4"/>
+  </g>
+</svg>

--- a/public/images/v3/course-fermi-01.svg
+++ b/public/images/v3/course-fermi-01.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-f1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="globe-f1" cx="0.4" cy="0.35" r="0.65">
+      <stop offset="0%" stop-color="#7AAEFF"/>
+      <stop offset="60%" stop-color="#3B5BBF"/>
+      <stop offset="100%" stop-color="#1B2954"/>
+    </radialGradient>
+    <radialGradient id="glow-f1" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-f1)"/>
+  <circle cx="400" cy="200" r="280" fill="url(#glow-f1)"/>
+
+  <!-- 地球（中央） -->
+  <g transform="translate(400,210)">
+    <!-- 影 -->
+    <ellipse cx="0" cy="124" rx="124" ry="14" fill="#0B1424" opacity="0.7"/>
+    <!-- 本体 -->
+    <circle cx="0" cy="0" r="118" fill="url(#globe-f1)"/>
+    <!-- 経緯線 -->
+    <g fill="none" stroke="#7AAEFF" stroke-width="1" opacity="0.5">
+      <ellipse cx="0" cy="0" rx="118" ry="40"/>
+      <ellipse cx="0" cy="0" rx="118" ry="80"/>
+      <ellipse cx="0" cy="0" rx="40" ry="118"/>
+      <ellipse cx="0" cy="0" rx="80" ry="118"/>
+      <line x1="-118" y1="0" x2="118" y2="0"/>
+    </g>
+    <!-- 大陸（簡略化） -->
+    <g fill="#C49A3C" opacity="0.7">
+      <path d="M -50 -40 Q -40 -50 -20 -45 Q -10 -38 -20 -25 Q -40 -22 -55 -30 Z"/>
+      <path d="M 10 -10 Q 30 -20 50 -10 Q 60 5 50 18 Q 30 22 15 14 Z"/>
+      <path d="M -30 30 Q -10 28 0 40 Q -8 56 -28 52 Q -42 44 -38 36 Z"/>
+      <path d="M 60 -50 Q 78 -52 84 -42 Q 80 -34 66 -38 Z"/>
+    </g>
+    <!-- ハイライト -->
+    <ellipse cx="-40" cy="-50" rx="40" ry="30" fill="#F4ECC4" opacity="0.18"/>
+  </g>
+
+  <!-- 浮かぶ概算式（吹き出し） -->
+  <g font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-weight="700">
+    <!-- 左上：人口 -->
+    <g transform="translate(140,90)">
+      <rect x="-58" y="-22" width="116" height="44" rx="6" fill="#1A2540" stroke="#FFD566" stroke-width="1.4"/>
+      <text x="0" y="-3" text-anchor="middle" font-size="11" fill="#7AAEFF" opacity="0.85">人口</text>
+      <text x="0" y="14" text-anchor="middle" font-size="14" fill="#FFD566">1.25 億</text>
+    </g>
+    <!-- 右上：1人あたり -->
+    <g transform="translate(660,90)">
+      <rect x="-58" y="-22" width="116" height="44" rx="6" fill="#1A2540" stroke="#FFD566" stroke-width="1.4"/>
+      <text x="0" y="-3" text-anchor="middle" font-size="11" fill="#7AAEFF" opacity="0.85">1人/年</text>
+      <text x="0" y="14" text-anchor="middle" font-size="14" fill="#FFD566">¥ 50万</text>
+    </g>
+    <!-- 下：合計 -->
+    <g transform="translate(400,360)">
+      <rect x="-90" y="-22" width="180" height="44" rx="6" fill="#1A2540" stroke="#C49A3C" stroke-width="1.6"/>
+      <text x="0" y="-3" text-anchor="middle" font-size="11" fill="#C49A3C" opacity="0.85">≒ 市場規模</text>
+      <text x="0" y="14" text-anchor="middle" font-size="16" fill="#FFD566">¥ 62.5 兆</text>
+    </g>
+  </g>
+
+  <!-- 接続線 -->
+  <g stroke="#FFD566" stroke-width="1" stroke-dasharray="4 3" fill="none" opacity="0.6">
+    <line x1="200" y1="100" x2="304" y2="172"/>
+    <line x1="600" y1="100" x2="496" y2="172"/>
+    <line x1="400" y1="328" x2="400" y2="338"/>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.55">
+    <circle cx="60" cy="50" r="1.4"/>
+    <circle cx="240" cy="40" r="1.0"/>
+    <circle cx="560" cy="40" r="1.2"/>
+    <circle cx="740" cy="60" r="1.4"/>
+    <circle cx="120" cy="220" r="1.0"/>
+    <circle cx="700" cy="220" r="1.2"/>
+  </g>
+</svg>

--- a/public/images/v3/course-hypothesis-01.svg
+++ b/public/images/v3/course-hypothesis-01.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-h1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-h1" cx="0.5" cy="0.4" r="0.5">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.34"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="bulb-h1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FFE489"/>
+      <stop offset="100%" stop-color="#C49A3C"/>
+    </linearGradient>
+    <linearGradient id="paper-h1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F4ECC4"/>
+      <stop offset="100%" stop-color="#D8C898"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-h1)"/>
+  <circle cx="400" cy="170" r="260" fill="url(#glow-h1)"/>
+
+  <!-- 机面 -->
+  <rect x="0" y="320" width="800" height="80" fill="#0E1424"/>
+  <line x1="0" y1="320" x2="800" y2="320" stroke="#2A3656" stroke-width="1" opacity="0.5"/>
+
+  <!-- 電球（中央上、仮説のひらめき） -->
+  <g transform="translate(400,140)">
+    <circle cx="0" cy="0" r="84" fill="url(#glow-h1)" opacity="0.7"/>
+    <path d="M -34 -12 Q -34 -56 0 -56 Q 34 -56 34 -12 Q 34 14 18 26 L 18 42 L -18 42 L -18 26 Q -34 14 -34 -12 Z" fill="url(#bulb-h1)"/>
+    <line x1="-18" y1="46" x2="18" y2="46" stroke="#1A2540" stroke-width="3" stroke-linecap="round"/>
+    <line x1="-14" y1="54" x2="14" y2="54" stroke="#1A2540" stroke-width="3" stroke-linecap="round"/>
+    <!-- フィラメント -->
+    <path d="M -10 12 Q 0 -8 10 12" fill="none" stroke="#7A5A1F" stroke-width="1.4" opacity="0.7"/>
+    <!-- 光線 -->
+    <g stroke="#FFD566" stroke-width="2" stroke-linecap="round" opacity="0.7">
+      <line x1="0" y1="-72" x2="0" y2="-86"/>
+      <line x1="-50" y1="-50" x2="-58" y2="-58"/>
+      <line x1="50" y1="-50" x2="58" y2="-58"/>
+      <line x1="-66" y1="-12" x2="-78" y2="-12"/>
+      <line x1="66" y1="-12" x2="78" y2="-12"/>
+    </g>
+  </g>
+
+  <!-- ノート（仮説 → 検証） -->
+  <g transform="translate(190,290)">
+    <rect x="-90" y="-60" width="180" height="100" rx="2" fill="url(#paper-h1)"/>
+    <text x="-72" y="-40" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="11" font-weight="700" fill="#3F2E0F">仮説</text>
+    <line x1="-50" y1="-44" x2="-50" y2="-32" stroke="#3F2E0F" stroke-width="0.5" opacity="0.6"/>
+    <g stroke="#3F2E0F" stroke-width="1" opacity="0.55">
+      <line x1="-72" y1="-22" x2="74" y2="-22"/>
+      <line x1="-72" y1="-8" x2="60" y2="-8"/>
+      <line x1="-72" y1="6" x2="74" y2="6"/>
+      <line x1="-72" y1="20" x2="50" y2="20"/>
+    </g>
+  </g>
+
+  <!-- 検証（右、データ点グラフ） -->
+  <g transform="translate(610,290)">
+    <rect x="-90" y="-60" width="180" height="100" rx="2" fill="url(#paper-h1)"/>
+    <text x="-72" y="-40" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="11" font-weight="700" fill="#3F2E0F">検証</text>
+    <!-- 散布図 -->
+    <g transform="translate(-72,-14)">
+      <line x1="0" y1="0" x2="0" y2="44" stroke="#3F2E0F" stroke-width="0.8" opacity="0.6"/>
+      <line x1="0" y1="44" x2="138" y2="44" stroke="#3F2E0F" stroke-width="0.8" opacity="0.6"/>
+      <g fill="#3B5BBF">
+        <circle cx="14" cy="36" r="2.4"/>
+        <circle cx="32" cy="30" r="2.4"/>
+        <circle cx="48" cy="22" r="2.4"/>
+        <circle cx="68" cy="26" r="2.4"/>
+        <circle cx="84" cy="14" r="2.4"/>
+        <circle cx="104" cy="18" r="2.4"/>
+        <circle cx="122" cy="6" r="2.4"/>
+      </g>
+      <line x1="10" y1="38" x2="126" y2="6" stroke="#7A2E2E" stroke-width="1.4" opacity="0.85"/>
+    </g>
+  </g>
+
+  <!-- つなぎの矢印（仮説→電球→検証） -->
+  <g stroke="#FFD566" stroke-width="2" fill="none" stroke-linecap="round" stroke-dasharray="5 4" opacity="0.7">
+    <path d="M 280 280 Q 340 220 380 200"/>
+    <path d="M 420 200 Q 460 220 520 280"/>
+  </g>
+  <!-- 検証→仮説 (フィードバック) -->
+  <g stroke="#7AAEFF" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.55">
+    <path d="M 600 350 Q 400 380 200 350"/>
+    <polyline points="208,344 198,352 210,358"/>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="60" cy="50" r="1.4"/>
+    <circle cx="180" cy="36" r="1.0"/>
+    <circle cx="700" cy="50" r="1.4"/>
+    <circle cx="740" cy="100" r="1.0"/>
+  </g>
+</svg>

--- a/public/images/v3/course-lateral-01.svg
+++ b/public/images/v3/course-lateral-01.svg
@@ -1,0 +1,104 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-la1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-la1" cx="0.65" cy="0.5" r="0.45">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.36"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="brick-la1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7A5A1F"/>
+      <stop offset="100%" stop-color="#3F2E0F"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-la1)"/>
+  <circle cx="540" cy="200" r="260" fill="url(#glow-la1)"/>
+
+  <ellipse cx="400" cy="358" rx="280" ry="14" fill="#0B1424" opacity="0.6"/>
+
+  <!-- レンガの壁（左半分、堅牢） -->
+  <g transform="translate(200,200)">
+    <!-- 壁の枠 -->
+    <g fill="url(#brick-la1)" stroke="#1A1306" stroke-width="1.5">
+      <!-- 行1 -->
+      <rect x="-180" y="-130" width="62" height="26"/>
+      <rect x="-118" y="-130" width="62" height="26"/>
+      <rect x="-56" y="-130" width="62" height="26"/>
+      <rect x="6" y="-130" width="62" height="26"/>
+      <!-- 行2 -->
+      <rect x="-150" y="-104" width="62" height="26"/>
+      <rect x="-88" y="-104" width="62" height="26"/>
+      <rect x="-26" y="-104" width="62" height="26"/>
+      <rect x="36" y="-104" width="32" height="26"/>
+      <rect x="-180" y="-104" width="30" height="26"/>
+      <!-- 行3 -->
+      <rect x="-180" y="-78" width="62" height="26"/>
+      <rect x="-118" y="-78" width="62" height="26"/>
+      <rect x="-56" y="-78" width="62" height="26"/>
+      <rect x="6" y="-78" width="62" height="26"/>
+      <!-- 行4 -->
+      <rect x="-150" y="-52" width="62" height="26"/>
+      <rect x="-88" y="-52" width="62" height="26"/>
+      <rect x="-26" y="-52" width="62" height="26"/>
+      <rect x="36" y="-52" width="32" height="26"/>
+      <rect x="-180" y="-52" width="30" height="26"/>
+      <!-- 行5（穴の上） -->
+      <rect x="-180" y="-26" width="62" height="26"/>
+      <rect x="-118" y="-26" width="62" height="26"/>
+      <rect x="6" y="-26" width="62" height="26"/>
+      <!-- 行6（下） -->
+      <rect x="-150" y="0" width="62" height="26"/>
+      <rect x="-88" y="0" width="62" height="26"/>
+      <rect x="-26" y="0" width="62" height="26"/>
+      <rect x="36" y="0" width="32" height="26"/>
+      <rect x="-180" y="0" width="30" height="26"/>
+      <!-- 行7 -->
+      <rect x="-180" y="26" width="62" height="26"/>
+      <rect x="-118" y="26" width="62" height="26"/>
+      <rect x="-56" y="26" width="62" height="26"/>
+      <rect x="6" y="26" width="62" height="26"/>
+    </g>
+
+    <!-- 隙間（突破口）－光が漏れる -->
+    <rect x="-56" y="-26" width="62" height="26" fill="#FFD566" opacity="0.18"/>
+    <g stroke="#FFD566" stroke-width="2" opacity="0.85" fill="none">
+      <line x1="-30" y1="-13" x2="120" y2="-50" stroke-linecap="round"/>
+      <line x1="-30" y1="-13" x2="130" y2="-13" stroke-linecap="round"/>
+      <line x1="-30" y1="-13" x2="120" y2="22" stroke-linecap="round"/>
+    </g>
+  </g>
+
+  <!-- 突破した先（右、明るい風景：開けた空・道） -->
+  <g transform="translate(560,210)">
+    <!-- 空 -->
+    <rect x="-120" y="-130" width="240" height="200" rx="10" fill="#1A2540" opacity="0.4"/>
+    <!-- 太陽 -->
+    <circle cx="40" cy="-80" r="22" fill="#FFD566"/>
+    <g stroke="#FFD566" stroke-width="2" opacity="0.7" stroke-linecap="round">
+      <line x1="40" y1="-110" x2="40" y2="-118"/>
+      <line x1="68" y1="-80" x2="76" y2="-80"/>
+      <line x1="60" y1="-100" x2="66" y2="-106"/>
+      <line x1="20" y1="-100" x2="14" y2="-106"/>
+    </g>
+    <!-- 道（地平線） -->
+    <polygon points="-110,68 110,68 70,-10 -70,-10" fill="#3B5BBF" opacity="0.5"/>
+    <line x1="0" y1="-10" x2="0" y2="68" stroke="#FFD566" stroke-width="2" stroke-dasharray="6 4" opacity="0.85"/>
+    <!-- 山並み -->
+    <polygon points="-110,-10 -50,-50 0,-30 50,-60 110,-10" fill="#1B2954" opacity="0.85"/>
+  </g>
+
+  <!-- 矢印（穴を抜ける動線） -->
+  <g stroke="#FFD566" stroke-width="3" fill="#FFD566" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="200" y1="187" x2="430" y2="187"/>
+    <polygon points="424,178 444,187 424,196"/>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="80" cy="50" r="1.4"/>
+    <circle cx="220" cy="36" r="1.0"/>
+    <circle cx="700" cy="60" r="1.4"/>
+  </g>
+</svg>

--- a/public/images/v3/course-logic-01.svg
+++ b/public/images/v3/course-logic-01.svg
@@ -1,0 +1,81 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-l1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-l1" cx="0.5" cy="0.4" r="0.5">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="board-l1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F4ECC4"/>
+      <stop offset="100%" stop-color="#D8C898"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-l1)"/>
+  <circle cx="400" cy="180" r="260" fill="url(#glow-l1)"/>
+
+  <!-- ホワイトボード -->
+  <g transform="translate(400,200)">
+    <ellipse cx="0" cy="158" rx="280" ry="10" fill="#0B1424" opacity="0.6"/>
+    <rect x="-300" y="-150" width="600" height="300" rx="6" fill="url(#board-l1)" stroke="#3F2E0F" stroke-width="3"/>
+
+    <!-- ロジックツリー（左半分） -->
+    <g stroke="#3B5BBF" stroke-width="1.6" fill="none">
+      <!-- 根ノード -->
+      <rect x="-260" y="-30" width="80" height="36" rx="4" fill="#3B5BBF" opacity="0.92"/>
+      <!-- 第1階層 -->
+      <line x1="-180" y1="-12" x2="-150" y2="-90"/>
+      <line x1="-180" y1="-12" x2="-150" y2="-12"/>
+      <line x1="-180" y1="-12" x2="-150" y2="66"/>
+      <rect x="-150" y="-104" width="70" height="28" rx="3" fill="#7AAEFF" opacity="0.85" stroke="none"/>
+      <rect x="-150" y="-26" width="70" height="28" rx="3" fill="#7AAEFF" opacity="0.85" stroke="none"/>
+      <rect x="-150" y="52" width="70" height="28" rx="3" fill="#7AAEFF" opacity="0.85" stroke="none"/>
+      <!-- 第2階層 -->
+      <line x1="-80" y1="-90" x2="-50" y2="-110"/>
+      <line x1="-80" y1="-90" x2="-50" y2="-72"/>
+      <line x1="-80" y1="-12" x2="-50" y2="-32"/>
+      <line x1="-80" y1="-12" x2="-50" y2="8"/>
+      <line x1="-80" y1="66" x2="-50" y2="50"/>
+      <line x1="-80" y1="66" x2="-50" y2="86"/>
+      <g fill="#C49A3C" stroke="none">
+        <rect x="-50" y="-118" width="50" height="18" rx="3"/>
+        <rect x="-50" y="-82" width="50" height="18" rx="3"/>
+        <rect x="-50" y="-42" width="50" height="18" rx="3"/>
+        <rect x="-50" y="-2" width="50" height="18" rx="3"/>
+        <rect x="-50" y="40" width="50" height="18" rx="3"/>
+        <rect x="-50" y="78" width="50" height="18" rx="3"/>
+      </g>
+    </g>
+
+    <!-- MECE グリッド（右半分） -->
+    <g transform="translate(150,-100)">
+      <text x="0" y="-12" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="14" font-weight="700" fill="#3F2E0F">MECE</text>
+      <g stroke="#3F2E0F" stroke-width="1.4" fill="none">
+        <rect x="0" y="0" width="60" height="48" fill="#3B5BBF" opacity="0.85" stroke="none"/>
+        <rect x="64" y="0" width="60" height="48" fill="#7A2E2E" opacity="0.85" stroke="none"/>
+        <rect x="0" y="52" width="60" height="48" fill="#C49A3C" opacity="0.85" stroke="none"/>
+        <rect x="64" y="52" width="60" height="48" fill="#3F8C5F" opacity="0.85" stroke="none"/>
+      </g>
+      <!-- 細い罫線 -->
+      <line x1="-10" y1="116" x2="134" y2="116" stroke="#3F2E0F" stroke-width="1" opacity="0.5"/>
+      <line x1="-10" y1="124" x2="100" y2="124" stroke="#3F2E0F" stroke-width="1" opacity="0.4"/>
+    </g>
+
+    <!-- マーカー -->
+    <g transform="translate(190,110) rotate(28)">
+      <rect x="0" y="-6" width="46" height="12" rx="2" fill="#3B5BBF"/>
+      <rect x="46" y="-6" width="14" height="12" fill="#1A2540"/>
+      <polygon points="60,-6 70,0 60,6" fill="#1A2540"/>
+    </g>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="80" cy="50" r="1.4"/>
+    <circle cx="200" cy="36" r="1.0"/>
+    <circle cx="700" cy="50" r="1.4"/>
+    <circle cx="730" cy="80" r="1.0"/>
+  </g>
+</svg>

--- a/public/images/v3/course-philosophy-01.svg
+++ b/public/images/v3/course-philosophy-01.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-ph1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-ph1" cx="0.5" cy="0.3" r="0.5">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.36"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="column-ph1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F4ECC4"/>
+      <stop offset="100%" stop-color="#9B8A4F"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-ph1)"/>
+  <circle cx="400" cy="120" r="280" fill="url(#glow-ph1)"/>
+
+  <!-- 床（神殿の段差） -->
+  <rect x="0" y="340" width="800" height="60" fill="#0E1424"/>
+  <rect x="60" y="330" width="680" height="14" fill="#3F2E0F" opacity="0.7"/>
+  <rect x="100" y="320" width="600" height="12" fill="#5A4214" opacity="0.7"/>
+
+  <!-- 光線（上から降り注ぐ） -->
+  <g opacity="0.55">
+    <polygon points="280,0 240,340 320,340" fill="#FFD566" opacity="0.18"/>
+    <polygon points="400,0 370,340 430,340" fill="#FFD566" opacity="0.22"/>
+    <polygon points="520,0 480,340 560,340" fill="#FFD566" opacity="0.18"/>
+  </g>
+
+  <!-- 神殿の柱（3本） -->
+  <g>
+    <!-- 左柱 -->
+    <g transform="translate(200,200)">
+      <!-- 柱頭 -->
+      <rect x="-30" y="-90" width="60" height="14" fill="url(#column-ph1)"/>
+      <rect x="-26" y="-100" width="52" height="10" fill="#C9B57A"/>
+      <!-- 柱身 -->
+      <rect x="-22" y="-76" width="44" height="194" fill="url(#column-ph1)"/>
+      <!-- 縦溝 -->
+      <g stroke="#9B8A4F" stroke-width="1" opacity="0.7">
+        <line x1="-12" y1="-76" x2="-12" y2="118"/>
+        <line x1="0" y1="-76" x2="0" y2="118"/>
+        <line x1="12" y1="-76" x2="12" y2="118"/>
+      </g>
+      <!-- 柱基 -->
+      <rect x="-30" y="118" width="60" height="14" fill="url(#column-ph1)"/>
+    </g>
+    <!-- 中央柱 -->
+    <g transform="translate(400,180)">
+      <rect x="-32" y="-110" width="64" height="14" fill="url(#column-ph1)"/>
+      <rect x="-28" y="-122" width="56" height="12" fill="#C9B57A"/>
+      <rect x="-24" y="-96" width="48" height="234" fill="url(#column-ph1)"/>
+      <g stroke="#9B8A4F" stroke-width="1" opacity="0.7">
+        <line x1="-14" y1="-96" x2="-14" y2="138"/>
+        <line x1="0" y1="-96" x2="0" y2="138"/>
+        <line x1="14" y1="-96" x2="14" y2="138"/>
+      </g>
+      <rect x="-32" y="138" width="64" height="14" fill="url(#column-ph1)"/>
+    </g>
+    <!-- 右柱 -->
+    <g transform="translate(600,200)">
+      <rect x="-30" y="-90" width="60" height="14" fill="url(#column-ph1)"/>
+      <rect x="-26" y="-100" width="52" height="10" fill="#C9B57A"/>
+      <rect x="-22" y="-76" width="44" height="194" fill="url(#column-ph1)"/>
+      <g stroke="#9B8A4F" stroke-width="1" opacity="0.7">
+        <line x1="-12" y1="-76" x2="-12" y2="118"/>
+        <line x1="0" y1="-76" x2="0" y2="118"/>
+        <line x1="12" y1="-76" x2="12" y2="118"/>
+      </g>
+      <rect x="-30" y="118" width="60" height="14" fill="url(#column-ph1)"/>
+    </g>
+  </g>
+
+  <!-- 浮かぶクエスチョンマーク（金色、思考） -->
+  <g font-family="'Cormorant Garamond','Times New Roman',serif" font-weight="700" fill="#FFD566">
+    <text x="120" y="120" font-size="48" opacity="0.9">?</text>
+    <text x="320" y="80" font-size="32" opacity="0.6">?</text>
+    <text x="500" y="100" font-size="38" opacity="0.85">?</text>
+    <text x="700" y="140" font-size="30" opacity="0.5">?</text>
+  </g>
+
+  <!-- 開いた書物（中央前景） -->
+  <g transform="translate(400,330)">
+    <ellipse cx="0" cy="22" rx="100" ry="6" fill="#0B1424" opacity="0.7"/>
+    <polygon points="-90,-30 0,-44 90,-30 90,18 0,4 -90,18" fill="#F4ECC4"/>
+    <line x1="0" y1="-44" x2="0" y2="4" stroke="#7A5A1F" stroke-width="1" opacity="0.6"/>
+    <g stroke="#3F2E0F" stroke-width="0.7" opacity="0.5">
+      <line x1="-80" y1="-26" x2="-12" y2="-32"/>
+      <line x1="-80" y1="-16" x2="-14" y2="-22"/>
+      <line x1="-80" y1="-6" x2="-12" y2="-12"/>
+      <line x1="12" y1="-32" x2="80" y2="-26"/>
+      <line x1="12" y1="-22" x2="76" y2="-16"/>
+      <line x1="12" y1="-12" x2="80" y2="-6"/>
+    </g>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.55">
+    <circle cx="80" cy="50" r="1.4"/>
+    <circle cx="160" cy="40" r="1.2"/>
+    <circle cx="660" cy="50" r="1.4"/>
+    <circle cx="730" cy="80" r="1.0"/>
+  </g>
+</svg>

--- a/public/images/v3/course-problem-01.svg
+++ b/public/images/v3/course-problem-01.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-pr1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-pr1" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.32"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="water" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3B5BBF" stop-opacity="0.7"/>
+      <stop offset="100%" stop-color="#1B2954" stop-opacity="0.95"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-pr1)"/>
+  <circle cx="400" cy="180" r="260" fill="url(#glow-pr1)"/>
+
+  <!-- 水面 -->
+  <rect x="0" y="200" width="800" height="200" fill="url(#water)"/>
+  <line x1="0" y1="200" x2="800" y2="200" stroke="#7AAEFF" stroke-width="1.2" opacity="0.7"/>
+  <g stroke="#7AAEFF" stroke-width="0.8" opacity="0.4">
+    <line x1="60" y1="220" x2="160" y2="220"/>
+    <line x1="240" y1="240" x2="340" y2="240"/>
+    <line x1="500" y1="230" x2="600" y2="230"/>
+    <line x1="660" y1="260" x2="740" y2="260"/>
+  </g>
+
+  <!-- 氷山（中央、tipは小さくbottomは巨大） -->
+  <g transform="translate(400,200)">
+    <!-- 水面下の本体（巨大） -->
+    <polygon points="-180,0 180,0 140,180 -140,180" fill="#7AAEFF" opacity="0.55"/>
+    <polygon points="-150,0 150,0 110,160 -110,160" fill="#3B5BBF" opacity="0.6"/>
+    <!-- 影/陰影 -->
+    <polygon points="-180,0 -90,0 -50,180 -140,180" fill="#1B2954" opacity="0.4"/>
+    <!-- 表面に出ている見える部分（小さい） -->
+    <polygon points="-50,0 50,0 30,-60 -30,-60" fill="#F4ECC4"/>
+    <polygon points="-50,0 -10,0 -22,-46 -30,-60" fill="#C9B57A"/>
+    <!-- ハイライト -->
+    <line x1="-22" y1="-46" x2="20" y2="-30" stroke="#F4ECC4" stroke-width="1" opacity="0.7"/>
+  </g>
+
+  <!-- 「症状」ラベル（水面上） -->
+  <g transform="translate(490,150)">
+    <rect x="-50" y="-16" width="100" height="32" rx="4" fill="#1A2540" stroke="#FFD566" stroke-width="1.2"/>
+    <text x="0" y="-2" text-anchor="middle" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="10" fill="#7AAEFF" opacity="0.85">表面の</text>
+    <text x="0" y="11" text-anchor="middle" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="11" font-weight="700" fill="#FFD566">症状</text>
+  </g>
+  <line x1="440" y1="160" x2="400" y2="180" stroke="#FFD566" stroke-width="1" stroke-dasharray="3 3" opacity="0.6"/>
+
+  <!-- 「本当の問題」ラベル（水面下） -->
+  <g transform="translate(620,330)">
+    <rect x="-70" y="-16" width="140" height="32" rx="4" fill="#1A2540" stroke="#C49A3C" stroke-width="1.4"/>
+    <text x="0" y="-2" text-anchor="middle" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="10" fill="#7AAEFF" opacity="0.85">深層にある</text>
+    <text x="0" y="11" text-anchor="middle" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="11" font-weight="700" fill="#C49A3C">本当の問題</text>
+  </g>
+  <line x1="550" y1="330" x2="500" y2="320" stroke="#C49A3C" stroke-width="1" stroke-dasharray="3 3" opacity="0.6"/>
+
+  <!-- 矢印（症状→深層へ掘り下げ） -->
+  <g stroke="#FFD566" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.85">
+    <path d="M 200 160 Q 200 250 200 340"/>
+    <polyline points="190,330 200,344 210,330"/>
+  </g>
+  <text x="180" y="250" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="10" fill="#FFD566" opacity="0.85">深掘り</text>
+
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="80" cy="50" r="1.4"/>
+    <circle cx="220" cy="36" r="1.0"/>
+    <circle cx="660" cy="50" r="1.4"/>
+    <circle cx="730" cy="80" r="1.0"/>
+  </g>
+</svg>

--- a/public/images/v3/course-proposal-01.svg
+++ b/public/images/v3/course-proposal-01.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-p1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-p1" cx="0.55" cy="0.45" r="0.45">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.32"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="paper-p1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F4ECC4"/>
+      <stop offset="100%" stop-color="#D8C898"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-p1)"/>
+
+  <g stroke="#2A3656" stroke-width="1" opacity="0.25">
+    <line x1="0" y1="100" x2="800" y2="100"/>
+    <line x1="0" y1="200" x2="800" y2="200"/>
+    <line x1="0" y1="300" x2="800" y2="300"/>
+  </g>
+
+  <circle cx="440" cy="180" r="240" fill="url(#glow-p1)"/>
+
+  <!-- 提案書（中央） -->
+  <g transform="translate(280,90)">
+    <rect x="0" y="0" width="220" height="260" rx="4" fill="url(#paper-p1)"/>
+    <rect x="0" y="0" width="220" height="36" fill="#3B5BBF" opacity="0.9"/>
+    <line x1="20" y1="58" x2="200" y2="58" stroke="#3F2E0F" stroke-width="2.4" opacity="0.85"/>
+    <g stroke="#3F2E0F" stroke-width="1.2" opacity="0.55">
+      <line x1="20" y1="80" x2="195" y2="80"/>
+      <line x1="20" y1="100" x2="180" y2="100"/>
+      <line x1="20" y1="120" x2="200" y2="120"/>
+      <line x1="20" y1="140" x2="170" y2="140"/>
+      <line x1="20" y1="170" x2="195" y2="170"/>
+      <line x1="20" y1="190" x2="185" y2="190"/>
+      <line x1="20" y1="210" x2="200" y2="210"/>
+      <line x1="20" y1="230" x2="160" y2="230"/>
+    </g>
+    <!-- アクセントの強調行 -->
+    <rect x="20" y="138" width="150" height="6" fill="#C49A3C" opacity="0.85"/>
+  </g>
+
+  <!-- 矢印（提案→決断） -->
+  <g stroke="#FFD566" stroke-width="3.5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 520 220 Q 580 200 620 220"/>
+    <polyline points="612,210 622,222 612,232"/>
+  </g>
+
+  <!-- 決断（チェックマーク+円） -->
+  <g transform="translate(680,220)">
+    <circle cx="0" cy="0" r="42" fill="#1A2540" stroke="#FFD566" stroke-width="2.5"/>
+    <polyline points="-18,2 -4,16 20,-12" stroke="#FFD566" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <!-- 床の影 -->
+  <ellipse cx="390" cy="358" rx="160" ry="10" fill="#0B1424" opacity="0.6"/>
+  <ellipse cx="680" cy="280" rx="50" ry="6" fill="#0B1424" opacity="0.5"/>
+
+  <!-- 細かい星 -->
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="80" cy="60" r="1.4"/>
+    <circle cx="180" cy="40" r="1.2"/>
+    <circle cx="260" cy="60" r="1.0"/>
+    <circle cx="660" cy="60" r="1.4"/>
+    <circle cx="740" cy="90" r="1.2"/>
+    <circle cx="100" cy="320" r="1.2"/>
+  </g>
+</svg>

--- a/public/images/v3/course-proposal-course-01.svg
+++ b/public/images/v3/course-proposal-course-01.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-pc1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-pc1" cx="0.55" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#FFD566" stop-opacity="0.34"/>
+      <stop offset="100%" stop-color="#FFD566" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="paper-pc1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F4ECC4"/>
+      <stop offset="100%" stop-color="#D8C898"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-pc1)"/>
+
+  <circle cx="500" cy="200" r="260" fill="url(#glow-pc1)"/>
+
+  <!-- 下書きの紙（散らばる、左奥） -->
+  <g transform="translate(160,210) rotate(-12)" opacity="0.7">
+    <rect x="-90" y="-60" width="180" height="120" rx="2" fill="url(#paper-pc1)" opacity="0.8"/>
+    <g stroke="#3F2E0F" stroke-width="1" opacity="0.4">
+      <line x1="-78" y1="-40" x2="78" y2="-40"/>
+      <line x1="-78" y1="-20" x2="60" y2="-20"/>
+      <line x1="-78" y1="0" x2="70" y2="0"/>
+      <line x1="-78" y1="20" x2="50" y2="20"/>
+    </g>
+    <!-- 修正線 -->
+    <line x1="-60" y1="-22" x2="20" y2="-18" stroke="#7A2E2E" stroke-width="2" opacity="0.7"/>
+  </g>
+
+  <g transform="translate(220,270) rotate(8)" opacity="0.85">
+    <rect x="-90" y="-60" width="180" height="120" rx="2" fill="url(#paper-pc1)" opacity="0.9"/>
+    <g stroke="#3F2E0F" stroke-width="1" opacity="0.45">
+      <line x1="-78" y1="-40" x2="78" y2="-40"/>
+      <line x1="-78" y1="-20" x2="65" y2="-20"/>
+      <line x1="-78" y1="0" x2="70" y2="0"/>
+      <line x1="-78" y1="20" x2="55" y2="20"/>
+    </g>
+    <!-- チェックと書き込み -->
+    <polyline points="-50,4 -42,12 -28,-2" stroke="#3B5BBF" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <!-- 仕上げの一冊（中央、光沢） -->
+  <g transform="translate(490,200)">
+    <ellipse cx="0" cy="138" rx="140" ry="10" fill="#0B1424" opacity="0.65"/>
+    <rect x="-110" y="-130" width="220" height="270" rx="4" fill="url(#paper-pc1)"/>
+    <!-- ヘッダ -->
+    <rect x="-110" y="-130" width="220" height="40" fill="#1A2540"/>
+    <rect x="-110" y="-130" width="220" height="40" fill="url(#glow-pc1)" opacity="0.5"/>
+    <line x1="-90" y1="-110" x2="60" y2="-110" stroke="#FFD566" stroke-width="2"/>
+    <!-- 本文行 -->
+    <g stroke="#3F2E0F" stroke-width="1.3" opacity="0.6">
+      <line x1="-90" y1="-70" x2="80" y2="-70"/>
+      <line x1="-90" y1="-50" x2="60" y2="-50"/>
+      <line x1="-90" y1="-30" x2="80" y2="-30"/>
+      <line x1="-90" y1="-10" x2="40" y2="-10"/>
+    </g>
+    <!-- 仮説→検証の矢印（中段） -->
+    <g stroke="#3B5BBF" stroke-width="2" fill="none" stroke-linecap="round">
+      <circle cx="-70" cy="30" r="6" fill="#3B5BBF" opacity="0.85"/>
+      <circle cx="0" cy="30" r="6" fill="#C49A3C"/>
+      <circle cx="70" cy="30" r="6" fill="#3B5BBF" opacity="0.85"/>
+      <line x1="-60" y1="30" x2="-10" y2="30"/>
+      <line x1="10" y1="30" x2="60" y2="30"/>
+    </g>
+    <g stroke="#3F2E0F" stroke-width="1.3" opacity="0.5">
+      <line x1="-90" y1="60" x2="80" y2="60"/>
+      <line x1="-90" y1="80" x2="50" y2="80"/>
+      <line x1="-90" y1="100" x2="80" y2="100"/>
+    </g>
+  </g>
+
+  <!-- 万年筆 -->
+  <g transform="translate(630,300) rotate(-25)">
+    <line x1="0" y1="0" x2="56" y2="0" stroke="#1A1F2E" stroke-width="6" stroke-linecap="round"/>
+    <line x1="56" y1="0" x2="76" y2="0" stroke="#C49A3C" stroke-width="6" stroke-linecap="round"/>
+    <polygon points="76,0 86,-2 86,2" fill="#1A1F2E"/>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="60" cy="50" r="1.4"/>
+    <circle cx="160" cy="40" r="1.2"/>
+    <circle cx="700" cy="60" r="1.4"/>
+    <circle cx="730" cy="100" r="1.0"/>
+  </g>
+</svg>

--- a/public/images/v3/course-strategy-01.svg
+++ b/public/images/v3/course-strategy-01.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-s1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-s1" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#C49A3C" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#C49A3C" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="board-light" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F4ECC4"/>
+      <stop offset="100%" stop-color="#C9B57A"/>
+    </linearGradient>
+    <linearGradient id="board-dark" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3F2E0F"/>
+      <stop offset="100%" stop-color="#1A1306"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-s1)"/>
+  <circle cx="400" cy="200" r="280" fill="url(#glow-s1)"/>
+
+  <!-- 床の影 -->
+  <ellipse cx="400" cy="350" rx="240" ry="14" fill="#0B1424" opacity="0.7"/>
+
+  <!-- チェス盤（俯瞰風、台形にゆがませる） -->
+  <g transform="translate(400,250)">
+    <!-- 外枠 -->
+    <polygon points="-220,80 220,80 160,-60 -160,-60" fill="#1A2540" stroke="#C49A3C" stroke-width="2"/>
+    <!-- 8x8 マス（簡略化4x4で配置感） -->
+    <g>
+      <polygon points="-160,-60 -80,-60 -100,-25 -180,-25" fill="url(#board-light)"/>
+      <polygon points="-80,-60 0,-60 0,-25 -100,-25" fill="url(#board-dark)"/>
+      <polygon points="0,-60 80,-60 100,-25 0,-25" fill="url(#board-light)"/>
+      <polygon points="80,-60 160,-60 180,-25 100,-25" fill="url(#board-dark)"/>
+
+      <polygon points="-180,-25 -100,-25 -120,10 -200,10" fill="url(#board-dark)"/>
+      <polygon points="-100,-25 0,-25 0,10 -120,10" fill="url(#board-light)"/>
+      <polygon points="0,-25 100,-25 120,10 0,10" fill="url(#board-dark)"/>
+      <polygon points="100,-25 180,-25 200,10 120,10" fill="url(#board-light)"/>
+
+      <polygon points="-200,10 -120,10 -140,45 -210,45" fill="url(#board-light)"/>
+      <polygon points="-120,10 0,10 0,45 -140,45" fill="url(#board-dark)"/>
+      <polygon points="0,10 120,10 140,45 0,45" fill="url(#board-light)"/>
+      <polygon points="120,10 200,10 210,45 140,45" fill="url(#board-dark)"/>
+
+      <polygon points="-210,45 -140,45 -160,80 -220,80" fill="url(#board-dark)"/>
+      <polygon points="-140,45 0,45 0,80 -160,80" fill="url(#board-light)"/>
+      <polygon points="0,45 140,45 160,80 0,80" fill="url(#board-dark)"/>
+      <polygon points="140,45 220,45 220,80 160,80" fill="url(#board-light)"/>
+    </g>
+  </g>
+
+  <!-- 駒（簡略化シルエット） -->
+  <!-- キング（中央） -->
+  <g transform="translate(400,210)" fill="#FFD566">
+    <ellipse cx="0" cy="28" rx="18" ry="4" fill="#0B1424" opacity="0.7"/>
+    <rect x="-12" y="6" width="24" height="20" rx="2"/>
+    <ellipse cx="0" cy="6" rx="14" ry="4"/>
+    <rect x="-8" y="-12" width="16" height="20"/>
+    <rect x="-3" y="-22" width="6" height="14"/>
+    <rect x="-8" y="-18" width="16" height="4"/>
+  </g>
+
+  <!-- ナイト（左後） -->
+  <g transform="translate(310,170)" fill="#3B5BBF">
+    <ellipse cx="0" cy="22" rx="15" ry="3.5" fill="#0B1424" opacity="0.7"/>
+    <rect x="-10" y="2" width="20" height="20" rx="2"/>
+    <path d="M -8 0 Q -8 -18 6 -18 Q 14 -18 14 -8 L 14 4 L -8 4 Z"/>
+    <circle cx="6" cy="-10" r="1.5" fill="#1A2540"/>
+  </g>
+
+  <!-- ルーク（右後） -->
+  <g transform="translate(490,170)" fill="#7A2E2E">
+    <ellipse cx="0" cy="22" rx="15" ry="3.5" fill="#0B1424" opacity="0.7"/>
+    <rect x="-10" y="0" width="20" height="22" rx="2"/>
+    <rect x="-12" y="-12" width="24" height="14"/>
+    <rect x="-12" y="-16" width="6" height="6"/>
+    <rect x="-3" y="-16" width="6" height="6"/>
+    <rect x="6" y="-16" width="6" height="6"/>
+  </g>
+
+  <!-- ポーン（前列） -->
+  <g fill="#3B5BBF">
+    <g transform="translate(330,260)">
+      <ellipse cx="0" cy="14" rx="9" ry="2.5" fill="#0B1424" opacity="0.7"/>
+      <rect x="-6" y="-2" width="12" height="14" rx="1"/>
+      <circle cx="0" cy="-6" r="6"/>
+    </g>
+    <g transform="translate(370,260)">
+      <ellipse cx="0" cy="14" rx="9" ry="2.5" fill="#0B1424" opacity="0.7"/>
+      <rect x="-6" y="-2" width="12" height="14" rx="1"/>
+      <circle cx="0" cy="-6" r="6"/>
+    </g>
+    <g transform="translate(430,260)">
+      <ellipse cx="0" cy="14" rx="9" ry="2.5" fill="#0B1424" opacity="0.7"/>
+      <rect x="-6" y="-2" width="12" height="14" rx="1"/>
+      <circle cx="0" cy="-6" r="6"/>
+    </g>
+    <g transform="translate(470,260)">
+      <ellipse cx="0" cy="14" rx="9" ry="2.5" fill="#0B1424" opacity="0.7"/>
+      <rect x="-6" y="-2" width="12" height="14" rx="1"/>
+      <circle cx="0" cy="-6" r="6"/>
+    </g>
+  </g>
+
+  <!-- タイムライン（古典戦略の系譜） -->
+  <g transform="translate(400,80)" stroke="#FFD566" stroke-width="1.4" fill="#FFD566" opacity="0.85">
+    <line x1="-260" y1="0" x2="260" y2="0" stroke-width="1"/>
+    <circle cx="-260" cy="0" r="3"/>
+    <circle cx="-130" cy="0" r="3"/>
+    <circle cx="0" cy="0" r="3"/>
+    <circle cx="130" cy="0" r="3"/>
+    <circle cx="260" cy="0" r="3"/>
+    <text x="-260" y="-10" font-family="'Cormorant Garamond', serif" font-size="11" text-anchor="middle">Taylor</text>
+    <text x="-130" y="-10" font-family="'Cormorant Garamond', serif" font-size="11" text-anchor="middle">Ford</text>
+    <text x="0" y="-10" font-family="'Cormorant Garamond', serif" font-size="11" text-anchor="middle">Ansoff</text>
+    <text x="130" y="-10" font-family="'Cormorant Garamond', serif" font-size="11" text-anchor="middle">PPM</text>
+    <text x="260" y="-10" font-family="'Cormorant Garamond', serif" font-size="11" text-anchor="middle">Porter</text>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="80" cy="40" r="1.4"/>
+    <circle cx="160" cy="50" r="1.0"/>
+    <circle cx="700" cy="50" r="1.4"/>
+    <circle cx="730" cy="80" r="1.0"/>
+  </g>
+</svg>

--- a/public/images/v3/course-systems-01.svg
+++ b/public/images/v3/course-systems-01.svg
@@ -1,0 +1,81 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg-sy1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#101729"/>
+    </linearGradient>
+    <radialGradient id="glow-sy1" cx="0.5" cy="0.45" r="0.5">
+      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="ice-sy1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F4ECC4"/>
+      <stop offset="100%" stop-color="#C9B57A"/>
+    </linearGradient>
+    <linearGradient id="water-sy1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3B5BBF" stop-opacity="0.7"/>
+      <stop offset="100%" stop-color="#1B2954" stop-opacity="0.95"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="400" fill="url(#bg-sy1)"/>
+  <circle cx="400" cy="180" r="260" fill="url(#glow-sy1)"/>
+
+  <!-- 水面 -->
+  <rect x="0" y="190" width="800" height="210" fill="url(#water-sy1)"/>
+  <line x1="0" y1="190" x2="800" y2="190" stroke="#7AAEFF" stroke-width="1.4" opacity="0.7"/>
+
+  <!-- 氷山 -->
+  <g transform="translate(400,190)">
+    <!-- 水面下 -->
+    <polygon points="-150,0 150,0 110,170 -100,170" fill="#3B5BBF" opacity="0.55"/>
+    <polygon points="-130,0 130,0 90,150 -90,150" fill="#3B5BBF" opacity="0.7"/>
+    <polygon points="-150,0 -90,0 -70,170 -100,170" fill="#1B2954" opacity="0.5"/>
+    <!-- 表面 -->
+    <polygon points="-60,0 60,0 36,-70 -38,-70" fill="url(#ice-sy1)"/>
+    <polygon points="-60,0 -16,0 -28,-54 -38,-70" fill="#9B8A4F" opacity="0.7"/>
+    <line x1="-28" y1="-54" x2="22" y2="-32" stroke="#F4ECC4" stroke-width="1" opacity="0.6"/>
+  </g>
+
+  <!-- 氷山の各層ラベル -->
+  <g font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-weight="700">
+    <g transform="translate(620,140)">
+      <text x="0" y="0" font-size="12" fill="#FFD566">事象</text>
+      <line x1="-110" y1="-4" x2="-30" y2="-4" stroke="#FFD566" stroke-width="1" stroke-dasharray="3 3" opacity="0.6"/>
+    </g>
+    <g transform="translate(620,250)">
+      <text x="0" y="0" font-size="12" fill="#7AAEFF">パターン</text>
+      <line x1="-130" y1="-4" x2="-50" y2="-4" stroke="#7AAEFF" stroke-width="1" stroke-dasharray="3 3" opacity="0.6"/>
+    </g>
+    <g transform="translate(620,330)">
+      <text x="0" y="0" font-size="12" fill="#C49A3C">構造</text>
+      <line x1="-110" y1="-4" x2="-30" y2="-4" stroke="#C49A3C" stroke-width="1" stroke-dasharray="3 3" opacity="0.6"/>
+    </g>
+  </g>
+
+  <!-- フィードバックループ（左下、円環矢印） -->
+  <g transform="translate(180,250)">
+    <circle cx="0" cy="0" r="68" fill="none" stroke="#FFD566" stroke-width="3" stroke-dasharray="8 6" opacity="0.85"/>
+    <!-- 矢印頭 -->
+    <polygon points="60,-22 76,-12 60,-2" fill="#FFD566"/>
+    <polygon points="-60,22 -76,12 -60,2" fill="#FFD566"/>
+    <!-- 中心 -->
+    <circle cx="0" cy="0" r="14" fill="#FFD566"/>
+    <text x="0" y="6" text-anchor="middle" font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-size="14" font-weight="700" fill="#1A2540">∞</text>
+    <!-- ノード -->
+    <g fill="#7AAEFF">
+      <circle cx="0" cy="-68" r="8"/>
+      <circle cx="68" cy="0" r="8"/>
+      <circle cx="0" cy="68" r="8"/>
+      <circle cx="-68" cy="0" r="8"/>
+    </g>
+  </g>
+
+  <g fill="#7AAEFF" opacity="0.5">
+    <circle cx="80" cy="50" r="1.4"/>
+    <circle cx="220" cy="36" r="1.0"/>
+    <circle cx="560" cy="50" r="1.2"/>
+    <circle cx="700" cy="50" r="1.4"/>
+    <circle cx="730" cy="80" r="1.0"/>
+  </g>
+</svg>

--- a/src/courseData.ts
+++ b/src/courseData.ts
@@ -183,6 +183,7 @@ export const COURSES: Course[] = [
     lessonIds: [72, 73, 74, 75, 76],
     level: '中級',
     description: '読み手の判断基準から逆算し、決断を引き出す提案書の構造を習得する。',
+    image: '/images/v3/course-proposal-01.svg',
   },
 
   // ── 提案書作成 ──────────────────────────────────────
@@ -194,6 +195,7 @@ export const COURSES: Course[] = [
     lessonIds: [82, 83, 84, 86, 87],
     level: '上級',
     description: 'コンサル的アプローチで仮説を立て、検証しながら説得力のある提案書を完成させる。',
+    image: '/images/v3/course-proposal-course-01.svg',
   },
 
   // ── クライアントワーク ──────────────────────────────
@@ -205,6 +207,7 @@ export const COURSES: Course[] = [
     lessonIds: [89, 90, 91, 92, 97],
     level: '中級',
     description: '桁感覚と概算力を鍛え、クライアントの場でも即座に数字を扱えるようになる。',
+    image: '/images/v3/course-client-01.svg',
   },
   {
     id: 'client-02',
@@ -236,6 +239,7 @@ export const COURSES: Course[] = [
     lessonIds: [28, 29, 35, 36, 316],
     level: '上級',
     description: '利益構造の分解から市場参入まで、ケース面接の頻出テーマを体系的に攻略する。',
+    image: '/images/v3/course-case-01.svg',
   },
 
   // ── 経営戦略 ────────────────────────────────────────
@@ -247,6 +251,7 @@ export const COURSES: Course[] = [
     lessonIds: [320, 321, 322, 323, 324],
     level: '上級',
     description: 'テイラー・フォードからアンゾフ、PPM、ポーターまで。経営戦略の古典理論を通史的に押さえる。',
+    image: '/images/v3/course-strategy-01.svg',
   },
   {
     id: 'strategy-02',
@@ -268,6 +273,7 @@ export const COURSES: Course[] = [
     lessonIds: [200, 201, 202, 203, 204],
     level: '中級',
     description: '数式を立てて分解し、正確さより「だいたい正しい」答えを素早く出す力を鍛える。',
+    image: '/images/v3/course-fermi-01.svg',
   },
 
   // ── 数字に強くなる ──────────────────────────────────

--- a/src/courseData.ts
+++ b/src/courseData.ts
@@ -42,6 +42,7 @@ export const COURSES: Course[] = [
     lessonIds: [20, 21, 22, 23, 24],
     level: '初級',
     description: 'MECEとロジックツリーで、考えを漏れなく・ダブりなく整理する力を身につける。',
+    image: '/images/v3/course-logic-01.svg',
   },
   {
     id: 'logic-02',
@@ -63,6 +64,7 @@ export const COURSES: Course[] = [
     lessonIds: [40, 41, 42, 43, 69],
     level: '初級',
     description: '批判的思考の基礎から論理的誤謬の見破り方まで、判断力を鍛える。',
+    image: '/images/v3/course-critical-01.svg',
   },
   {
     id: 'critical-02',
@@ -84,6 +86,7 @@ export const COURSES: Course[] = [
     lessonIds: [50, 51, 52, 70, 304],
     level: '中級',
     description: '仮説を先に立て、検証で磨く思考サイクルを身につける。',
+    image: '/images/v3/course-hypothesis-01.svg',
   },
 
   // ── 課題設定 ────────────────────────────────────────
@@ -95,6 +98,7 @@ export const COURSES: Course[] = [
     lessonIds: [53, 54, 55, 305, 306],
     level: '中級',
     description: '問題と課題の違いを理解し、本質的な問いを設定する力を養う。',
+    image: '/images/v3/course-problem-01.svg',
   },
 
   // ── デザインシンキング ──────────────────────────────
@@ -106,6 +110,7 @@ export const COURSES: Course[] = [
     lessonIds: [56, 57, 58, 307, 308],
     level: '初級',
     description: '共感からプロトタイプまで、人間中心設計の思考プロセスを実践する。',
+    image: '/images/v3/course-design-01.svg',
   },
 
   // ── システムシンキング ──────────────────────────────
@@ -117,6 +122,7 @@ export const COURSES: Course[] = [
     lessonIds: [65, 66, 67, 313, 314],
     level: '上級',
     description: 'フィードバックループと氷山モデルで、問題の根本原因を構造的に捉える。',
+    image: '/images/v3/course-systems-01.svg',
   },
 
   // ── ラテラルシンキング ──────────────────────────────
@@ -128,6 +134,7 @@ export const COURSES: Course[] = [
     lessonIds: [59, 60, 61, 309, 310],
     level: '中級',
     description: 'リフレーミングと逆転の発想で、固定観念を超えたアイデアを生み出す。',
+    image: '/images/v3/course-lateral-01.svg',
   },
 
   // ── アナロジー思考 ──────────────────────────────────
@@ -139,6 +146,7 @@ export const COURSES: Course[] = [
     lessonIds: [62, 63, 64, 311, 312],
     level: '中級',
     description: '構造的類似性を見抜き、異分野の知見を自分の課題に応用する。',
+    image: '/images/v3/course-analogy-01.svg',
   },
 
   // ── 哲学 ────────────────────────────────────────────
@@ -150,6 +158,7 @@ export const COURSES: Course[] = [
     lessonIds: [77, 78, 79, 80, 81],
     level: '上級',
     description: 'ソクラテスの問答法と反証可能性を通じて、思考の原理を学ぶ。',
+    image: '/images/v3/course-philosophy-01.svg',
   },
 
   // ── 東洋思想 ────────────────────────────────────────


### PR DESCRIPTION
## Summary

- 残り9コース(logic-01, critical-01, hypothesis-01, problem-01, design-01, systems-01, lateral-01, analogy-01, philosophy-01)に対し、既存SVGと統一感のあるシーン重視サムネイルを新規作成
- これにより**全23コースがカスタムサムネイル付き**で表示される

## 新規作成SVG（9件）

| コース | コンセプト |
|---|---|
| `course-logic-01.svg` | ホワイトボード上のロジックツリー + MECE 4分割グリッド |
| `course-critical-01.svg` | 文書を覗き込む虫眼鏡(?→✓)、取り消し線で誤謬を排除 |
| `course-hypothesis-01.svg` | 中央の電球(ひらめき) + 仮説ノート + 検証グラフ + サイクル矢印 |
| `course-problem-01.svg` | 海の氷山(表面の症状/深層の本当の問題) + 深掘り矢印 |
| `course-design-01.svg` | ユーザー人物 + 思考の吹き出し + ワイヤフレーム入りプロトタイプ |
| `course-systems-01.svg` | 氷山(事象/パターン/構造)階層 + フィードバックループ円環 |
| `course-lateral-01.svg` | レンガ壁の突破口から光が漏れ、晴れた風景の道へ抜ける |
| `course-analogy-01.svg` | 左の樹木と右の回路基板を3本の点線で構造的類似性として接続 |
| `course-philosophy-01.svg` | 古代神殿の柱3本+光線+浮遊するクエスチョンマーク+開いた書物 |

すべて既存SVGと同じ作風(800×400、ダーク背景 #1F2942→#101729、暖色スポット光、シーン構成、控えめな星)。

## Test plan

- [ ] `npm run dev` でコース一覧画面を表示し、9コースに新規サムネイルが表示されること
- [ ] 各サムネイルが800×400で適切にスケールすること
- [ ] フォールバック画像が呼ばれていないことを確認(全23コースが`image:`プロパティ付き)

https://claude.ai/code/session_01L6wDEdj49p5XZo4daHzkVs

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6wDEdj49p5XZo4daHzkVs)_