### PR TITLE
fix(daily-fermi): 別問題リロール時に参考データも追従させる

### DIFF
--- a/src/fermiData.ts
+++ b/src/fermiData.ts
@@ -84,7 +84,12 @@ export const FERMI_STATS: FermiStat[][] = [
   [{ label: 'JR総路線距離', value: '約2万km' }, { label: '私鉄・地下鉄路線距離', value: '約1.5万km' }, { label: '1路線の1日の運行本数（参考）', value: '約100〜500本' }],
 ]
 
+/** 指定インデックスの問題に対応した参考データを返す */
+export function getFermiStatsByIndex(index: number): FermiStat[] {
+  return FERMI_STATS[index] ?? []
+}
+
 /** 今日の問題に対応した参考データを返す */
 export function getDailyFermiStats(): FermiStat[] {
-  return FERMI_STATS[getDailyFermiIndex()] ?? []
+  return getFermiStatsByIndex(getDailyFermiIndex())
 }

--- a/src/screens/DailyFermiScreen.tsx
+++ b/src/screens/DailyFermiScreen.tsx
@@ -3,7 +3,7 @@ import { LightbulbIcon, BarChartIcon, MicIcon } from '../icons'
 import { Header } from '../components/platform/Header'
 import { Button } from '../components/Button'
 import { API_BASE } from './apiBase'
-import { getDailyFermi, getDailyFermiIndex, FERMI_POOL, getDailyFermiStats } from '../fermiData'
+import { getDailyFermi, getDailyFermiIndex, FERMI_POOL, getFermiStatsByIndex } from '../fermiData'
 import { t, getLocale } from '../i18n'
 import { getGuestId } from '../guestId'
 import { haptic } from '../platform/haptics'
@@ -44,7 +44,7 @@ function getDailyRerollLimit(): number {
 }
 
 // 基礎統計データ（フェルミ推定時の参考値）
-// 参考データは fermiData.ts の getDailyFermiStats() を使用
+// 参考データは fermiData.ts の getFermiStatsByIndex() を使用（別問題リロール時も追従）
 
 /** Convert **bold** to <strong> */
 function boldify(text: string): string {
@@ -539,7 +539,7 @@ export function DailyFermiScreen({ onBack, onReport }: DailyFermiScreenProps) {
                   <div style={{ paddingTop: 12, borderTop: '1px solid rgba(108,142,245,0.2)' }}>
                     <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.1em', color: 'var(--text-muted)', marginBottom: 10, textTransform: 'uppercase' }}>参考データ</div>
                     <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                      {getDailyFermiStats().map((s) => (
+                      {getFermiStatsByIndex(currentPoolIndex).map((s) => (
                         <div key={s.label} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 13 }}>
                           <span style={{ color: 'var(--text-secondary)' }}>{s.label}</span>
                           <span style={{ fontWeight: 700, color: 'var(--text-primary)', marginLeft: 12 }}>{s.value}</span>


### PR DESCRIPTION
## 概要
DailyFermiScreen の「ヒント」内に表示される **参考データ** が、常に日付ベースの「今日の問題」に固定されていました。そのためユーザーが「別の問題を選ぶ」で問題を切り替えても、参考データだけ元の問題のまま表示されるという不整合が発生していました。

## 変更内容
- `src/fermiData.ts`
  - `getFermiStatsByIndex(index)` を新設し、任意のインデックスに対応する参考データを返せるように。
  - 既存の `getDailyFermiStats()` は新関数のラッパーに変更（後方互換）。
- `src/screens/DailyFermiScreen.tsx`
  - 参考データ描画箇所を `getDailyFermiStats()` から `getFermiStatsByIndex(currentPoolIndex)` に切り替え。リロール後も問題に対応した値が表示される。

## Test plan
- [ ] デイリーフェルミを開き、ヒントを開く → 今日の問題の参考データが表示される
- [ ] 「別の問題を選ぶ」で問題を変更 → ヒントを開いたとき、新しい問題に対応した参考データに切り替わっている
- [ ] さらに数回リロールしても、表示中の問題と参考データが常に一致している
- [ ] HomeScreenV3 の表示や採点フローにデグレがないこと

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5KxiLQSdEzyEjj2BiimtV)_