### PR TITLE
Phase 4-4 続: a11y CI 8画面 + V2/V3 全 aria-label 補完 + 未使用 icons 整理 (75% → 76%)

### DIFF
--- a/docs/HIG_MATERIAL_AUDIT_20260504.md
+++ b/docs/HIG_MATERIAL_AUDIT_20260504.md
@@ -15,10 +15,10 @@
 | **Phase 0** リリースブロッカー | 8h | ~8h | ✅ 100% |
 | **Phase 1** デザインシステム土台 | 32h | ~28h | ✅ 88% |
 | **Phase 2** 全画面 HIG/M3 適合 | 60h | ~58h | ✅ 100%（構造的タスク完了） |
-| **Phase 3** 個別最適化 | 80h | ~44h | 🟡 55%（機械的置換 + dead code 大量削除 -3000 行 + vendor split） |
-| **Phase 4** 仕上げ・検証 | 24h | ~14h | 🟡 axe-core blocking + lint blocking + QA |
+| **Phase 3** 個別最適化 | 80h | ~46h | 🟡 58%（機械的置換 + dead code 大量削除 + 未使用 icons 整理） |
+| **Phase 4** 仕上げ・検証 | 24h | ~16h | 🟡 axe-core 8 画面 blocking + 全 input/textarea/icon button に aria-label 補完 |
 
-**累計 ~152h / 204h ≒ 75%**
+**累計 ~156h / 204h ≒ 76%**
 
 ### Phase 3 進捗（2026-05-05 セッション）
 - ✅ 第1波: prefers-reduced-motion + Lesson 系 a11y 強化 (#96)

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -94,4 +94,19 @@ test.describe('a11y / axe-core', () => {
     const results = await buildScanner(page).analyze()
     expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([])
   })
+
+  test('Onboarding screen has no critical accessibility violations', async ({ page }) => {
+    await page.addInitScript(() => {
+      // logic-onboarded を意図的にセットしない → onboarding に進む
+      localStorage.setItem('logic-install-id', 'test')
+    })
+    await page.goto('/?preview=onboarding')
+    // OnboardingScreen は AppShell を介さず full-screen 表示なので
+    // .app-shell ではなく Suspense 解決後の内容ロードを待つ。
+    await page.waitForLoadState('networkidle')
+    // body に何らかの interactive element が出現するまで明示的に待機
+    await page.waitForSelector('button, input', { timeout: 10_000 })
+    const results = await buildScanner(page).analyze()
+    expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([])
+  })
 })

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -82,6 +82,16 @@ test.describe('a11y / axe-core', () => {
     expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([])
   })
 
-  // Onboarding / Pricing は別 PR で違反確認 + 修正 + 追加予定。
-  // 一旦コア 6 画面のみで blocking 運用を維持する。
+  test('Pricing screen has no critical accessibility violations', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('logic-onboarded', '1')
+      localStorage.setItem('logic-install-id', 'test')
+    })
+    await page.goto('/?preview=pricing')
+    await page.waitForSelector('.app-shell', { timeout: 10_000 })
+    // pricing screen のレイアウト遷移完了を待つ (Suspense / fade-in 含む)
+    await page.waitForLoadState('networkidle')
+    const results = await buildScanner(page).analyze()
+    expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([])
+  })
 })

--- a/src/AIProblemGen.tsx
+++ b/src/AIProblemGen.tsx
@@ -64,6 +64,7 @@ export default function AIProblemGen({ onBack, onPlayProblem }: Props) {
           </p>
 
           <textarea
+            aria-label="作りたい問題のテーマや条件"
             className="aip-input"
             placeholder="例: MECEの問題を3問作って"
             value={prompt}

--- a/src/AppV3.tsx
+++ b/src/AppV3.tsx
@@ -623,6 +623,7 @@ function AppV3() {
           </div>
           <input
             type="text"
+            aria-label="表示名"
             placeholder="名前を入力（例：田中 太郎）"
             value={nameInput}
             onChange={e => setNameInput(e.target.value)}

--- a/src/Feedback.tsx
+++ b/src/Feedback.tsx
@@ -90,6 +90,7 @@ export default function Feedback({ onBack }: { onBack: () => void }) {
             </p>
           )}
           <textarea
+            aria-label="フィードバック内容"
             className="fb-textarea"
             placeholder={category === 'バグ報告' ? '例: レッスン第3問目で「次へ」ボタンを押すと画面が白くなる。iOS 17.2、iPhone 15で発生。' : 'アプリの改善点やほしい機能を教えてください...'}
             value={message}

--- a/src/FermiLesson.tsx
+++ b/src/FermiLesson.tsx
@@ -155,6 +155,7 @@ export default function FermiLesson({ onBack, onUpgrade }: Props) {
               <strong>分解のヒント</strong>：「対象・場所・頻度」の順に考えると整理しやすい。
             </div>
             <textarea
+              aria-label="フェルミ推定の解答"
               className="fl-textarea"
               value={userInput}
               onChange={(e) => setUserInput(e.target.value)}

--- a/src/ReportProblem.tsx
+++ b/src/ReportProblem.tsx
@@ -93,6 +93,7 @@ export default function ReportProblem({ lessonTitle, lessonId, question, options
             <div className="rp-field">
               <div className="rp-label">詳細（任意）</div>
               <textarea
+                aria-label="詳細（任意）"
                 className="rp-textarea"
                 placeholder="どこが間違っているか、何が不明か..."
                 value={comment}

--- a/src/components/ActionSheet.tsx
+++ b/src/components/ActionSheet.tsx
@@ -41,7 +41,7 @@ export function ActionSheet({ open, title, message, items, onSelect, onCancel }:
 
   return createPortal(
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events -- scrim タップでの dismiss は意図通り (キーボードは Escape で代替済)
-    <div className="m3-sheet__scrim" role="dialog" aria-modal="true" onClick={onCancel}>
+    <div className="m3-sheet__scrim" role="dialog" aria-modal="true" aria-label={title ?? 'Options'} onClick={onCancel}>
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- sheet 本体内クリックは event 伝播停止のみ */}
       <div
         className="m3-sheet"

--- a/src/icons/index.tsx
+++ b/src/icons/index.tsx
@@ -12,33 +12,6 @@ const base = {
   strokeLinejoin: 'round' as const,
 }
 
-export function HomeIcon(p: IconProps) {
-  return (
-    <svg {...base} {...p}>
-      <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-      <polyline points="9 22 9 12 15 12 15 22" />
-    </svg>
-  )
-}
-
-export function BookIcon(p: IconProps) {
-  return (
-    <svg {...base} {...p}>
-      <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
-      <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
-    </svg>
-  )
-}
-
-export function UserIcon(p: IconProps) {
-  return (
-    <svg {...base} {...p}>
-      <circle cx="12" cy="8" r="4" />
-      <path d="M4 21v-1a7 7 0 0 1 14 0v1" />
-    </svg>
-  )
-}
-
 export function ArrowLeftIcon(p: IconProps) {
   return (
     <svg {...base} strokeWidth={2.5} {...p}>
@@ -53,15 +26,6 @@ export function ArrowRightIcon(p: IconProps) {
     <svg {...base} strokeWidth={2.5} {...p}>
       <line x1="5" y1="12" x2="19" y2="12" />
       <polyline points="12 5 19 12 12 19" />
-    </svg>
-  )
-}
-
-export function SettingsIcon(p: IconProps) {
-  return (
-    <svg {...base} {...p}>
-      <circle cx="12" cy="12" r="3" />
-      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
     </svg>
   )
 }
@@ -103,16 +67,6 @@ export function TrophyIcon(p: IconProps) {
   )
 }
 
-export function TargetIcon(p: IconProps) {
-  return (
-    <svg {...base} {...p}>
-      <circle cx="12" cy="12" r="10" />
-      <circle cx="12" cy="12" r="6" />
-      <circle cx="12" cy="12" r="2" />
-    </svg>
-  )
-}
-
 export function ChevronRightIcon(p: IconProps) {
   return (
     <svg {...base} {...p}>
@@ -136,44 +90,6 @@ export function BarChartIcon(p: IconProps) {
       <line x1="18" y1="20" x2="18" y2="10" />
       <line x1="12" y1="20" x2="12" y2="4" />
       <line x1="6" y1="20" x2="6" y2="14" />
-    </svg>
-  )
-}
-
-export function TrendingUpIcon(p: IconProps) {
-  return (
-    <svg {...base} {...p}>
-      <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
-      <polyline points="17 6 23 6 23 12" />
-    </svg>
-  )
-}
-
-export function MessageCircleIcon(p: IconProps) {
-  return (
-    <svg {...base} {...p}>
-      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-    </svg>
-  )
-}
-
-export function LayersIcon(p: IconProps) {
-  return (
-    <svg {...base} {...p}>
-      <polygon points="12 2 2 7 12 12 22 7 12 2" />
-      <polyline points="2 17 12 22 22 17" />
-      <polyline points="2 12 12 17 22 12" />
-    </svg>
-  )
-}
-
-export function CalendarIcon(p: IconProps) {
-  return (
-    <svg {...base} {...p}>
-      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
-      <line x1="16" y1="2" x2="16" y2="6" />
-      <line x1="8" y1="2" x2="8" y2="6" />
-      <line x1="3" y1="10" x2="21" y2="10" />
     </svg>
   )
 }
@@ -209,17 +125,6 @@ export function BookOpenIcon(p: IconProps) {
   )
 }
 
-export function TableIcon(p: IconProps) {
-  return (
-    <svg {...base} {...p}>
-      <rect x="3" y="3" width="18" height="18" rx="2" />
-      <line x1="3" y1="9" x2="21" y2="9" />
-      <line x1="3" y1="15" x2="21" y2="15" />
-      <line x1="9" y1="3" x2="9" y2="21" />
-    </svg>
-  )
-}
-
 export function LightbulbIcon(p: IconProps) {
   return (
     <svg {...base} {...p}>
@@ -230,28 +135,11 @@ export function LightbulbIcon(p: IconProps) {
   )
 }
 
-export function ZapIcon(p: IconProps) {
-  return (
-    <svg {...base} {...p}>
-      <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
-    </svg>
-  )
-}
-
 export function CheckCircleIcon(p: IconProps) {
   return (
     <svg {...base} {...p}>
       <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
       <polyline points="22 4 12 14.01 9 11.01" />
-    </svg>
-  )
-}
-
-export function BriefcaseIcon(p: IconProps) {
-  return (
-    <svg {...base} {...p}>
-      <rect x="2" y="7" width="20" height="14" rx="2" ry="2" />
-      <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16" />
     </svg>
   )
 }
@@ -293,40 +181,11 @@ export function XIcon(p: IconProps) {
   )
 }
 
-export function FlagIcon(p: IconProps) {
-  return (
-    <svg {...base} {...p}>
-      <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
-      <line x1="4" y1="22" x2="4" y2="15" />
-    </svg>
-  )
-}
-
 export function ThumbsUpIcon(p: IconProps) {
   return (
     <svg {...base} {...p}>
       <path d="M7 10v12" />
       <path d="M15 5.88L14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H7V10l4.42-9a1.5 1.5 0 0 1 2.7 1.04l-.12 3.84z" />
-    </svg>
-  )
-}
-
-export function AlertTriangleIcon(p: IconProps) {
-  return (
-    <svg {...base} {...p}>
-      <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
-      <line x1="12" y1="9" x2="12" y2="13" />
-      <line x1="12" y1="17" x2="12.01" y2="17" />
-    </svg>
-  )
-}
-
-export function InfoIcon(p: IconProps) {
-  return (
-    <svg {...base} {...p}>
-      <circle cx="12" cy="12" r="10" />
-      <line x1="12" y1="16" x2="12" y2="12" />
-      <line x1="12" y1="8" x2="12.01" y2="8" />
     </svg>
   )
 }

--- a/src/screens/AIProblemGenScreen.tsx
+++ b/src/screens/AIProblemGenScreen.tsx
@@ -149,6 +149,7 @@ function RatingPopup({ onSubmit, onSkip }: RatingPopupProps) {
         </div>
         {/* コメント */}
         <textarea
+          aria-label="感想・改善点（任意）"
           value={comment}
           onChange={e => setComment(e.target.value)}
           placeholder="感想・改善点など（任意）"
@@ -296,6 +297,7 @@ export function AIProblemGenScreen({ onBack, onPlay, onUpgrade }: AIProblemGenSc
               <div style={{ fontSize: 13, fontWeight: 700, color: v3.color.text, marginBottom: 6 }}>どんな問題を作る？</div>
               <div style={{ fontSize: 12, color: v3.color.text2, marginBottom: 10 }}>テーマや条件を自由に入力してね</div>
               <textarea
+                aria-label="作りたい問題のテーマや条件"
                 value={prompt}
                 onChange={e => setPrompt(e.target.value)}
                 placeholder="例：MECEを使った問題を3問（コンビニのターゲット分析）"

--- a/src/screens/AIProblemScreen.tsx
+++ b/src/screens/AIProblemScreen.tsx
@@ -148,6 +148,7 @@ export function AIProblemScreen({ problem, onBack, onReport }: AIProblemScreenPr
               自分の言葉でまとめてみよう（任意）
             </label>
             <textarea
+              aria-label="自分の言葉でまとめる"
               value={thinkingNote}
               onChange={(e) => setThinkingNote(e.target.value)}
               placeholder="理解したことや気づいたことをメモ..."

--- a/src/screens/AccountSettingsScreen.tsx
+++ b/src/screens/AccountSettingsScreen.tsx
@@ -87,6 +87,7 @@ export function AccountSettingsScreen({ onBack, currentUser, onOpenLogin, onLogo
                 <div>
                   <input
                     type="text"
+                    aria-label="表示名"
                     value={nameInput}
                     onChange={e => setNameInput(e.target.value)}
                     onKeyDown={e => { if (e.key === 'Enter') handleSaveName() }}

--- a/src/screens/DailyFermiScreen.tsx
+++ b/src/screens/DailyFermiScreen.tsx
@@ -129,6 +129,7 @@ function FermiChatModal({ question, locale, onClose }: {
     <div
       role="dialog"
       aria-modal="true"
+      aria-label="フェルミ推定 質問入力"
       style={{
         position: 'fixed', inset: 0, zIndex: 1000,
         background: 'rgba(0,0,0,0.55)',

--- a/src/screens/DailyFermiScreen.tsx
+++ b/src/screens/DailyFermiScreen.tsx
@@ -238,8 +238,10 @@ function FermiChatModal({ question, locale, onClose }: {
             />
           </div>
           <button
+            type="button"
             onClick={send}
             disabled={!input.trim() || loading}
+            aria-label="送信"
             style={{
               width: 40, height: 40,
               borderRadius: '50%',

--- a/src/screens/DailyFermiScreen.tsx
+++ b/src/screens/DailyFermiScreen.tsx
@@ -215,6 +215,7 @@ function FermiChatModal({ question, locale, onClose }: {
         }}>
           <div style={{ flex: 1, position: 'relative' }}>
             <textarea
+              aria-label="質問を入力"
               value={input}
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send() } }}
@@ -565,6 +566,7 @@ export function DailyFermiScreen({ onBack, onReport }: DailyFermiScreenProps) {
               <div style={{ position: 'relative', marginTop: guideActive ? 28 : 0 }}>
                 {guideActive && <GuideLabel text="まず自分の考えを書いてみましょう" position="top" />}
                 <textarea
+                  aria-label="フェルミ推定の解答"
                   value={answer}
                   onChange={(e) => { setAnswer(e.target.value); if (guideActive) dismissGuide() }}
                   placeholder={t('fermi.placeholder')}

--- a/src/screens/DeviationScreen.tsx
+++ b/src/screens/DeviationScreen.tsx
@@ -193,6 +193,7 @@ export function DeviationScreen({ onBack, onRetakeTest, onStartLesson }: Deviati
         <div
           role="dialog"
           aria-modal="true"
+          aria-label="偏差値の説明"
           style={{
             position: 'fixed', inset: 0, zIndex: 1000,
             background: 'rgba(0,0,0,0.5)',

--- a/src/screens/FeedbackDashboardScreen.tsx
+++ b/src/screens/FeedbackDashboardScreen.tsx
@@ -104,10 +104,12 @@ export function FeedbackDashboardScreen({ onClose }: Props) {
         borderBottom: `1px solid ${v3.color.line}`,
       }}>
         <button
+          type="button"
           onClick={onClose}
+          aria-label="閉じる"
           style={{ background: v3.color.card, border: 'none', borderRadius: '50%', width: 36, height: 36, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: v3.color.text2, flexShrink: 0 }}
         >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><path d="M19 12H5M12 5l-7 7 7 7"/></svg>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" aria-hidden="true"><path d="M19 12H5M12 5l-7 7 7 7"/></svg>
         </button>
         <div>
           <div style={{ fontSize: 18, fontWeight: 700 }}>フィードバック分析</div>

--- a/src/screens/FeedbackScreen.tsx
+++ b/src/screens/FeedbackScreen.tsx
@@ -109,6 +109,7 @@ export function FeedbackScreen({ onBack }: FeedbackScreenProps) {
           内容
         </label>
         <textarea
+          aria-label="フィードバック内容"
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           placeholder="気になった点、改善してほしい点、欲しい機能など..."

--- a/src/screens/FermiScreen.tsx
+++ b/src/screens/FermiScreen.tsx
@@ -166,6 +166,7 @@ function FermiMobile({ onBack, state, onReport }: { onBack: () => void; state: F
       <div style={{ marginTop: 'var(--s-4)' }}>
         <label className="label">Your answer</label>
         <textarea
+          aria-label="フェルミ推定の解答"
           className="textarea"
           rows={6}
           placeholder="計算式や考え方を書いてみよう..."
@@ -217,6 +218,7 @@ function FermiDesktop({ onBack, state, onReport }: { onBack: () => void; state: 
         <div className="answer-card">
           <span className="answer-label">{t('label.yourAnswer')}</span>
           <textarea
+            aria-label="フェルミ推定の解答"
             placeholder="計算式や考え方を書いてみよう..."
             value={answer}
             onChange={(e) => setAnswer(e.target.value)}

--- a/src/screens/JournalInputScreen.tsx
+++ b/src/screens/JournalInputScreen.tsx
@@ -201,6 +201,7 @@ export function JournalInputScreen({ onBack }: JournalInputScreenProps) {
             <input
               className="input"
               type="number"
+              aria-label="借方金額"
               placeholder="金額"
               value={debitAmount}
               onChange={(e) => setDebitAmount(e.target.value)}
@@ -231,6 +232,7 @@ export function JournalInputScreen({ onBack }: JournalInputScreenProps) {
             <input
               className="input"
               type="number"
+              aria-label="貸方金額"
               placeholder="金額"
               value={creditAmount}
               onChange={(e) => setCreditAmount(e.target.value)}

--- a/src/screens/LessonStoriesScreen.tsx
+++ b/src/screens/LessonStoriesScreen.tsx
@@ -275,6 +275,7 @@ export function LessonStoriesScreen(props: LessonStoriesScreenProps) {
                 <div style={{ marginBottom: 16 }}>
                   <div style={{ fontSize: 13, color: v3.color.text2, marginBottom: 8 }}>詳しく教えてください（任意）</div>
                   <textarea
+                    aria-label="問題の詳細（任意）"
                     value={reportDetail}
                     onChange={(e) => setReportDetail(e.target.value)}
                     placeholder="どの箇所が、どのように間違っているか…"

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -153,6 +153,7 @@ export function LoginScreen({ onLoginSuccess }: LoginScreenProps) {
         {/* メールアドレス入力 */}
         <input
           type="email"
+          aria-label="メールアドレス"
           placeholder="メールアドレス"
           value={email}
           onChange={e => setEmail(e.target.value)}
@@ -164,6 +165,7 @@ export function LoginScreen({ onLoginSuccess }: LoginScreenProps) {
         {mode !== 'reset' && (
           <input
             type="password"
+            aria-label="パスワード"
             placeholder="パスワード"
             value={password}
             onChange={e => setPassword(e.target.value)}

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -848,6 +848,7 @@ function RegisterScreen({ onComplete, onSkip, onBack, onNavigateToLogin }: { onC
         {/* メール入力 */}
         <input
           type="email"
+          aria-label="メールアドレス"
           placeholder="メールアドレス"
           value={email}
           onChange={e => setEmail(e.target.value)}
@@ -858,6 +859,7 @@ function RegisterScreen({ onComplete, onSkip, onBack, onNavigateToLogin }: { onC
         {/* パスワード入力 */}
         <input
           type="password"
+          aria-label="パスワード"
           placeholder="パスワード"
           value={password}
           onChange={e => setPassword(e.target.value)}

--- a/src/screens/ProfileScreenV3.tsx
+++ b/src/screens/ProfileScreenV3.tsx
@@ -152,6 +152,7 @@ export function ProfileScreenV3(props: ProfileScreenV3Props) {
         <div
           role="dialog"
           aria-modal="true"
+          aria-label="メニュー"
           style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(0,0,0,0.6)', display: 'flex', alignItems: 'flex-end' }}
         >
           <button

--- a/src/screens/RankScreen.tsx
+++ b/src/screens/RankScreen.tsx
@@ -265,6 +265,7 @@ export function RankScreen({ onBack }: RankScreenProps) {
         <div
           role="dialog"
           aria-modal="true"
+          aria-label="ランク詳細"
           style={{
             position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.55)',
             zIndex: 200, display: 'flex', alignItems: 'flex-end',

--- a/src/screens/ReportProblemScreen.tsx
+++ b/src/screens/ReportProblemScreen.tsx
@@ -147,6 +147,7 @@ export function ReportProblemScreen({ context, onBack }: ReportProblemScreenProp
           {t('report.commentLabel')}
         </label>
         <textarea
+          aria-label={t('report.commentLabel')}
           value={comment}
           onChange={(e) => setComment(e.target.value)}
           placeholder={t('report.commentPlaceholder')}

--- a/src/screens/RoadmapScreenV3.tsx
+++ b/src/screens/RoadmapScreenV3.tsx
@@ -251,6 +251,7 @@ export function RoadmapScreenV3(props: RoadmapScreenV3Props) {
         <div style={{ position: 'relative' }}>
           <input
             type="search"
+            aria-label="レッスン・コース検索"
             placeholder="レッスン・コースを検索..."
             value={searchQuery}
             onChange={e => setSearchQuery(e.target.value)}

--- a/src/screens/WorksheetScreen.tsx
+++ b/src/screens/WorksheetScreen.tsx
@@ -196,6 +196,7 @@ export function WorksheetScreen({ onBack }: WorksheetScreenProps) {
                         <div style={{ position: 'relative' }}>
                           <input
                             type="number"
+                            aria-label={`row ${row + 1} col ${col + 1}`}
                             value={inputs[key] || ''}
                             onChange={(e) => setInputs((prev) => ({ ...prev, [key]: e.target.value }))}
                             disabled={submitted}

--- a/src/tutorial/coachmark.tsx
+++ b/src/tutorial/coachmark.tsx
@@ -32,6 +32,7 @@ export function HomeCoachmark({ targetRef, onDismiss }: CoachmarkProps) {
     <div
       role="dialog"
       aria-modal="true"
+      aria-label="チュートリアル"
       style={{
         position: 'fixed', inset: 0, zIndex: 9999,
         background: 'transparent',


### PR DESCRIPTION
## Summary

axe-core a11y CI を 6 → **8 画面** に拡張 + 全 V2/V3 active 画面の `<input>` / `<textarea>` / アイコン `<button>` に体系的な aria-label 補完 + 未使用 icons 削除。

**累計 75% → 76%（156h / 204h）**

### 第1陣: a11y CI を Pricing / Onboarding にも拡張
`e2e/a11y.spec.ts` に 2 テスト追加:
- **Pricing screen** (?preview=pricing) — AppShell 経由
- **Onboarding screen** (?preview=onboarding) — full-screen, `networkidle` + `button, input` セレクタで描画待機

これで主要 **8 画面** で WCAG 2.1 A/AA を CI で blocking 検証。

### 第2陣: V3 + V2 全 `<input>` に aria-label 補完
- OnboardingScreen / LoginScreen: メールアドレス / パスワード
- AppV3 (welcome): 表示名
- AccountSettingsScreen: 表示名（編集モード）
- RoadmapScreenV3: レッスン・コース検索
- JournalInputScreen: 借方金額 / 貸方金額
- WorksheetScreen: 行列セル番号

### 第3陣: V3 + V2 全 `<textarea>` に aria-label 補完
- V3 active: AIProblemGen / AIProblem / DailyFermi / Feedback / Fermi / LessonStories / ReportProblem
- V2 legacy: AIProblemGen / Feedback / FermiLesson / ReportProblem

### 第4陣: アイコン専用 `<button>` に aria-label 補完
- DailyFermiScreen: 送信ボタン
- FeedbackDashboardScreen: 閉じるボタン（+ 装飾 svg に `aria-hidden="true"`）

### 第5陣: 未使用 icons 削除（-141 行）
`src/icons/index.tsx` 39 → 25 に整理。tree-shaking で bundle からは元々除外されているが source の見通し改善。

### 検証
- `npm run lint` ✅ クリーン
- `tsc --noEmit` ✅ クリーン
- `npm run build` ✅ 成功
- 直近 CI: build-and-lint ✅ / a11y ✅ blocking で 8 画面 pass

## Test plan
- [ ] CI で a11y job が 8 画面 blocking で pass
- [ ] スクリーンリーダーで input / textarea / icon button の名前が読み上げられる
- [ ] V2 ルートで textarea のラベルが読み上げられる