### PR TITLE
ci: 手動トリガー専用の AAB ビルドワークフローを追加

### DIFF
--- a/.github/workflows/build-aab.yml
+++ b/.github/workflows/build-aab.yml
@@ -1,0 +1,142 @@
+name: Build Android AAB (manual)
+
+# 手動トリガー専用。Play Console には自動配信せず、AAB を artifact として
+# ダウンロードできる状態にする。Play Console には手動アップロードする想定。
+#
+# 必要な GitHub Secrets:
+#   ANDROID_KEYSTORE_PASSWORD  キーストア本体のパスワード
+#   ANDROID_KEY_ALIAS          鍵エイリアス (通常 "logic")
+#   ANDROID_KEY_PASSWORD       鍵のパスワード
+#   VITE_API_BASE              (任意) Vite のビルド時 env
+#
+# 使用キーストアはリポジトリにコミット済みの keystores/logic-release.keystore。
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_code_override:
+        description: "versionCode を指定 (空なら build.gradle の値をそのまま使用)"
+        required: false
+        default: ""
+      version_name_override:
+        description: "versionName を指定 (空なら build.gradle の値をそのまま使用)"
+        required: false
+        default: ""
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web (Vite)
+        run: npm run build
+        env:
+          VITE_API_BASE: ${{ secrets.VITE_API_BASE }}
+
+      - name: Add Android platform (if not exists)
+        run: |
+          if [ ! -d "android" ]; then
+            npx cap add android
+          fi
+
+      - name: Capacitor sync
+        run: npx cap sync android
+
+      - name: Override versionCode / versionName (if input given)
+        run: |
+          GRADLE=android/app/build.gradle
+          if [ -n "${{ inputs.version_code_override }}" ]; then
+            sed -i "s/versionCode [0-9]*/versionCode ${{ inputs.version_code_override }}/" "$GRADLE"
+          fi
+          if [ -n "${{ inputs.version_name_override }}" ]; then
+            sed -i "s/versionName \"[^\"]*\"/versionName \"${{ inputs.version_name_override }}\"/" "$GRADLE"
+          fi
+          echo "── effective version ──"
+          grep -E "versionCode|versionName" "$GRADLE"
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-
+
+      - name: Verify required secrets
+        run: |
+          missing=0
+          for s in ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_ALIAS ANDROID_KEY_PASSWORD; do
+            v="${!s}"
+            if [ -z "$v" ]; then
+              echo "::error::Secret $s is not set"
+              missing=1
+            fi
+          done
+          [ "$missing" = "0" ]
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+
+      - name: Write key.properties
+        run: |
+          KEYSTORE_PATH=keystores/logic-release.keystore
+          if [ ! -f "$KEYSTORE_PATH" ]; then
+            echo "::error::Keystore file not found at $KEYSTORE_PATH"
+            exit 1
+          fi
+          cat > android/key.properties << EOF
+          LOGIC_KEYSTORE_FILE=../../keystores/logic-release.keystore
+          LOGIC_KEYSTORE_PASSWORD=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          LOGIC_KEY_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}
+          LOGIC_KEY_PASSWORD=${{ secrets.ANDROID_KEY_PASSWORD }}
+          EOF
+          keytool -list -keystore "$KEYSTORE_PATH" \
+            -storepass "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" \
+            -alias "${{ secrets.ANDROID_KEY_ALIAS }}" \
+            > /dev/null && echo "✓ keystore + password verified"
+
+      - name: Build release AAB
+        working-directory: android
+        run: ./gradlew :app:bundleRelease --stacktrace --no-daemon
+
+      - name: Show AAB info
+        run: |
+          AAB=android/app/build/outputs/bundle/release/app-release.aab
+          ls -lh "$AAB"
+          echo "── sha256 ──"
+          sha256sum "$AAB"
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-aab
+          path: android/app/build/outputs/bundle/release/app-release.aab
+          retention-days: 30
+
+      - name: Cleanup secrets file
+        if: always()
+        run: rm -f android/key.properties


### PR DESCRIPTION
## 概要

Play Console への自動配信を伴わずに、署名付き AAB ファイルを GitHub Actions の artifact としてダウンロードできるワークフローを追加します。手動アップロード派の運用向け。

既存の `android-deploy.yml` は `push: main` で内部テストトラックまで自動配信されるため、「AAB だけ欲しい」ケースで使いづらかったのを補完します。

## 使い方

GitHub Actions タブ → **Build Android AAB (manual)** → **Run workflow**

入力欄 (任意):
- `version_code_override`: 空なら `android/app/build.gradle` の値 (現在 21) をそのまま使用
- `version_name_override`: 空なら現在 `1.5.2` をそのまま使用

完了後、Run の Artifacts から `app-release-aab` をダウンロード → Play Console に手動アップロード。

## 必要な GitHub Secrets

| Secret | 内容 |
|---|---|
| `ANDROID_KEYSTORE_PASSWORD` | キーストア本体のパスワード |
| `ANDROID_KEY_ALIAS` | 鍵エイリアス (通常 `logic`) |
| `ANDROID_KEY_PASSWORD` | 鍵のパスワード |
| `VITE_API_BASE` (任意) | Vite ビルド時 env |

※ 既存の `android-deploy.yml` と同じ secret を共用するので、Play Console 自動配信ワークフローが既に動いているならそのまま使えます。

## 現状のバージョン

Play Store 公開中: `versionCode 20 / versionName 1.5.1`
リポジトリの `android/app/build.gradle`: `versionCode 21 / versionName 1.5.2`

そのまま走らせれば 1.5.2 (21) として AAB が生成されます。

## Test plan

- [ ] Actions タブから Run workflow を実行
- [ ] `keytool -list` ステップで keystore の検証が通ること
- [ ] `app-release.aab` artifact が生成されること
- [ ] ダウンロードした AAB を Play Console の内部テストにアップロードして受理されること

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_014mSejd93An6CdkbRhPpsP2)_