### PR TITLE
パーソナルコースバナーの文字を読みやすく

### DIFF
--- a/src/screens/RoadmapScreenV3.tsx
+++ b/src/screens/RoadmapScreenV3.tsx
@@ -913,7 +913,7 @@ function PersonalCourseBanner({
         padding: '16px 18px',
         boxShadow: v3.shadow.card,
         cursor: 'pointer',
-        color: '#fff',
+        color: v3.m3.onPrimary,
         position: 'relative',
         overflow: 'hidden',
         border: 'none',
@@ -923,23 +923,23 @@ function PersonalCourseBanner({
       }}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
-        <div style={{ fontSize: 10, fontWeight: 800, letterSpacing: '.1em', background: 'rgba(255,255,255,0.18)', padding: '2px 8px', borderRadius: 6 }}>YOUR COURSE</div>
+        <div style={{ fontSize: 10, fontWeight: 800, letterSpacing: '.1em', background: 'rgba(10,31,77,0.14)', padding: '2px 8px', borderRadius: 6 }}>YOUR COURSE</div>
         {allDone && (
-          <div style={{ fontSize: 10, fontWeight: 800, letterSpacing: '.1em', background: 'rgba(255,255,255,0.22)', padding: '2px 8px', borderRadius: 6 }}>完了</div>
+          <div style={{ fontSize: 10, fontWeight: 800, letterSpacing: '.1em', background: 'rgba(10,31,77,0.18)', padding: '2px 8px', borderRadius: 6 }}>完了</div>
         )}
       </div>
       <div style={{ fontSize: 16, fontWeight: 800, lineHeight: 1.35, marginBottom: 4 }}>{course.title}</div>
-      <div style={{ fontSize: 12, opacity: 0.92, lineHeight: 1.55, marginBottom: 10 }}>
+      <div style={{ fontSize: 12, lineHeight: 1.55, marginBottom: 10 }}>
         {weakest ? `「${axisLabel(weakest).label}」を最優先に` : '弱点を最優先に'} ・ {total}レッスン構成
       </div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-        <div style={{ flex: 1, height: 4, background: 'rgba(255,255,255,0.25)', borderRadius: 2, overflow: 'hidden' }}>
-          <div style={{ height: '100%', width: `${(completedCount / Math.max(1, total)) * 100}%`, background: 'var(--bg-card)', borderRadius: 2, transition: 'width .3s' }} />
+        <div style={{ flex: 1, height: 4, background: 'rgba(10,31,77,0.20)', borderRadius: 2, overflow: 'hidden' }}>
+          <div style={{ height: '100%', width: `${(completedCount / Math.max(1, total)) * 100}%`, background: v3.m3.onPrimary, borderRadius: 2, transition: 'width .3s' }} />
         </div>
         <div style={{ fontSize: 12, fontWeight: 700 }}>{completedCount}/{total}</div>
       </div>
       <div style={{ marginTop: 10, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <div style={{ fontSize: 12, fontWeight: 700, opacity: 0.95 }}>
+        <div style={{ fontSize: 12, fontWeight: 700 }}>
           {allDone ? 'もう一度進める' : completedCount > 0 ? '続きから進める' : 'コースを進める'}
         </div>
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>


### PR DESCRIPTION
## Summary
- 「あなた専用コース」バナーで白文字 (#fff) が淡いラベンダー (#A8C0FF) のグラデーション上に乗っており、コントラスト不足で読みにくかった。
- M3 パレットで定義済みの `onPrimary` (#0A1F4D / 濃紺) を本文色に採用し、サブタイトル / CTA に掛かっていた `opacity 0.92 / 0.95` の減光を解除。
- 文字色変更に合わせて、バッジ背景と進捗トラックの白半透明を濃紺半透明に、進捗バーの塗りも `onPrimary` に合わせて差し替え。

## Test plan
- [ ] トレーニング画面トップで `PersonalCourseBanner` を表示し、「YOUR COURSE」バッジ・タイトル・サブタイトル・「コースを進める」がはっきり読めることを確認
- [ ] コース完了時の「完了」バッジ／「もう一度進める」表示でも読みやすいことを確認
- [ ] 進捗バー（背景・塗り）が違和感なく表示されることを確認

https://claude.ai/code/session_01Jp3vmrPyf8wFFp2ZTHj17z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp3vmrPyf8wFFp2ZTHj17z)_