### PR TITLE
feat(images): Gemini で course/lesson イラストを生成するスクリプト追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@ STRIPE_PRICE_PREMIUM_YEARLY=price_...
 # --- Anthropic (AI問題生成) ---
 ANTHROPIC_API_KEY=sk-ant-api03-...
 
+# --- Gemini (コース／レッスン画像生成) ---
+# scripts/generate-course-images.ts で使用
+GEMINI_API_KEY=AIza...
+
 # --- Jira ---
 JIRA_URL=https://logic.atlassian.net
 JIRA_EMAIL=keita.urano@gmail.com

--- a/docs/BATCH_PROMPT.txt
+++ b/docs/BATCH_PROMPT.txt
@@ -1,0 +1,297 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+画像生成バッチ依頼
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+以下のリストを上から順番に、1 件ずつ画像生成してください。
+各画像の生成時は必ず:
+  - 共通スタイル（下記）を完全に守る
+  - 16:9 のアスペクト比
+  - 文字・ロゴ・透かし・数字を一切含めない
+  - 出力時に「ファイル名: xxx.png」と一行添える
+  - 一回のメッセージで 1 枚ずつ生成 (ペースを守って続けてください)
+
+完成後、このチャット内のすべての画像を順次保存します。
+
+━━━ 共通スタイル（全画像共通） ━━━
+
+3D isometric illustration, clean modern minimalist style, deep navy blue gradient background (#101729 to #1F2942), subtle warm golden glow accent in upper area, soft pastel highlights, professional educational app thumbnail, centered composition, cinematic lighting, octane render style, no text, no captions, no watermarks, no logos, no letters, no numbers
+
+━━━ コース 24枚 ━━━
+
+01. ファイル名: course-logic-01.png
+    題材: ロジカルに考えて、整理する
+    プロンプト: four colorful 3D isometric cubes arranged in a 2x2 grid (red, blue, gold, green) representing MECE classification, with a separate floating isometric tree of connected cube nodes branching outward like a logic tree, subtle floating papers with checkmarks
+
+02. ファイル名: course-logic-02.png
+    題材: 論理を組み立て、相手を動かす
+    プロンプト: a 3D isometric three-tier pyramid built from stacked cubes, with bidirectional vertical arrows on the side representing So What going up and Why So going down, a small figure presenting the pyramid to an audience
+
+03. ファイル名: course-critical-01.png
+    題材: 思い込みを疑い、正しく判断する
+    プロンプト: a 3D isometric scene of a giant magnifying glass examining a floating document, with question marks transforming into green checkmarks, broken chain links representing logical fallacies floating around
+
+04. ファイル名: course-critical-02.png
+    題材: バイアスを外し、客観的に見る
+    プロンプト: a 3D isometric translucent human brain with several glass filter panels being lifted away, releasing colored prismatic fragments representing cognitive biases drifting off
+
+05. ファイル名: course-hypothesis-01.png
+    題材: 仮説を立ててから、調べる
+    プロンプト: a 3D isometric scene with a floating hypothesis card connected by an arrow loop to a laboratory beaker and a magnifying glass, representing hypothesis-then-verify cycle
+
+06. ファイル名: course-problem-01.png
+    題材: 本当の問題を見極め、定義する
+    プロンプト: a 3D isometric iceberg cut in half showing a small visible tip above the water and a massive submerged base with glowing root cause spheres inside, target marker on the deep core
+
+07. ファイル名: course-design-01.png
+    題材: ユーザーの本音を掘り下げ、解決する
+    プロンプト: a 3D isometric central persona figure surrounded by an empathy map split into four quadrants on the floor, sticky notes floating, prototype paper shapes, journey path lines
+
+08. ファイル名: course-systems-01.png
+    題材: 全体を俯瞰し、根本から変える
+    プロンプト: a 3D isometric circular feedback loop diagram with connected nodes, large circular arrow flowing through them, an iceberg model integrated below the loop
+
+09. ファイル名: course-lateral-01.png
+    題材: 常識を疑い、突破口を開く
+    プロンプト: a 3D isometric glowing lightbulb breaking out of a cube box, with sideways arrows pointing in unconventional directions, prism splitting white light into colors
+
+10. ファイル名: course-analogy-01.png
+    題材: 別分野の知恵を借りて、応用する
+    プロンプト: a 3D isometric bridge connecting two distinct floating islands - left island shaped like a tree of nature, right island shaped like a business chart - with a glowing lightbulb hovering above the bridge
+
+11. ファイル名: course-philosophy-01.png
+    題材: 哲学の問いで、思考を深める
+    プロンプト: a 3D isometric ancient Greek stone column with a contemplative thinker silhouette sitting beside it, an open scroll, abstract thought clouds with question marks above
+
+12. ファイル名: course-eastern-01.png
+    題材: 古代中国思想で、人と組織を見る
+    プロンプト: a 3D isometric Chinese pavilion roof with a wise sage figure seated inside, traditional scrolls, glowing networked relationship lines connecting smaller figures around it, soft mist
+
+13. ファイル名: course-eastern-02.png
+    題材: 古代中国思想で、戦略と決断を見る
+    プロンプト: a 3D isometric bamboo grove garden with a floating yin-yang symbol, abstract tao-flow lines like flowing water around stones, strategy chess pieces on a low platform
+
+14. ファイル名: course-proposal-01.png
+    題材: 相手が動く提案をつくる
+    プロンプト: a 3D isometric professional document with a small presenter figure beside it, golden impact arrows radiating from the document toward a small target, audience silhouettes in front
+
+15. ファイル名: course-proposal-course-01.png
+    題材: 仮説と検証で、提案書を仕上げる
+    プロンプト: a 3D isometric workflow from a small hypothesis card on the left to a polished bound proposal document on the right, with checkmark verification steps in between
+
+16. ファイル名: course-client-01.png
+    題材: 数字で状況を素早く読み解く
+    プロンプト: a 3D isometric floating spreadsheet panel with bar charts and large numerical figures, a calculator, a business person reading the data with a confident posture
+
+17. ファイル名: course-client-02.png
+    題材: 論点を定め、深く引き出す
+    プロンプト: a 3D isometric scene with two figures across a small table, one extracting information through a glowing question stream, structured cards organizing the answers
+
+18. ファイル名: course-client-03.png
+    題材: 未経験の業界で、短期間で立ち上がる
+    プロンプト: a 3D isometric figure climbing a steeply rising learning curve graph, stacked books on the path, expert silhouettes guiding from above
+
+19. ファイル名: course-case-01.png
+    題材: ケース面接で、論理力を証明する
+    プロンプト: a 3D isometric profit equation tree splitting into revenue and cost branches with sub-cubes, a small interview chair scene, structured framework boards
+
+20. ファイル名: course-strategy-01.png
+    題材: 戦略の源流と競争戦略を学ぶ
+    プロンプト: a 3D isometric vintage industrial factory with conveyor belts on a circular platform, surrounded by five large arrows pointing inward representing five forces, a classic strategy book
+
+21. ファイル名: course-strategy-02.png
+    題材: 資源・能力・共進化の戦略へ
+    プロンプト: a 3D isometric calm blue ocean with a small sailing ship, glowing resource gems on the seabed, mechanical capability gears interlocking, platform hub with radiating connections
+
+22. ファイル名: course-fermi-01.png
+    題材: 概算で、世界の規模を掴む
+    プロンプト: a 3D isometric small earth globe with floating numerical figures around it, calculator, decomposition arrows breaking the globe into smaller cube estimates
+
+23. ファイル名: course-numeracy-01.png
+    題材: 数字に強くなる
+    プロンプト: a 3D isometric scene with floating percentage symbol, yen currency sign, bar chart and pie chart, calculator, a person confidently reading numbers, scale balance
+
+24. ファイル名: course-peak-performance-01.png
+    題材: 自分史上最高のパフォーマンスで働く
+    プロンプト: a 3D isometric morning scene with a moon-to-sun cycle arc, an energy graph rising and falling with peaks, an athletic figure stretching, a glowing focus zone marker
+
+━━━ レッスン 44枚 ━━━
+
+25. ファイル名: lesson-20.png
+    題材: MECE
+    プロンプト: a 3D isometric 2x2 grid of four large colored cubes (red, blue, gold, green) showing MECE classification, no overlap no gap
+
+26. ファイル名: lesson-21.png
+    題材: ロジックツリー
+    プロンプト: a 3D isometric tree diagram with a single root cube branching into mid-level cubes and leaf cubes
+
+27. ファイル名: lesson-22.png
+    題材: So What / Why So
+    プロンプト: a 3D isometric pair of vertical arrows side by side, one pointing up and one pointing down, between layered cube stacks, representing So What and Why So
+
+28. ファイル名: lesson-23.png
+    題材: ピラミッド原則
+    プロンプト: a 3D isometric three-tier pyramid built from stacked cubes, conclusion on top supported by reason cubes below
+
+29. ファイル名: lesson-24.png
+    題材: ケーススタディ
+    プロンプト: a 3D isometric briefcase opening with documents flying out, case study notebook, charts
+
+30. ファイル名: lesson-25.png
+    題材: 演繹法
+    プロンプト: a 3D isometric flow from general principle cube down to specific conclusion cube, deduction arrow
+
+31. ファイル名: lesson-26.png
+    題材: 帰納法
+    プロンプト: a 3D isometric flow from many small specific data cubes converging upward into a general pattern cube, induction arrow
+
+32. ファイル名: lesson-27.png
+    題材: 形式論理
+    プロンプト: a 3D isometric formal logic gate diagram with truth state cubes glowing in a connected pattern
+
+33. ファイル名: lesson-68.png
+    題材: 具体と抽象
+    プロンプト: a 3D isometric ladder of abstraction with concrete object cubes at the bottom and abstract idea cubes at the top, vertical arrow
+
+34. ファイル名: lesson-28.png
+    題材: ケース面接入門
+    プロンプト: a 3D isometric interview room with two chairs across a small table, structured frameworks floating between them
+
+35. ファイル名: lesson-29.png
+    題材: プロフィタビリティ
+    プロンプト: a 3D isometric profit equation tree with revenue branch and cost branch breaking into smaller cubes
+
+36. ファイル名: lesson-35.png
+    題材: 新市場参入
+    プロンプト: a 3D isometric arrow pointing from a small island to a larger market continent, decision flowchart cubes around the arrow
+
+37. ファイル名: lesson-36.png
+    題材: M&A
+    プロンプト: a 3D isometric two companies represented as separate cube clusters merging into one larger cluster, M&A handshake
+
+38. ファイル名: lesson-40.png
+    題材: クリティカルシンキング入門
+    プロンプト: a 3D isometric magnifying glass examining a checklist document, question marks turning into checkmarks
+
+39. ファイル名: lesson-41.png
+    題材: 論理的誤謬
+    プロンプト: a 3D isometric set of broken chain links labeled as logical fallacies, with a corrected solid chain link beside them
+
+40. ファイル名: lesson-42.png
+    題材: データを読む
+    プロンプト: a 3D isometric data dashboard with floating bar charts and a person carefully reading numbers, hidden patterns highlighted
+
+41. ファイル名: lesson-43.png
+    題材: 問いを立てる
+    プロンプト: a 3D isometric large question mark cube being polished, surrounded by smaller question marks being filtered into a clearer one
+
+42. ファイル名: lesson-69.png
+    題材: 認知バイアス
+    プロンプト: a 3D isometric brain with translucent biased glasses being removed, prismatic fragments drifting
+
+43. ファイル名: lesson-71.png
+    題材: 相関と因果
+    プロンプト: a 3D isometric two correlated wave lines diverging where one is a true cause arrow and the other is just correlation
+
+44. ファイル名: lesson-50.png
+    題材: 仮説思考入門
+    プロンプト: a 3D isometric thought bubble with a hypothesis card pointing forward to a verification path
+
+45. ファイル名: lesson-51.png
+    題材: 仮説の立て方
+    プロンプト: a 3D isometric figure drafting hypothesis cards on a desk, multiple options floating up
+
+46. ファイル名: lesson-52.png
+    題材: 仮説ドリブン
+    プロンプト: a 3D isometric arrow loop from hypothesis card to data verification beaker and back
+
+47. ファイル名: lesson-70.png
+    題材: 仮説の検証設計
+    プロンプト: a 3D isometric experimental setup with measurement instruments, control versus test cubes
+
+48. ファイル名: lesson-53.png
+    題材: 課題設定入門
+    プロンプト: a 3D isometric target board with concentric rings, an arrow finding the true bullseye among decoys
+
+49. ファイル名: lesson-54.png
+    題材: イシュー分析
+    プロンプト: a 3D isometric large issue card being decomposed downward into smaller sub-issue cubes
+
+50. ファイル名: lesson-55.png
+    題材: 課題設定実践
+    プロンプト: a 3D isometric workspace with multiple problem cards being prioritized into a focused single card
+
+51. ファイル名: lesson-56.png
+    題材: デザインシンキング入門
+    プロンプト: a 3D isometric design thinking cycle with five connected stage cubes (empathize, define, ideate, prototype, test)
+
+52. ファイル名: lesson-57.png
+    題材: 共感マップ
+    プロンプト: a 3D isometric empathy map quadrants on the floor surrounding a central persona figure
+
+53. ファイル名: lesson-58.png
+    題材: デザインシンキング実践
+    プロンプト: a 3D isometric prototype paper model being tested by a user figure with feedback bubbles
+
+54. ファイル名: lesson-59.png
+    題材: ラテラルシンキング入門
+    プロンプト: a 3D isometric lightbulb breaking out of a cube box, sideways arrows in unconventional directions
+
+55. ファイル名: lesson-60.png
+    題材: ラテラル技法
+    プロンプト: a 3D isometric prism splitting a single light beam into multiple colorful diverging directions
+
+56. ファイル名: lesson-61.png
+    題材: ラテラル実践
+    プロンプト: a 3D isometric flipped perspective scene where a problem cube is rotated to reveal a different unexpected facet
+
+57. ファイル名: lesson-62.png
+    題材: アナロジー思考入門
+    プロンプト: a 3D isometric bridge connecting two distinct floating islands with different visual themes
+
+58. ファイル名: lesson-63.png
+    題材: アナロジー技法
+    プロンプト: a 3D isometric structural pattern card being lifted from one domain and placed onto another domain
+
+59. ファイル名: lesson-64.png
+    題材: アナロジー実践
+    プロンプト: a 3D isometric two parallel scenes side by side with matching structural arrows showing analogy mapping
+
+60. ファイル名: lesson-65.png
+    題材: システムシンキング入門
+    プロンプト: a 3D isometric circular feedback loop with connected node cubes flowing in a circle
+
+61. ファイル名: lesson-66.png
+    題材: システム原型
+    プロンプト: a 3D isometric system archetype diagram with reinforcing and balancing loops shown as gears
+
+62. ファイル名: lesson-67.png
+    題材: システム実践
+    プロンプト: a 3D isometric iceberg model with events on top, patterns mid, structures and mental models at the deep base
+
+63. ファイル名: lesson-72.png
+    題材: 提案書の目的
+    プロンプト: a 3D isometric professional bound proposal document with a clear target arrow above it
+
+64. ファイル名: lesson-73.png
+    題材: 相手の立場
+    プロンプト: a 3D isometric two figures facing a document, one offering and one receiving, perspective lines aligning their viewpoints
+
+65. ファイル名: lesson-74.png
+    題材: ストーリーライン
+    プロンプト: a 3D isometric storyline path with sequential narrative cube panels leading to a conclusion
+
+66. ファイル名: lesson-75.png
+    題材: メッセージを磨く
+    プロンプト: a 3D isometric message card being polished and sharpened on a workbench with sparkles
+
+67. ファイル名: lesson-76.png
+    題材: 反論を先読み
+    プロンプト: a 3D isometric shield deflecting incoming counter-argument arrows, behind it a strong document
+
+68. ファイル名: lesson-77.png
+    題材: ソクラテス
+    プロンプト: a 3D isometric ancient Greek stone column with a Socrates-like silhouette and a scroll, question marks rising
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+合計 68 枚。準備ができたら 1 番から順に生成を始めてください。
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/docs/IMAGE_GENERATION.md
+++ b/docs/IMAGE_GENERATION.md
@@ -1,0 +1,672 @@
+# コース・レッスン画像生成ガイド
+
+Gemini で各コース／レッスンのイラストを生成し、 `public/images/v3/` 以下に
+規約のファイル名で保存すれば `npm run wire:images` で自動的に
+`courseData.ts` / `lessonSlides.ts` の参照が更新される。
+
+> このドキュメントは `scripts/imagePrompts.ts` から自動生成されています。
+> 編集する場合は `imagePrompts.ts` を直して `npm run prompts:md` を実行してください。
+
+## 手順
+
+1. Gemini を開く（推奨: Imagen 4 が使えるモード）
+2. 最初に「共通スタイル指示」を一度送る
+3. 各コース／レッスンのプロンプトを順次送り、生成された画像を保存先のファイル名でダウンロード
+4. `public/images/v3/` 以下に保存
+5. リポジトリで `npm run wire:images` を実行 → `courseData.ts` / `lessonSlides.ts` の参照が PNG に切り替わる
+
+## 共通スタイル指示（最初に Gemini に送る）
+
+```text
+これから複数の画像を生成してもらいます。
+全画像とも以下の共通スタイルを必ず守ってください:
+
+3D isometric illustration, clean modern minimalist style, deep navy blue gradient background (#101729 to #1F2942), subtle warm golden glow accent in upper area, soft pastel highlights, professional educational app thumbnail, centered composition, cinematic lighting, octane render style, no text, no captions, no watermarks, no logos, no letters, no numbers
+
+アスペクト比は 16:9。各回ひとつだけ画像を生成してください。
+```
+
+## コース (24枚)
+
+| ID | タイトル | 保存ファイル |
+|----|---------|-------------|
+| `logic-01` | ロジカルに考えて、整理する | `course-logic-01.png` |
+| `logic-02` | 論理を組み立て、相手を動かす | `course-logic-02.png` |
+| `critical-01` | 思い込みを疑い、正しく判断する | `course-critical-01.png` |
+| `critical-02` | バイアスを外し、客観的に見る | `course-critical-02.png` |
+| `hypothesis-01` | 仮説を立ててから、調べる | `course-hypothesis-01.png` |
+| `problem-01` | 本当の問題を見極め、定義する | `course-problem-01.png` |
+| `design-01` | ユーザーの本音を掘り下げ、解決する | `course-design-01.png` |
+| `systems-01` | 全体を俯瞰し、根本から変える | `course-systems-01.png` |
+| `lateral-01` | 常識を疑い、突破口を開く | `course-lateral-01.png` |
+| `analogy-01` | 別分野の知恵を借りて、応用する | `course-analogy-01.png` |
+| `philosophy-01` | 哲学の問いで、思考を深める | `course-philosophy-01.png` |
+| `eastern-01` | 古代中国思想で、人と組織を見る | `course-eastern-01.png` |
+| `eastern-02` | 古代中国思想で、戦略と決断を見る | `course-eastern-02.png` |
+| `proposal-01` | 相手が動く提案をつくる | `course-proposal-01.png` |
+| `proposal-course-01` | 仮説と検証で、提案書を仕上げる | `course-proposal-course-01.png` |
+| `client-01` | 数字で状況を素早く読み解く | `course-client-01.png` |
+| `client-02` | 論点を定め、深く引き出す | `course-client-02.png` |
+| `client-03` | 未経験の業界で、短期間で立ち上がる | `course-client-03.png` |
+| `case-01` | ケース面接で、論理力を証明する | `course-case-01.png` |
+| `strategy-01` | 戦略の源流と競争戦略を学ぶ | `course-strategy-01.png` |
+| `strategy-02` | 資源・能力・共進化の戦略へ | `course-strategy-02.png` |
+| `fermi-01` | 概算で、世界の規模を掴む | `course-fermi-01.png` |
+| `numeracy-01` | 数字に強くなる | `course-numeracy-01.png` |
+| `peak-performance-01` | 自分史上最高のパフォーマンスで働く | `course-peak-performance-01.png` |
+
+### logic-01 — ロジカルに考えて、整理する
+**保存先**: `public/images/v3/course-logic-01.png`  
+**種別**: コース
+
+```text
+four colorful 3D isometric cubes arranged in a 2x2 grid (red, blue, gold, green) representing MECE classification, with a separate floating isometric tree of connected cube nodes branching outward like a logic tree, subtle floating papers with checkmarks
+```
+
+### logic-02 — 論理を組み立て、相手を動かす
+**保存先**: `public/images/v3/course-logic-02.png`  
+**種別**: コース
+
+```text
+a 3D isometric three-tier pyramid built from stacked cubes, with bidirectional vertical arrows on the side representing So What going up and Why So going down, a small figure presenting the pyramid to an audience
+```
+
+### critical-01 — 思い込みを疑い、正しく判断する
+**保存先**: `public/images/v3/course-critical-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric scene of a giant magnifying glass examining a floating document, with question marks transforming into green checkmarks, broken chain links representing logical fallacies floating around
+```
+
+### critical-02 — バイアスを外し、客観的に見る
+**保存先**: `public/images/v3/course-critical-02.png`  
+**種別**: コース
+
+```text
+a 3D isometric translucent human brain with several glass filter panels being lifted away, releasing colored prismatic fragments representing cognitive biases drifting off
+```
+
+### hypothesis-01 — 仮説を立ててから、調べる
+**保存先**: `public/images/v3/course-hypothesis-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric scene with a floating hypothesis card connected by an arrow loop to a laboratory beaker and a magnifying glass, representing hypothesis-then-verify cycle
+```
+
+### problem-01 — 本当の問題を見極め、定義する
+**保存先**: `public/images/v3/course-problem-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric iceberg cut in half showing a small visible tip above the water and a massive submerged base with glowing root cause spheres inside, target marker on the deep core
+```
+
+### design-01 — ユーザーの本音を掘り下げ、解決する
+**保存先**: `public/images/v3/course-design-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric central persona figure surrounded by an empathy map split into four quadrants on the floor, sticky notes floating, prototype paper shapes, journey path lines
+```
+
+### systems-01 — 全体を俯瞰し、根本から変える
+**保存先**: `public/images/v3/course-systems-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric circular feedback loop diagram with connected nodes, large circular arrow flowing through them, an iceberg model integrated below the loop
+```
+
+### lateral-01 — 常識を疑い、突破口を開く
+**保存先**: `public/images/v3/course-lateral-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric glowing lightbulb breaking out of a cube box, with sideways arrows pointing in unconventional directions, prism splitting white light into colors
+```
+
+### analogy-01 — 別分野の知恵を借りて、応用する
+**保存先**: `public/images/v3/course-analogy-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric bridge connecting two distinct floating islands - left island shaped like a tree of nature, right island shaped like a business chart - with a glowing lightbulb hovering above the bridge
+```
+
+### philosophy-01 — 哲学の問いで、思考を深める
+**保存先**: `public/images/v3/course-philosophy-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric ancient Greek stone column with a contemplative thinker silhouette sitting beside it, an open scroll, abstract thought clouds with question marks above
+```
+
+### eastern-01 — 古代中国思想で、人と組織を見る
+**保存先**: `public/images/v3/course-eastern-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric Chinese pavilion roof with a wise sage figure seated inside, traditional scrolls, glowing networked relationship lines connecting smaller figures around it, soft mist
+```
+
+### eastern-02 — 古代中国思想で、戦略と決断を見る
+**保存先**: `public/images/v3/course-eastern-02.png`  
+**種別**: コース
+
+```text
+a 3D isometric bamboo grove garden with a floating yin-yang symbol, abstract tao-flow lines like flowing water around stones, strategy chess pieces on a low platform
+```
+
+### proposal-01 — 相手が動く提案をつくる
+**保存先**: `public/images/v3/course-proposal-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric professional document with a small presenter figure beside it, golden impact arrows radiating from the document toward a small target, audience silhouettes in front
+```
+
+### proposal-course-01 — 仮説と検証で、提案書を仕上げる
+**保存先**: `public/images/v3/course-proposal-course-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric workflow from a small hypothesis card on the left to a polished bound proposal document on the right, with checkmark verification steps in between
+```
+
+### client-01 — 数字で状況を素早く読み解く
+**保存先**: `public/images/v3/course-client-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric floating spreadsheet panel with bar charts and large numerical figures, a calculator, a business person reading the data with a confident posture
+```
+
+### client-02 — 論点を定め、深く引き出す
+**保存先**: `public/images/v3/course-client-02.png`  
+**種別**: コース
+
+```text
+a 3D isometric scene with two figures across a small table, one extracting information through a glowing question stream, structured cards organizing the answers
+```
+
+### client-03 — 未経験の業界で、短期間で立ち上がる
+**保存先**: `public/images/v3/course-client-03.png`  
+**種別**: コース
+
+```text
+a 3D isometric figure climbing a steeply rising learning curve graph, stacked books on the path, expert silhouettes guiding from above
+```
+
+### case-01 — ケース面接で、論理力を証明する
+**保存先**: `public/images/v3/course-case-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric profit equation tree splitting into revenue and cost branches with sub-cubes, a small interview chair scene, structured framework boards
+```
+
+### strategy-01 — 戦略の源流と競争戦略を学ぶ
+**保存先**: `public/images/v3/course-strategy-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric vintage industrial factory with conveyor belts on a circular platform, surrounded by five large arrows pointing inward representing five forces, a classic strategy book
+```
+
+### strategy-02 — 資源・能力・共進化の戦略へ
+**保存先**: `public/images/v3/course-strategy-02.png`  
+**種別**: コース
+
+```text
+a 3D isometric calm blue ocean with a small sailing ship, glowing resource gems on the seabed, mechanical capability gears interlocking, platform hub with radiating connections
+```
+
+### fermi-01 — 概算で、世界の規模を掴む
+**保存先**: `public/images/v3/course-fermi-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric small earth globe with floating numerical figures around it, calculator, decomposition arrows breaking the globe into smaller cube estimates
+```
+
+### numeracy-01 — 数字に強くなる
+**保存先**: `public/images/v3/course-numeracy-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric scene with floating percentage symbol, yen currency sign, bar chart and pie chart, calculator, a person confidently reading numbers, scale balance
+```
+
+### peak-performance-01 — 自分史上最高のパフォーマンスで働く
+**保存先**: `public/images/v3/course-peak-performance-01.png`  
+**種別**: コース
+
+```text
+a 3D isometric morning scene with a moon-to-sun cycle arc, an energy graph rising and falling with peaks, an athletic figure stretching, a glowing focus zone marker
+```
+
+## レッスン (44枚)
+
+| ID | タイトル | 保存ファイル |
+|----|---------|-------------|
+| `20` | MECE | `lesson-20.png` |
+| `21` | ロジックツリー | `lesson-21.png` |
+| `22` | So What / Why So | `lesson-22.png` |
+| `23` | ピラミッド原則 | `lesson-23.png` |
+| `24` | ケーススタディ | `lesson-24.png` |
+| `25` | 演繹法 | `lesson-25.png` |
+| `26` | 帰納法 | `lesson-26.png` |
+| `27` | 形式論理 | `lesson-27.png` |
+| `68` | 具体と抽象 | `lesson-68.png` |
+| `28` | ケース面接入門 | `lesson-28.png` |
+| `29` | プロフィタビリティ | `lesson-29.png` |
+| `35` | 新市場参入 | `lesson-35.png` |
+| `36` | M&A | `lesson-36.png` |
+| `40` | クリティカルシンキング入門 | `lesson-40.png` |
+| `41` | 論理的誤謬 | `lesson-41.png` |
+| `42` | データを読む | `lesson-42.png` |
+| `43` | 問いを立てる | `lesson-43.png` |
+| `69` | 認知バイアス | `lesson-69.png` |
+| `71` | 相関と因果 | `lesson-71.png` |
+| `50` | 仮説思考入門 | `lesson-50.png` |
+| `51` | 仮説の立て方 | `lesson-51.png` |
+| `52` | 仮説ドリブン | `lesson-52.png` |
+| `70` | 仮説の検証設計 | `lesson-70.png` |
+| `53` | 課題設定入門 | `lesson-53.png` |
+| `54` | イシュー分析 | `lesson-54.png` |
+| `55` | 課題設定実践 | `lesson-55.png` |
+| `56` | デザインシンキング入門 | `lesson-56.png` |
+| `57` | 共感マップ | `lesson-57.png` |
+| `58` | デザインシンキング実践 | `lesson-58.png` |
+| `59` | ラテラルシンキング入門 | `lesson-59.png` |
+| `60` | ラテラル技法 | `lesson-60.png` |
+| `61` | ラテラル実践 | `lesson-61.png` |
+| `62` | アナロジー思考入門 | `lesson-62.png` |
+| `63` | アナロジー技法 | `lesson-63.png` |
+| `64` | アナロジー実践 | `lesson-64.png` |
+| `65` | システムシンキング入門 | `lesson-65.png` |
+| `66` | システム原型 | `lesson-66.png` |
+| `67` | システム実践 | `lesson-67.png` |
+| `72` | 提案書の目的 | `lesson-72.png` |
+| `73` | 相手の立場 | `lesson-73.png` |
+| `74` | ストーリーライン | `lesson-74.png` |
+| `75` | メッセージを磨く | `lesson-75.png` |
+| `76` | 反論を先読み | `lesson-76.png` |
+| `77` | ソクラテス | `lesson-77.png` |
+
+### 20 — MECE
+**保存先**: `public/images/v3/lesson-20.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric 2x2 grid of four large colored cubes (red, blue, gold, green) showing MECE classification, no overlap no gap
+```
+
+### 21 — ロジックツリー
+**保存先**: `public/images/v3/lesson-21.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric tree diagram with a single root cube branching into mid-level cubes and leaf cubes
+```
+
+### 22 — So What / Why So
+**保存先**: `public/images/v3/lesson-22.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric pair of vertical arrows side by side, one pointing up and one pointing down, between layered cube stacks, representing So What and Why So
+```
+
+### 23 — ピラミッド原則
+**保存先**: `public/images/v3/lesson-23.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric three-tier pyramid built from stacked cubes, conclusion on top supported by reason cubes below
+```
+
+### 24 — ケーススタディ
+**保存先**: `public/images/v3/lesson-24.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric briefcase opening with documents flying out, case study notebook, charts
+```
+
+### 25 — 演繹法
+**保存先**: `public/images/v3/lesson-25.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric flow from general principle cube down to specific conclusion cube, deduction arrow
+```
+
+### 26 — 帰納法
+**保存先**: `public/images/v3/lesson-26.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric flow from many small specific data cubes converging upward into a general pattern cube, induction arrow
+```
+
+### 27 — 形式論理
+**保存先**: `public/images/v3/lesson-27.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric formal logic gate diagram with truth state cubes glowing in a connected pattern
+```
+
+### 68 — 具体と抽象
+**保存先**: `public/images/v3/lesson-68.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric ladder of abstraction with concrete object cubes at the bottom and abstract idea cubes at the top, vertical arrow
+```
+
+### 28 — ケース面接入門
+**保存先**: `public/images/v3/lesson-28.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric interview room with two chairs across a small table, structured frameworks floating between them
+```
+
+### 29 — プロフィタビリティ
+**保存先**: `public/images/v3/lesson-29.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric profit equation tree with revenue branch and cost branch breaking into smaller cubes
+```
+
+### 35 — 新市場参入
+**保存先**: `public/images/v3/lesson-35.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric arrow pointing from a small island to a larger market continent, decision flowchart cubes around the arrow
+```
+
+### 36 — M&A
+**保存先**: `public/images/v3/lesson-36.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric two companies represented as separate cube clusters merging into one larger cluster, M&A handshake
+```
+
+### 40 — クリティカルシンキング入門
+**保存先**: `public/images/v3/lesson-40.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric magnifying glass examining a checklist document, question marks turning into checkmarks
+```
+
+### 41 — 論理的誤謬
+**保存先**: `public/images/v3/lesson-41.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric set of broken chain links labeled as logical fallacies, with a corrected solid chain link beside them
+```
+
+### 42 — データを読む
+**保存先**: `public/images/v3/lesson-42.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric data dashboard with floating bar charts and a person carefully reading numbers, hidden patterns highlighted
+```
+
+### 43 — 問いを立てる
+**保存先**: `public/images/v3/lesson-43.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric large question mark cube being polished, surrounded by smaller question marks being filtered into a clearer one
+```
+
+### 69 — 認知バイアス
+**保存先**: `public/images/v3/lesson-69.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric brain with translucent biased glasses being removed, prismatic fragments drifting
+```
+
+### 71 — 相関と因果
+**保存先**: `public/images/v3/lesson-71.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric two correlated wave lines diverging where one is a true cause arrow and the other is just correlation
+```
+
+### 50 — 仮説思考入門
+**保存先**: `public/images/v3/lesson-50.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric thought bubble with a hypothesis card pointing forward to a verification path
+```
+
+### 51 — 仮説の立て方
+**保存先**: `public/images/v3/lesson-51.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric figure drafting hypothesis cards on a desk, multiple options floating up
+```
+
+### 52 — 仮説ドリブン
+**保存先**: `public/images/v3/lesson-52.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric arrow loop from hypothesis card to data verification beaker and back
+```
+
+### 70 — 仮説の検証設計
+**保存先**: `public/images/v3/lesson-70.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric experimental setup with measurement instruments, control versus test cubes
+```
+
+### 53 — 課題設定入門
+**保存先**: `public/images/v3/lesson-53.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric target board with concentric rings, an arrow finding the true bullseye among decoys
+```
+
+### 54 — イシュー分析
+**保存先**: `public/images/v3/lesson-54.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric large issue card being decomposed downward into smaller sub-issue cubes
+```
+
+### 55 — 課題設定実践
+**保存先**: `public/images/v3/lesson-55.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric workspace with multiple problem cards being prioritized into a focused single card
+```
+
+### 56 — デザインシンキング入門
+**保存先**: `public/images/v3/lesson-56.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric design thinking cycle with five connected stage cubes (empathize, define, ideate, prototype, test)
+```
+
+### 57 — 共感マップ
+**保存先**: `public/images/v3/lesson-57.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric empathy map quadrants on the floor surrounding a central persona figure
+```
+
+### 58 — デザインシンキング実践
+**保存先**: `public/images/v3/lesson-58.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric prototype paper model being tested by a user figure with feedback bubbles
+```
+
+### 59 — ラテラルシンキング入門
+**保存先**: `public/images/v3/lesson-59.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric lightbulb breaking out of a cube box, sideways arrows in unconventional directions
+```
+
+### 60 — ラテラル技法
+**保存先**: `public/images/v3/lesson-60.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric prism splitting a single light beam into multiple colorful diverging directions
+```
+
+### 61 — ラテラル実践
+**保存先**: `public/images/v3/lesson-61.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric flipped perspective scene where a problem cube is rotated to reveal a different unexpected facet
+```
+
+### 62 — アナロジー思考入門
+**保存先**: `public/images/v3/lesson-62.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric bridge connecting two distinct floating islands with different visual themes
+```
+
+### 63 — アナロジー技法
+**保存先**: `public/images/v3/lesson-63.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric structural pattern card being lifted from one domain and placed onto another domain
+```
+
+### 64 — アナロジー実践
+**保存先**: `public/images/v3/lesson-64.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric two parallel scenes side by side with matching structural arrows showing analogy mapping
+```
+
+### 65 — システムシンキング入門
+**保存先**: `public/images/v3/lesson-65.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric circular feedback loop with connected node cubes flowing in a circle
+```
+
+### 66 — システム原型
+**保存先**: `public/images/v3/lesson-66.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric system archetype diagram with reinforcing and balancing loops shown as gears
+```
+
+### 67 — システム実践
+**保存先**: `public/images/v3/lesson-67.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric iceberg model with events on top, patterns mid, structures and mental models at the deep base
+```
+
+### 72 — 提案書の目的
+**保存先**: `public/images/v3/lesson-72.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric professional bound proposal document with a clear target arrow above it
+```
+
+### 73 — 相手の立場
+**保存先**: `public/images/v3/lesson-73.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric two figures facing a document, one offering and one receiving, perspective lines aligning their viewpoints
+```
+
+### 74 — ストーリーライン
+**保存先**: `public/images/v3/lesson-74.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric storyline path with sequential narrative cube panels leading to a conclusion
+```
+
+### 75 — メッセージを磨く
+**保存先**: `public/images/v3/lesson-75.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric message card being polished and sharpened on a workbench with sparkles
+```
+
+### 76 — 反論を先読み
+**保存先**: `public/images/v3/lesson-76.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric shield deflecting incoming counter-argument arrows, behind it a strong document
+```
+
+### 77 — ソクラテス
+**保存先**: `public/images/v3/lesson-77.png`  
+**種別**: レッスン
+
+```text
+a 3D isometric ancient Greek stone column with a Socrates-like silhouette and a scroll, question marks rising
+```
+
+## 紐付け（自動）
+
+```bash
+# 何が更新されるかプレビュー
+npm run wire:images -- --dry-run
+
+# 実行（src/courseData.ts と src/lessonSlides.ts を書き換え）
+npm run wire:images
+```
+
+`public/images/v3/course-{id}.png` または `lesson-{id}.png` が見つかった ID
+についてのみ、それぞれの参照を `.png` パスに更新する。
+保存していないコース／レッスンの参照は変更されない。
+
+## 自動 API 経由で一括生成したい場合
+
+```bash
+export GEMINI_API_KEY=AIza...
+npm run gen:images -- --target=courses        # コース 24 枚
+npm run gen:images -- --target=all            # コース + レッスン 全 68 枚
+npm run gen:images -- --only=logic-01,fermi-01 # 特定だけ
+```

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "android:release": "git pull && npm run build && node scripts/bump-android-version.js && npx cap sync android && npm run cap:open:android",
     "deploy:web": "npm run build && vercel --prod",
     "db:migrate": "node scripts/run-migration.js",
-    "gen:images": "tsx scripts/generate-course-images.ts"
+    "gen:images": "tsx scripts/generate-course-images.ts",
+    "wire:images": "tsx scripts/wire-images.ts",
+    "prompts:md": "tsx scripts/print-prompts-md.ts --write"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "cap:open:android": "npx cap open android",
     "android:release": "git pull && npm run build && node scripts/bump-android-version.js && npx cap sync android && npm run cap:open:android",
     "deploy:web": "npm run build && vercel --prod",
-    "db:migrate": "node scripts/run-migration.js"
+    "db:migrate": "node scripts/run-migration.js",
+    "gen:images": "tsx scripts/generate-course-images.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",

--- a/scripts/generate-course-images.ts
+++ b/scripts/generate-course-images.ts
@@ -1,0 +1,405 @@
+/**
+ * Generate course / lesson illustration images via Gemini API.
+ *
+ * 使い方:
+ *   GEMINI_API_KEY=xxx npx tsx scripts/generate-course-images.ts
+ *
+ * オプション:
+ *   --target=courses|lessons|all   生成対象 (default: courses)
+ *   --only=<id1>,<id2>             特定IDのみ生成 (例: logic-01,critical-01 / 20,21)
+ *   --skip-existing                既存ファイルをスキップ (default: false → 上書き)
+ *   --model=<model>                Gemini モデル指定
+ *                                  (default: imagen-4.0-generate-preview-06-06)
+ *                                  例: imagen-3.0-generate-002,
+ *                                      gemini-2.5-flash-image-preview
+ *   --aspect=<ratio>               アスペクト比 (default: 16:9)
+ *                                  imagen系: 1:1, 3:4, 4:3, 9:16, 16:9
+ *   --concurrency=<n>              並列実行数 (default: 2)
+ *   --out=<dir>                    出力ディレクトリ
+ *                                  (default: public/images/v3)
+ *   --dry-run                      プロンプトを表示するだけで API を呼ばない
+ *
+ * 環境変数:
+ *   GEMINI_API_KEY (必須)
+ *
+ * 出力ファイル名:
+ *   コース: course-{id}.png    例: course-logic-01.png
+ *   レッスン: lesson-{id}.png  例: lesson-20.png
+ */
+
+import { writeFile, mkdir, access } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// ────────────────────────────────────────────────────────────────────────────
+// 共通スタイル: すべてのプロンプトに付与
+// ────────────────────────────────────────────────────────────────────────────
+const STYLE_SUFFIX =
+  '3D isometric illustration, clean modern minimalist style, ' +
+  'deep navy blue gradient background (#101729 to #1F2942), ' +
+  'subtle warm golden glow accent in upper area, ' +
+  'soft pastel highlights, professional educational app thumbnail, ' +
+  'centered composition, cinematic lighting, octane render style, ' +
+  'no text, no captions, no watermarks, no logos, no letters, no numbers'
+
+// ────────────────────────────────────────────────────────────────────────────
+// コース別プロンプト (内容に沿った主題を 1-2 文で記述)
+// ────────────────────────────────────────────────────────────────────────────
+const COURSE_PROMPTS: Record<string, string> = {
+  // 思考の基礎
+  'logic-01':
+    'four colorful 3D isometric cubes arranged in a 2x2 grid (red, blue, gold, green) representing MECE classification, with a separate floating isometric tree of connected cube nodes branching outward like a logic tree, subtle floating papers with checkmarks',
+  'logic-02':
+    'a 3D isometric three-tier pyramid built from stacked cubes, with bidirectional vertical arrows on the side representing So What going up and Why So going down, a small figure presenting the pyramid to an audience',
+  'critical-01':
+    'a 3D isometric scene of a giant magnifying glass examining a floating document, with question marks transforming into green checkmarks, broken chain links representing logical fallacies floating around',
+  'critical-02':
+    'a 3D isometric translucent human brain with several glass filter panels being lifted away, releasing colored prismatic fragments representing cognitive biases drifting off',
+  // 課題発見・解決
+  'hypothesis-01':
+    'a 3D isometric scene with a floating hypothesis card connected by an arrow loop to a laboratory beaker and a magnifying glass, representing hypothesis-then-verify cycle',
+  'problem-01':
+    'a 3D isometric iceberg cut in half showing a small visible tip above the water and a massive submerged base with glowing root cause spheres inside, target marker on the deep core',
+  'design-01':
+    'a 3D isometric central persona figure surrounded by an empathy map split into four quadrants on the floor, sticky notes floating, prototype paper shapes, journey path lines',
+  'systems-01':
+    'a 3D isometric circular feedback loop diagram with connected nodes, large circular arrow flowing through them, an iceberg model integrated below the loop',
+  // 発想・創造
+  'lateral-01':
+    'a 3D isometric glowing lightbulb breaking out of a cube box, with sideways arrows pointing in unconventional directions, prism splitting white light into colors',
+  'analogy-01':
+    'a 3D isometric bridge connecting two distinct floating islands - left island shaped like a tree of nature, right island shaped like a business chart - with a glowing lightbulb hovering above the bridge',
+  'philosophy-01':
+    'a 3D isometric ancient Greek stone column with a contemplative thinker silhouette sitting beside it, an open scroll, abstract thought clouds with question marks above',
+  'eastern-01':
+    'a 3D isometric Chinese pavilion roof with a wise sage figure seated inside, traditional scrolls, glowing networked relationship lines connecting smaller figures around it, soft mist',
+  'eastern-02':
+    'a 3D isometric bamboo grove garden with a floating yin-yang symbol, abstract tao-flow lines like flowing water around stones, strategy chess pieces on a low platform',
+  // 伝える・提案する
+  'proposal-01':
+    'a 3D isometric professional document with a small presenter figure beside it, golden impact arrows radiating from the document toward a small target, audience silhouettes in front',
+  'proposal-course-01':
+    'a 3D isometric workflow from a small hypothesis card on the left to a polished bound proposal document on the right, with checkmark verification steps in between',
+  'client-01':
+    'a 3D isometric floating spreadsheet panel with bar charts and large numerical figures, a calculator, a business person reading the data with a confident posture',
+  'client-02':
+    'a 3D isometric scene with two figures across a small table, one extracting information through a glowing question stream, structured cards organizing the answers',
+  'client-03':
+    'a 3D isometric figure climbing a steeply rising learning curve graph, stacked books on the path, expert silhouettes guiding from above',
+  // ビジネス実践
+  'case-01':
+    'a 3D isometric profit equation tree splitting into revenue and cost branches with sub-cubes, a small interview chair scene, structured framework boards',
+  'strategy-01':
+    'a 3D isometric vintage industrial factory with conveyor belts on a circular platform, surrounded by five large arrows pointing inward representing five forces, a classic strategy book',
+  'strategy-02':
+    'a 3D isometric calm blue ocean with a small sailing ship, glowing resource gems on the seabed, mechanical capability gears interlocking, platform hub with radiating connections',
+  'fermi-01':
+    'a 3D isometric small earth globe with floating numerical figures around it, calculator, decomposition arrows breaking the globe into smaller cube estimates',
+  'numeracy-01':
+    'a 3D isometric scene with floating percentage symbol, yen currency sign, bar chart and pie chart, calculator, a person confidently reading numbers, scale balance',
+  'peak-performance-01':
+    'a 3D isometric morning scene with a moon-to-sun cycle arc, an energy graph rising and falling with peaks, an athletic figure stretching, a glowing focus zone marker',
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// レッスン別プロンプト (主要レッスンのみ。残りはカテゴリのフォールバックを使う)
+// ────────────────────────────────────────────────────────────────────────────
+const LESSON_PROMPTS: Record<number, string> = {
+  // ロジカルシンキング
+  20: 'a 3D isometric 2x2 grid of four large colored cubes (red, blue, gold, green) showing MECE classification, no overlap no gap',
+  21: 'a 3D isometric tree diagram with a single root cube branching into mid-level cubes and leaf cubes',
+  22: 'a 3D isometric pair of vertical arrows side by side, one pointing up and one pointing down, between layered cube stacks, representing So What and Why So',
+  23: 'a 3D isometric three-tier pyramid built from stacked cubes, conclusion on top supported by reason cubes below',
+  24: 'a 3D isometric briefcase opening with documents flying out, case study notebook, charts',
+  25: 'a 3D isometric flow from general principle cube down to specific conclusion cube, deduction arrow',
+  26: 'a 3D isometric flow from many small specific data cubes converging upward into a general pattern cube, induction arrow',
+  27: 'a 3D isometric formal logic gate diagram with truth state cubes glowing in a connected pattern',
+  68: 'a 3D isometric ladder of abstraction with concrete object cubes at the bottom and abstract idea cubes at the top, vertical arrow',
+  // ケース面接
+  28: 'a 3D isometric interview room with two chairs across a small table, structured frameworks floating between them',
+  29: 'a 3D isometric profit equation tree with revenue branch and cost branch breaking into smaller cubes',
+  35: 'a 3D isometric arrow pointing from a small island to a larger market continent, decision flowchart cubes around the arrow',
+  36: 'a 3D isometric two companies represented as separate cube clusters merging into one larger cluster, M&A handshake',
+  // クリティカルシンキング
+  40: 'a 3D isometric magnifying glass examining a checklist document, question marks turning into checkmarks',
+  41: 'a 3D isometric set of broken chain links labeled as logical fallacies, with a corrected solid chain link beside them',
+  42: 'a 3D isometric data dashboard with floating bar charts and a person carefully reading numbers, hidden patterns highlighted',
+  43: 'a 3D isometric large question mark cube being polished, surrounded by smaller question marks being filtered into a clearer one',
+  69: 'a 3D isometric brain with translucent biased glasses being removed, prismatic fragments drifting',
+  71: 'a 3D isometric two correlated wave lines diverging where one is a true cause arrow and the other is just correlation',
+  // 仮説思考
+  50: 'a 3D isometric thought bubble with a hypothesis card pointing forward to a verification path',
+  51: 'a 3D isometric figure drafting hypothesis cards on a desk, multiple options floating up',
+  52: 'a 3D isometric arrow loop from hypothesis card to data verification beaker and back',
+  70: 'a 3D isometric experimental setup with measurement instruments, control versus test cubes',
+  // 課題設定
+  53: 'a 3D isometric target board with concentric rings, an arrow finding the true bullseye among decoys',
+  54: 'a 3D isometric large issue card being decomposed downward into smaller sub-issue cubes',
+  55: 'a 3D isometric workspace with multiple problem cards being prioritized into a focused single card',
+  // デザインシンキング
+  56: 'a 3D isometric design thinking cycle with five connected stage cubes (empathize, define, ideate, prototype, test)',
+  57: 'a 3D isometric empathy map quadrants on the floor surrounding a central persona figure',
+  58: 'a 3D isometric prototype paper model being tested by a user figure with feedback bubbles',
+  // ラテラルシンキング
+  59: 'a 3D isometric lightbulb breaking out of a cube box, sideways arrows in unconventional directions',
+  60: 'a 3D isometric prism splitting a single light beam into multiple colorful diverging directions',
+  61: 'a 3D isometric flipped perspective scene where a problem cube is rotated to reveal a different unexpected facet',
+  // アナロジー思考
+  62: 'a 3D isometric bridge connecting two distinct floating islands with different visual themes',
+  63: 'a 3D isometric structural pattern card being lifted from one domain and placed onto another domain',
+  64: 'a 3D isometric two parallel scenes side by side with matching structural arrows showing analogy mapping',
+  // システムシンキング
+  65: 'a 3D isometric circular feedback loop with connected node cubes flowing in a circle',
+  66: 'a 3D isometric system archetype diagram with reinforcing and balancing loops shown as gears',
+  67: 'a 3D isometric iceberg model with events on top, patterns mid, structures and mental models at the deep base',
+  // 提案・伝える技術
+  72: 'a 3D isometric professional bound proposal document with a clear target arrow above it',
+  73: 'a 3D isometric two figures facing a document, one offering and one receiving, perspective lines aligning their viewpoints',
+  74: 'a 3D isometric storyline path with sequential narrative cube panels leading to a conclusion',
+  75: 'a 3D isometric message card being polished and sharpened on a workbench with sparkles',
+  76: 'a 3D isometric shield deflecting incoming counter-argument arrows, behind it a strong document',
+  // 哲学
+  77: 'a 3D isometric ancient Greek stone column with a Socrates-like silhouette and a scroll, question marks rising',
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// CLI 引数パース
+// ────────────────────────────────────────────────────────────────────────────
+type Args = {
+  target: 'courses' | 'lessons' | 'all'
+  only: string[] | null
+  skipExisting: boolean
+  model: string
+  aspect: string
+  concurrency: number
+  out: string
+  dryRun: boolean
+}
+
+function parseArgs(argv: string[]): Args {
+  const get = (key: string): string | undefined => {
+    const arg = argv.find((a) => a.startsWith(`--${key}=`))
+    return arg ? arg.slice(`--${key}=`.length) : undefined
+  }
+  const has = (key: string): boolean => argv.includes(`--${key}`)
+
+  const target = (get('target') ?? 'courses') as Args['target']
+  if (!['courses', 'lessons', 'all'].includes(target)) {
+    throw new Error(`invalid --target: ${target}`)
+  }
+  const only = get('only')?.split(',').map((s) => s.trim()).filter(Boolean) ?? null
+
+  return {
+    target,
+    only,
+    skipExisting: has('skip-existing'),
+    model: get('model') ?? 'imagen-4.0-generate-preview-06-06',
+    aspect: get('aspect') ?? '16:9',
+    concurrency: Number(get('concurrency') ?? 2),
+    out: get('out') ?? 'public/images/v3',
+    dryRun: has('dry-run'),
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Gemini Imagen API 呼び出し
+// ────────────────────────────────────────────────────────────────────────────
+type GenResult = { ok: true; bytes: Buffer } | { ok: false; error: string }
+
+async function generateImage(
+  prompt: string,
+  apiKey: string,
+  model: string,
+  aspect: string,
+): Promise<GenResult> {
+  const fullPrompt = `${prompt}, ${STYLE_SUFFIX}`
+
+  // Imagen 系 (predict) と Gemini Flash Image 系 (generateContent) で
+  // エンドポイント形式が違うので分岐
+  const isImagen = model.startsWith('imagen-')
+  const url = isImagen
+    ? `https://generativelanguage.googleapis.com/v1beta/models/${model}:predict?key=${apiKey}`
+    : `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`
+
+  const body = isImagen
+    ? {
+        instances: [{ prompt: fullPrompt }],
+        parameters: {
+          sampleCount: 1,
+          aspectRatio: aspect,
+          personGeneration: 'allow_adult',
+          safetyFilterLevel: 'block_only_high',
+        },
+      }
+    : {
+        contents: [{ parts: [{ text: fullPrompt }] }],
+        generationConfig: {
+          responseModalities: ['IMAGE', 'TEXT'],
+        },
+      }
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => '')
+    return { ok: false, error: `HTTP ${res.status}: ${errText.slice(0, 400)}` }
+  }
+
+  const json = (await res.json()) as Record<string, unknown>
+
+  if (isImagen) {
+    type Pred = { bytesBase64Encoded?: string }
+    const preds = (json as { predictions?: Pred[] }).predictions
+    const b64 = preds?.[0]?.bytesBase64Encoded
+    if (!b64) {
+      return {
+        ok: false,
+        error: `no image in response: ${JSON.stringify(json).slice(0, 300)}`,
+      }
+    }
+    return { ok: true, bytes: Buffer.from(b64, 'base64') }
+  } else {
+    type Cand = {
+      content?: { parts?: { inlineData?: { data?: string; mimeType?: string } }[] }
+    }
+    const cands = (json as { candidates?: Cand[] }).candidates
+    const parts = cands?.[0]?.content?.parts ?? []
+    const inline = parts.find((p) => p.inlineData?.data)?.inlineData
+    if (!inline?.data) {
+      return {
+        ok: false,
+        error: `no image in response: ${JSON.stringify(json).slice(0, 300)}`,
+      }
+    }
+    return { ok: true, bytes: Buffer.from(inline.data, 'base64') }
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// 並列実行ユーティリティ
+// ────────────────────────────────────────────────────────────────────────────
+async function runConcurrent<T>(
+  tasks: (() => Promise<T>)[],
+  concurrency: number,
+): Promise<T[]> {
+  const results: T[] = new Array(tasks.length)
+  let next = 0
+  async function worker() {
+    while (next < tasks.length) {
+      const i = next++
+      results[i] = await tasks[i]()
+    }
+  }
+  const workers = Array.from({ length: Math.max(1, concurrency) }, () => worker())
+  await Promise.all(workers)
+  return results
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// main
+// ────────────────────────────────────────────────────────────────────────────
+type Job = { kind: 'course' | 'lesson'; id: string; prompt: string; outFile: string }
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+
+  const __filename = fileURLToPath(import.meta.url)
+  const __dirname = dirname(__filename)
+  const repoRoot = resolve(__dirname, '..')
+  const outDir = resolve(repoRoot, args.out)
+  await mkdir(outDir, { recursive: true })
+
+  const jobs: Job[] = []
+
+  if (args.target === 'courses' || args.target === 'all') {
+    for (const [id, prompt] of Object.entries(COURSE_PROMPTS)) {
+      if (args.only && !args.only.includes(id)) continue
+      jobs.push({
+        kind: 'course',
+        id,
+        prompt,
+        outFile: resolve(outDir, `course-${id}.png`),
+      })
+    }
+  }
+  if (args.target === 'lessons' || args.target === 'all') {
+    for (const [idStr, prompt] of Object.entries(LESSON_PROMPTS)) {
+      if (args.only && !args.only.includes(idStr)) continue
+      jobs.push({
+        kind: 'lesson',
+        id: idStr,
+        prompt,
+        outFile: resolve(outDir, `lesson-${idStr}.png`),
+      })
+    }
+  }
+
+  if (jobs.length === 0) {
+    console.error('no jobs to run (check --target / --only)')
+    process.exit(1)
+  }
+
+  const apiKey = process.env.GEMINI_API_KEY
+  if (!apiKey && !args.dryRun) {
+    console.error('error: GEMINI_API_KEY is not set')
+    process.exit(1)
+  }
+
+  console.log(
+    `[gen] model=${args.model} aspect=${args.aspect} concurrency=${args.concurrency} jobs=${jobs.length}`,
+  )
+
+  let done = 0
+  let skipped = 0
+  let failed = 0
+
+  const tasks = jobs.map((job) => async () => {
+    if (args.skipExisting && (await fileExists(job.outFile))) {
+      skipped++
+      console.log(`[skip] ${job.kind}/${job.id} (exists)`)
+      return
+    }
+    if (args.dryRun) {
+      console.log(`[dry-run] ${job.kind}/${job.id}\n  prompt: ${job.prompt}\n`)
+      done++
+      return
+    }
+    try {
+      const r = await generateImage(job.prompt, apiKey!, args.model, args.aspect)
+      if (!r.ok) {
+        failed++
+        console.error(`[fail] ${job.kind}/${job.id}: ${r.error}`)
+        return
+      }
+      await writeFile(job.outFile, r.bytes)
+      done++
+      console.log(`[ok]   ${job.kind}/${job.id} → ${job.outFile} (${r.bytes.length} bytes)`)
+    } catch (e) {
+      failed++
+      console.error(`[err]  ${job.kind}/${job.id}:`, (e as Error).message)
+    }
+  })
+
+  await runConcurrent(tasks, args.concurrency)
+
+  console.log(`\n[done] ok=${done} skipped=${skipped} failed=${failed}`)
+  if (failed > 0) process.exit(1)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/scripts/generate-course-images.ts
+++ b/scripts/generate-course-images.ts
@@ -25,142 +25,19 @@
  * 出力ファイル名:
  *   コース: course-{id}.png    例: course-logic-01.png
  *   レッスン: lesson-{id}.png  例: lesson-20.png
+ *
+ * プロンプトは scripts/imagePrompts.ts に集約されている。
  */
 
 import { writeFile, mkdir, access } from 'node:fs/promises'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-
-// ────────────────────────────────────────────────────────────────────────────
-// 共通スタイル: すべてのプロンプトに付与
-// ────────────────────────────────────────────────────────────────────────────
-const STYLE_SUFFIX =
-  '3D isometric illustration, clean modern minimalist style, ' +
-  'deep navy blue gradient background (#101729 to #1F2942), ' +
-  'subtle warm golden glow accent in upper area, ' +
-  'soft pastel highlights, professional educational app thumbnail, ' +
-  'centered composition, cinematic lighting, octane render style, ' +
-  'no text, no captions, no watermarks, no logos, no letters, no numbers'
-
-// ────────────────────────────────────────────────────────────────────────────
-// コース別プロンプト (内容に沿った主題を 1-2 文で記述)
-// ────────────────────────────────────────────────────────────────────────────
-const COURSE_PROMPTS: Record<string, string> = {
-  // 思考の基礎
-  'logic-01':
-    'four colorful 3D isometric cubes arranged in a 2x2 grid (red, blue, gold, green) representing MECE classification, with a separate floating isometric tree of connected cube nodes branching outward like a logic tree, subtle floating papers with checkmarks',
-  'logic-02':
-    'a 3D isometric three-tier pyramid built from stacked cubes, with bidirectional vertical arrows on the side representing So What going up and Why So going down, a small figure presenting the pyramid to an audience',
-  'critical-01':
-    'a 3D isometric scene of a giant magnifying glass examining a floating document, with question marks transforming into green checkmarks, broken chain links representing logical fallacies floating around',
-  'critical-02':
-    'a 3D isometric translucent human brain with several glass filter panels being lifted away, releasing colored prismatic fragments representing cognitive biases drifting off',
-  // 課題発見・解決
-  'hypothesis-01':
-    'a 3D isometric scene with a floating hypothesis card connected by an arrow loop to a laboratory beaker and a magnifying glass, representing hypothesis-then-verify cycle',
-  'problem-01':
-    'a 3D isometric iceberg cut in half showing a small visible tip above the water and a massive submerged base with glowing root cause spheres inside, target marker on the deep core',
-  'design-01':
-    'a 3D isometric central persona figure surrounded by an empathy map split into four quadrants on the floor, sticky notes floating, prototype paper shapes, journey path lines',
-  'systems-01':
-    'a 3D isometric circular feedback loop diagram with connected nodes, large circular arrow flowing through them, an iceberg model integrated below the loop',
-  // 発想・創造
-  'lateral-01':
-    'a 3D isometric glowing lightbulb breaking out of a cube box, with sideways arrows pointing in unconventional directions, prism splitting white light into colors',
-  'analogy-01':
-    'a 3D isometric bridge connecting two distinct floating islands - left island shaped like a tree of nature, right island shaped like a business chart - with a glowing lightbulb hovering above the bridge',
-  'philosophy-01':
-    'a 3D isometric ancient Greek stone column with a contemplative thinker silhouette sitting beside it, an open scroll, abstract thought clouds with question marks above',
-  'eastern-01':
-    'a 3D isometric Chinese pavilion roof with a wise sage figure seated inside, traditional scrolls, glowing networked relationship lines connecting smaller figures around it, soft mist',
-  'eastern-02':
-    'a 3D isometric bamboo grove garden with a floating yin-yang symbol, abstract tao-flow lines like flowing water around stones, strategy chess pieces on a low platform',
-  // 伝える・提案する
-  'proposal-01':
-    'a 3D isometric professional document with a small presenter figure beside it, golden impact arrows radiating from the document toward a small target, audience silhouettes in front',
-  'proposal-course-01':
-    'a 3D isometric workflow from a small hypothesis card on the left to a polished bound proposal document on the right, with checkmark verification steps in between',
-  'client-01':
-    'a 3D isometric floating spreadsheet panel with bar charts and large numerical figures, a calculator, a business person reading the data with a confident posture',
-  'client-02':
-    'a 3D isometric scene with two figures across a small table, one extracting information through a glowing question stream, structured cards organizing the answers',
-  'client-03':
-    'a 3D isometric figure climbing a steeply rising learning curve graph, stacked books on the path, expert silhouettes guiding from above',
-  // ビジネス実践
-  'case-01':
-    'a 3D isometric profit equation tree splitting into revenue and cost branches with sub-cubes, a small interview chair scene, structured framework boards',
-  'strategy-01':
-    'a 3D isometric vintage industrial factory with conveyor belts on a circular platform, surrounded by five large arrows pointing inward representing five forces, a classic strategy book',
-  'strategy-02':
-    'a 3D isometric calm blue ocean with a small sailing ship, glowing resource gems on the seabed, mechanical capability gears interlocking, platform hub with radiating connections',
-  'fermi-01':
-    'a 3D isometric small earth globe with floating numerical figures around it, calculator, decomposition arrows breaking the globe into smaller cube estimates',
-  'numeracy-01':
-    'a 3D isometric scene with floating percentage symbol, yen currency sign, bar chart and pie chart, calculator, a person confidently reading numbers, scale balance',
-  'peak-performance-01':
-    'a 3D isometric morning scene with a moon-to-sun cycle arc, an energy graph rising and falling with peaks, an athletic figure stretching, a glowing focus zone marker',
-}
-
-// ────────────────────────────────────────────────────────────────────────────
-// レッスン別プロンプト (主要レッスンのみ。残りはカテゴリのフォールバックを使う)
-// ────────────────────────────────────────────────────────────────────────────
-const LESSON_PROMPTS: Record<number, string> = {
-  // ロジカルシンキング
-  20: 'a 3D isometric 2x2 grid of four large colored cubes (red, blue, gold, green) showing MECE classification, no overlap no gap',
-  21: 'a 3D isometric tree diagram with a single root cube branching into mid-level cubes and leaf cubes',
-  22: 'a 3D isometric pair of vertical arrows side by side, one pointing up and one pointing down, between layered cube stacks, representing So What and Why So',
-  23: 'a 3D isometric three-tier pyramid built from stacked cubes, conclusion on top supported by reason cubes below',
-  24: 'a 3D isometric briefcase opening with documents flying out, case study notebook, charts',
-  25: 'a 3D isometric flow from general principle cube down to specific conclusion cube, deduction arrow',
-  26: 'a 3D isometric flow from many small specific data cubes converging upward into a general pattern cube, induction arrow',
-  27: 'a 3D isometric formal logic gate diagram with truth state cubes glowing in a connected pattern',
-  68: 'a 3D isometric ladder of abstraction with concrete object cubes at the bottom and abstract idea cubes at the top, vertical arrow',
-  // ケース面接
-  28: 'a 3D isometric interview room with two chairs across a small table, structured frameworks floating between them',
-  29: 'a 3D isometric profit equation tree with revenue branch and cost branch breaking into smaller cubes',
-  35: 'a 3D isometric arrow pointing from a small island to a larger market continent, decision flowchart cubes around the arrow',
-  36: 'a 3D isometric two companies represented as separate cube clusters merging into one larger cluster, M&A handshake',
-  // クリティカルシンキング
-  40: 'a 3D isometric magnifying glass examining a checklist document, question marks turning into checkmarks',
-  41: 'a 3D isometric set of broken chain links labeled as logical fallacies, with a corrected solid chain link beside them',
-  42: 'a 3D isometric data dashboard with floating bar charts and a person carefully reading numbers, hidden patterns highlighted',
-  43: 'a 3D isometric large question mark cube being polished, surrounded by smaller question marks being filtered into a clearer one',
-  69: 'a 3D isometric brain with translucent biased glasses being removed, prismatic fragments drifting',
-  71: 'a 3D isometric two correlated wave lines diverging where one is a true cause arrow and the other is just correlation',
-  // 仮説思考
-  50: 'a 3D isometric thought bubble with a hypothesis card pointing forward to a verification path',
-  51: 'a 3D isometric figure drafting hypothesis cards on a desk, multiple options floating up',
-  52: 'a 3D isometric arrow loop from hypothesis card to data verification beaker and back',
-  70: 'a 3D isometric experimental setup with measurement instruments, control versus test cubes',
-  // 課題設定
-  53: 'a 3D isometric target board with concentric rings, an arrow finding the true bullseye among decoys',
-  54: 'a 3D isometric large issue card being decomposed downward into smaller sub-issue cubes',
-  55: 'a 3D isometric workspace with multiple problem cards being prioritized into a focused single card',
-  // デザインシンキング
-  56: 'a 3D isometric design thinking cycle with five connected stage cubes (empathize, define, ideate, prototype, test)',
-  57: 'a 3D isometric empathy map quadrants on the floor surrounding a central persona figure',
-  58: 'a 3D isometric prototype paper model being tested by a user figure with feedback bubbles',
-  // ラテラルシンキング
-  59: 'a 3D isometric lightbulb breaking out of a cube box, sideways arrows in unconventional directions',
-  60: 'a 3D isometric prism splitting a single light beam into multiple colorful diverging directions',
-  61: 'a 3D isometric flipped perspective scene where a problem cube is rotated to reveal a different unexpected facet',
-  // アナロジー思考
-  62: 'a 3D isometric bridge connecting two distinct floating islands with different visual themes',
-  63: 'a 3D isometric structural pattern card being lifted from one domain and placed onto another domain',
-  64: 'a 3D isometric two parallel scenes side by side with matching structural arrows showing analogy mapping',
-  // システムシンキング
-  65: 'a 3D isometric circular feedback loop with connected node cubes flowing in a circle',
-  66: 'a 3D isometric system archetype diagram with reinforcing and balancing loops shown as gears',
-  67: 'a 3D isometric iceberg model with events on top, patterns mid, structures and mental models at the deep base',
-  // 提案・伝える技術
-  72: 'a 3D isometric professional bound proposal document with a clear target arrow above it',
-  73: 'a 3D isometric two figures facing a document, one offering and one receiving, perspective lines aligning their viewpoints',
-  74: 'a 3D isometric storyline path with sequential narrative cube panels leading to a conclusion',
-  75: 'a 3D isometric message card being polished and sharpened on a workbench with sparkles',
-  76: 'a 3D isometric shield deflecting incoming counter-argument arrows, behind it a strong document',
-  // 哲学
-  77: 'a 3D isometric ancient Greek stone column with a Socrates-like silhouette and a scroll, question marks rising',
-}
+import {
+  STYLE_SUFFIX,
+  COURSE_PROMPTS,
+  LESSON_PROMPTS,
+  type ImagePromptEntry,
+} from './imagePrompts.ts'
 
 // ────────────────────────────────────────────────────────────────────────────
 // CLI 引数パース
@@ -202,7 +79,7 @@ function parseArgs(argv: string[]): Args {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Gemini Imagen API 呼び出し
+// Gemini API 呼び出し
 // ────────────────────────────────────────────────────────────────────────────
 type GenResult = { ok: true; bytes: Buffer } | { ok: false; error: string }
 
@@ -311,7 +188,36 @@ async function fileExists(path: string): Promise<boolean> {
 // ────────────────────────────────────────────────────────────────────────────
 // main
 // ────────────────────────────────────────────────────────────────────────────
-type Job = { kind: 'course' | 'lesson'; id: string; prompt: string; outFile: string }
+type Job = {
+  kind: 'course' | 'lesson'
+  id: string
+  prompt: string
+  outFile: string
+}
+
+function buildJobs(args: Args, outDir: string): Job[] {
+  const jobs: Job[] = []
+  const push = (kind: Job['kind'], entries: ImagePromptEntry[]) => {
+    for (const e of entries) {
+      if (args.only && !args.only.includes(e.id)) continue
+      jobs.push({
+        kind,
+        id: e.id,
+        prompt: e.prompt,
+        outFile: resolve(outDir, e.filename),
+      })
+    }
+  }
+
+  if (args.target === 'courses' || args.target === 'all') {
+    push('course', COURSE_PROMPTS)
+  }
+  if (args.target === 'lessons' || args.target === 'all') {
+    push('lesson', LESSON_PROMPTS)
+  }
+
+  return jobs
+}
 
 async function main() {
   const args = parseArgs(process.argv.slice(2))
@@ -322,30 +228,7 @@ async function main() {
   const outDir = resolve(repoRoot, args.out)
   await mkdir(outDir, { recursive: true })
 
-  const jobs: Job[] = []
-
-  if (args.target === 'courses' || args.target === 'all') {
-    for (const [id, prompt] of Object.entries(COURSE_PROMPTS)) {
-      if (args.only && !args.only.includes(id)) continue
-      jobs.push({
-        kind: 'course',
-        id,
-        prompt,
-        outFile: resolve(outDir, `course-${id}.png`),
-      })
-    }
-  }
-  if (args.target === 'lessons' || args.target === 'all') {
-    for (const [idStr, prompt] of Object.entries(LESSON_PROMPTS)) {
-      if (args.only && !args.only.includes(idStr)) continue
-      jobs.push({
-        kind: 'lesson',
-        id: idStr,
-        prompt,
-        outFile: resolve(outDir, `lesson-${idStr}.png`),
-      })
-    }
-  }
+  const jobs = buildJobs(args, outDir)
 
   if (jobs.length === 0) {
     console.error('no jobs to run (check --target / --only)')

--- a/scripts/imagePrompts.ts
+++ b/scripts/imagePrompts.ts
@@ -1,0 +1,271 @@
+/**
+ * コース／レッスン画像生成のプロンプト定義（単一の真実情報源）
+ *
+ * このモジュールは以下から参照される:
+ * - scripts/generate-course-images.ts  (Gemini API で自動生成)
+ * - scripts/wire-images.ts             (生成済 PNG を courseData/lessonSlides に紐付け)
+ * - scripts/print-prompts-md.ts        (docs/IMAGE_GENERATION.md を自動生成)
+ *
+ * すべてのプロンプトには共通スタイル (STYLE_SUFFIX) が付与される。
+ */
+
+// ────────────────────────────────────────────────────────────────────────────
+// 共通スタイル
+// ────────────────────────────────────────────────────────────────────────────
+export const STYLE_SUFFIX =
+  '3D isometric illustration, clean modern minimalist style, ' +
+  'deep navy blue gradient background (#101729 to #1F2942), ' +
+  'subtle warm golden glow accent in upper area, ' +
+  'soft pastel highlights, professional educational app thumbnail, ' +
+  'centered composition, cinematic lighting, octane render style, ' +
+  'no text, no captions, no watermarks, no logos, no letters, no numbers'
+
+// ────────────────────────────────────────────────────────────────────────────
+// 型
+// ────────────────────────────────────────────────────────────────────────────
+export type ImagePromptEntry = {
+  id: string // 'logic-01' (course) または '20' (lesson)
+  title: string // 表示タイトル（ドキュメント用）
+  prompt: string // プロンプト本体（STYLE_SUFFIX 抜き）
+  filename: string // 保存ファイル名 (e.g. 'course-logic-01.png')
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// コース (24件)
+// ────────────────────────────────────────────────────────────────────────────
+export const COURSE_PROMPTS: ImagePromptEntry[] = [
+  // 思考の基礎
+  {
+    id: 'logic-01',
+    title: 'ロジカルに考えて、整理する',
+    prompt:
+      'four colorful 3D isometric cubes arranged in a 2x2 grid (red, blue, gold, green) representing MECE classification, with a separate floating isometric tree of connected cube nodes branching outward like a logic tree, subtle floating papers with checkmarks',
+    filename: 'course-logic-01.png',
+  },
+  {
+    id: 'logic-02',
+    title: '論理を組み立て、相手を動かす',
+    prompt:
+      'a 3D isometric three-tier pyramid built from stacked cubes, with bidirectional vertical arrows on the side representing So What going up and Why So going down, a small figure presenting the pyramid to an audience',
+    filename: 'course-logic-02.png',
+  },
+  {
+    id: 'critical-01',
+    title: '思い込みを疑い、正しく判断する',
+    prompt:
+      'a 3D isometric scene of a giant magnifying glass examining a floating document, with question marks transforming into green checkmarks, broken chain links representing logical fallacies floating around',
+    filename: 'course-critical-01.png',
+  },
+  {
+    id: 'critical-02',
+    title: 'バイアスを外し、客観的に見る',
+    prompt:
+      'a 3D isometric translucent human brain with several glass filter panels being lifted away, releasing colored prismatic fragments representing cognitive biases drifting off',
+    filename: 'course-critical-02.png',
+  },
+  // 課題発見・解決
+  {
+    id: 'hypothesis-01',
+    title: '仮説を立ててから、調べる',
+    prompt:
+      'a 3D isometric scene with a floating hypothesis card connected by an arrow loop to a laboratory beaker and a magnifying glass, representing hypothesis-then-verify cycle',
+    filename: 'course-hypothesis-01.png',
+  },
+  {
+    id: 'problem-01',
+    title: '本当の問題を見極め、定義する',
+    prompt:
+      'a 3D isometric iceberg cut in half showing a small visible tip above the water and a massive submerged base with glowing root cause spheres inside, target marker on the deep core',
+    filename: 'course-problem-01.png',
+  },
+  {
+    id: 'design-01',
+    title: 'ユーザーの本音を掘り下げ、解決する',
+    prompt:
+      'a 3D isometric central persona figure surrounded by an empathy map split into four quadrants on the floor, sticky notes floating, prototype paper shapes, journey path lines',
+    filename: 'course-design-01.png',
+  },
+  {
+    id: 'systems-01',
+    title: '全体を俯瞰し、根本から変える',
+    prompt:
+      'a 3D isometric circular feedback loop diagram with connected nodes, large circular arrow flowing through them, an iceberg model integrated below the loop',
+    filename: 'course-systems-01.png',
+  },
+  // 発想・創造
+  {
+    id: 'lateral-01',
+    title: '常識を疑い、突破口を開く',
+    prompt:
+      'a 3D isometric glowing lightbulb breaking out of a cube box, with sideways arrows pointing in unconventional directions, prism splitting white light into colors',
+    filename: 'course-lateral-01.png',
+  },
+  {
+    id: 'analogy-01',
+    title: '別分野の知恵を借りて、応用する',
+    prompt:
+      'a 3D isometric bridge connecting two distinct floating islands - left island shaped like a tree of nature, right island shaped like a business chart - with a glowing lightbulb hovering above the bridge',
+    filename: 'course-analogy-01.png',
+  },
+  {
+    id: 'philosophy-01',
+    title: '哲学の問いで、思考を深める',
+    prompt:
+      'a 3D isometric ancient Greek stone column with a contemplative thinker silhouette sitting beside it, an open scroll, abstract thought clouds with question marks above',
+    filename: 'course-philosophy-01.png',
+  },
+  {
+    id: 'eastern-01',
+    title: '古代中国思想で、人と組織を見る',
+    prompt:
+      'a 3D isometric Chinese pavilion roof with a wise sage figure seated inside, traditional scrolls, glowing networked relationship lines connecting smaller figures around it, soft mist',
+    filename: 'course-eastern-01.png',
+  },
+  {
+    id: 'eastern-02',
+    title: '古代中国思想で、戦略と決断を見る',
+    prompt:
+      'a 3D isometric bamboo grove garden with a floating yin-yang symbol, abstract tao-flow lines like flowing water around stones, strategy chess pieces on a low platform',
+    filename: 'course-eastern-02.png',
+  },
+  // 伝える・提案する
+  {
+    id: 'proposal-01',
+    title: '相手が動く提案をつくる',
+    prompt:
+      'a 3D isometric professional document with a small presenter figure beside it, golden impact arrows radiating from the document toward a small target, audience silhouettes in front',
+    filename: 'course-proposal-01.png',
+  },
+  {
+    id: 'proposal-course-01',
+    title: '仮説と検証で、提案書を仕上げる',
+    prompt:
+      'a 3D isometric workflow from a small hypothesis card on the left to a polished bound proposal document on the right, with checkmark verification steps in between',
+    filename: 'course-proposal-course-01.png',
+  },
+  {
+    id: 'client-01',
+    title: '数字で状況を素早く読み解く',
+    prompt:
+      'a 3D isometric floating spreadsheet panel with bar charts and large numerical figures, a calculator, a business person reading the data with a confident posture',
+    filename: 'course-client-01.png',
+  },
+  {
+    id: 'client-02',
+    title: '論点を定め、深く引き出す',
+    prompt:
+      'a 3D isometric scene with two figures across a small table, one extracting information through a glowing question stream, structured cards organizing the answers',
+    filename: 'course-client-02.png',
+  },
+  {
+    id: 'client-03',
+    title: '未経験の業界で、短期間で立ち上がる',
+    prompt:
+      'a 3D isometric figure climbing a steeply rising learning curve graph, stacked books on the path, expert silhouettes guiding from above',
+    filename: 'course-client-03.png',
+  },
+  // ビジネス実践
+  {
+    id: 'case-01',
+    title: 'ケース面接で、論理力を証明する',
+    prompt:
+      'a 3D isometric profit equation tree splitting into revenue and cost branches with sub-cubes, a small interview chair scene, structured framework boards',
+    filename: 'course-case-01.png',
+  },
+  {
+    id: 'strategy-01',
+    title: '戦略の源流と競争戦略を学ぶ',
+    prompt:
+      'a 3D isometric vintage industrial factory with conveyor belts on a circular platform, surrounded by five large arrows pointing inward representing five forces, a classic strategy book',
+    filename: 'course-strategy-01.png',
+  },
+  {
+    id: 'strategy-02',
+    title: '資源・能力・共進化の戦略へ',
+    prompt:
+      'a 3D isometric calm blue ocean with a small sailing ship, glowing resource gems on the seabed, mechanical capability gears interlocking, platform hub with radiating connections',
+    filename: 'course-strategy-02.png',
+  },
+  {
+    id: 'fermi-01',
+    title: '概算で、世界の規模を掴む',
+    prompt:
+      'a 3D isometric small earth globe with floating numerical figures around it, calculator, decomposition arrows breaking the globe into smaller cube estimates',
+    filename: 'course-fermi-01.png',
+  },
+  {
+    id: 'numeracy-01',
+    title: '数字に強くなる',
+    prompt:
+      'a 3D isometric scene with floating percentage symbol, yen currency sign, bar chart and pie chart, calculator, a person confidently reading numbers, scale balance',
+    filename: 'course-numeracy-01.png',
+  },
+  {
+    id: 'peak-performance-01',
+    title: '自分史上最高のパフォーマンスで働く',
+    prompt:
+      'a 3D isometric morning scene with a moon-to-sun cycle arc, an energy graph rising and falling with peaks, an athletic figure stretching, a glowing focus zone marker',
+    filename: 'course-peak-performance-01.png',
+  },
+]
+
+// ────────────────────────────────────────────────────────────────────────────
+// レッスン (44件 — 個別画像が割り当てられているもの)
+// ────────────────────────────────────────────────────────────────────────────
+export const LESSON_PROMPTS: ImagePromptEntry[] = [
+  // ロジカルシンキング
+  { id: '20', title: 'MECE', prompt: 'a 3D isometric 2x2 grid of four large colored cubes (red, blue, gold, green) showing MECE classification, no overlap no gap', filename: 'lesson-20.png' },
+  { id: '21', title: 'ロジックツリー', prompt: 'a 3D isometric tree diagram with a single root cube branching into mid-level cubes and leaf cubes', filename: 'lesson-21.png' },
+  { id: '22', title: 'So What / Why So', prompt: 'a 3D isometric pair of vertical arrows side by side, one pointing up and one pointing down, between layered cube stacks, representing So What and Why So', filename: 'lesson-22.png' },
+  { id: '23', title: 'ピラミッド原則', prompt: 'a 3D isometric three-tier pyramid built from stacked cubes, conclusion on top supported by reason cubes below', filename: 'lesson-23.png' },
+  { id: '24', title: 'ケーススタディ', prompt: 'a 3D isometric briefcase opening with documents flying out, case study notebook, charts', filename: 'lesson-24.png' },
+  { id: '25', title: '演繹法', prompt: 'a 3D isometric flow from general principle cube down to specific conclusion cube, deduction arrow', filename: 'lesson-25.png' },
+  { id: '26', title: '帰納法', prompt: 'a 3D isometric flow from many small specific data cubes converging upward into a general pattern cube, induction arrow', filename: 'lesson-26.png' },
+  { id: '27', title: '形式論理', prompt: 'a 3D isometric formal logic gate diagram with truth state cubes glowing in a connected pattern', filename: 'lesson-27.png' },
+  { id: '68', title: '具体と抽象', prompt: 'a 3D isometric ladder of abstraction with concrete object cubes at the bottom and abstract idea cubes at the top, vertical arrow', filename: 'lesson-68.png' },
+  // ケース面接
+  { id: '28', title: 'ケース面接入門', prompt: 'a 3D isometric interview room with two chairs across a small table, structured frameworks floating between them', filename: 'lesson-28.png' },
+  { id: '29', title: 'プロフィタビリティ', prompt: 'a 3D isometric profit equation tree with revenue branch and cost branch breaking into smaller cubes', filename: 'lesson-29.png' },
+  { id: '35', title: '新市場参入', prompt: 'a 3D isometric arrow pointing from a small island to a larger market continent, decision flowchart cubes around the arrow', filename: 'lesson-35.png' },
+  { id: '36', title: 'M&A', prompt: 'a 3D isometric two companies represented as separate cube clusters merging into one larger cluster, M&A handshake', filename: 'lesson-36.png' },
+  // クリティカルシンキング
+  { id: '40', title: 'クリティカルシンキング入門', prompt: 'a 3D isometric magnifying glass examining a checklist document, question marks turning into checkmarks', filename: 'lesson-40.png' },
+  { id: '41', title: '論理的誤謬', prompt: 'a 3D isometric set of broken chain links labeled as logical fallacies, with a corrected solid chain link beside them', filename: 'lesson-41.png' },
+  { id: '42', title: 'データを読む', prompt: 'a 3D isometric data dashboard with floating bar charts and a person carefully reading numbers, hidden patterns highlighted', filename: 'lesson-42.png' },
+  { id: '43', title: '問いを立てる', prompt: 'a 3D isometric large question mark cube being polished, surrounded by smaller question marks being filtered into a clearer one', filename: 'lesson-43.png' },
+  { id: '69', title: '認知バイアス', prompt: 'a 3D isometric brain with translucent biased glasses being removed, prismatic fragments drifting', filename: 'lesson-69.png' },
+  { id: '71', title: '相関と因果', prompt: 'a 3D isometric two correlated wave lines diverging where one is a true cause arrow and the other is just correlation', filename: 'lesson-71.png' },
+  // 仮説思考
+  { id: '50', title: '仮説思考入門', prompt: 'a 3D isometric thought bubble with a hypothesis card pointing forward to a verification path', filename: 'lesson-50.png' },
+  { id: '51', title: '仮説の立て方', prompt: 'a 3D isometric figure drafting hypothesis cards on a desk, multiple options floating up', filename: 'lesson-51.png' },
+  { id: '52', title: '仮説ドリブン', prompt: 'a 3D isometric arrow loop from hypothesis card to data verification beaker and back', filename: 'lesson-52.png' },
+  { id: '70', title: '仮説の検証設計', prompt: 'a 3D isometric experimental setup with measurement instruments, control versus test cubes', filename: 'lesson-70.png' },
+  // 課題設定
+  { id: '53', title: '課題設定入門', prompt: 'a 3D isometric target board with concentric rings, an arrow finding the true bullseye among decoys', filename: 'lesson-53.png' },
+  { id: '54', title: 'イシュー分析', prompt: 'a 3D isometric large issue card being decomposed downward into smaller sub-issue cubes', filename: 'lesson-54.png' },
+  { id: '55', title: '課題設定実践', prompt: 'a 3D isometric workspace with multiple problem cards being prioritized into a focused single card', filename: 'lesson-55.png' },
+  // デザインシンキング
+  { id: '56', title: 'デザインシンキング入門', prompt: 'a 3D isometric design thinking cycle with five connected stage cubes (empathize, define, ideate, prototype, test)', filename: 'lesson-56.png' },
+  { id: '57', title: '共感マップ', prompt: 'a 3D isometric empathy map quadrants on the floor surrounding a central persona figure', filename: 'lesson-57.png' },
+  { id: '58', title: 'デザインシンキング実践', prompt: 'a 3D isometric prototype paper model being tested by a user figure with feedback bubbles', filename: 'lesson-58.png' },
+  // ラテラルシンキング
+  { id: '59', title: 'ラテラルシンキング入門', prompt: 'a 3D isometric lightbulb breaking out of a cube box, sideways arrows in unconventional directions', filename: 'lesson-59.png' },
+  { id: '60', title: 'ラテラル技法', prompt: 'a 3D isometric prism splitting a single light beam into multiple colorful diverging directions', filename: 'lesson-60.png' },
+  { id: '61', title: 'ラテラル実践', prompt: 'a 3D isometric flipped perspective scene where a problem cube is rotated to reveal a different unexpected facet', filename: 'lesson-61.png' },
+  // アナロジー思考
+  { id: '62', title: 'アナロジー思考入門', prompt: 'a 3D isometric bridge connecting two distinct floating islands with different visual themes', filename: 'lesson-62.png' },
+  { id: '63', title: 'アナロジー技法', prompt: 'a 3D isometric structural pattern card being lifted from one domain and placed onto another domain', filename: 'lesson-63.png' },
+  { id: '64', title: 'アナロジー実践', prompt: 'a 3D isometric two parallel scenes side by side with matching structural arrows showing analogy mapping', filename: 'lesson-64.png' },
+  // システムシンキング
+  { id: '65', title: 'システムシンキング入門', prompt: 'a 3D isometric circular feedback loop with connected node cubes flowing in a circle', filename: 'lesson-65.png' },
+  { id: '66', title: 'システム原型', prompt: 'a 3D isometric system archetype diagram with reinforcing and balancing loops shown as gears', filename: 'lesson-66.png' },
+  { id: '67', title: 'システム実践', prompt: 'a 3D isometric iceberg model with events on top, patterns mid, structures and mental models at the deep base', filename: 'lesson-67.png' },
+  // 提案・伝える技術
+  { id: '72', title: '提案書の目的', prompt: 'a 3D isometric professional bound proposal document with a clear target arrow above it', filename: 'lesson-72.png' },
+  { id: '73', title: '相手の立場', prompt: 'a 3D isometric two figures facing a document, one offering and one receiving, perspective lines aligning their viewpoints', filename: 'lesson-73.png' },
+  { id: '74', title: 'ストーリーライン', prompt: 'a 3D isometric storyline path with sequential narrative cube panels leading to a conclusion', filename: 'lesson-74.png' },
+  { id: '75', title: 'メッセージを磨く', prompt: 'a 3D isometric message card being polished and sharpened on a workbench with sparkles', filename: 'lesson-75.png' },
+  { id: '76', title: '反論を先読み', prompt: 'a 3D isometric shield deflecting incoming counter-argument arrows, behind it a strong document', filename: 'lesson-76.png' },
+  // 哲学
+  { id: '77', title: 'ソクラテス', prompt: 'a 3D isometric ancient Greek stone column with a Socrates-like silhouette and a scroll, question marks rising', filename: 'lesson-77.png' },
+]

--- a/scripts/print-batch-prompt.ts
+++ b/scripts/print-batch-prompt.ts
@@ -1,0 +1,81 @@
+/**
+ * 一括ペースト用のプロンプトを 1 つの大きなテキストにまとめて出力する。
+ *
+ * 使い方:
+ *   npx tsx scripts/print-batch-prompt.ts            # 標準出力
+ *   npx tsx scripts/print-batch-prompt.ts --write    # docs/BATCH_PROMPT.txt に保存
+ */
+
+import { writeFile } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  STYLE_SUFFIX,
+  COURSE_PROMPTS,
+  LESSON_PROMPTS,
+} from './imagePrompts.ts'
+
+function render(): string {
+  const out: string[] = []
+  out.push('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━')
+  out.push('画像生成バッチ依頼')
+  out.push('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━')
+  out.push('')
+  out.push('以下のリストを上から順番に、1 件ずつ画像生成してください。')
+  out.push('各画像の生成時は必ず:')
+  out.push('  - 共通スタイル（下記）を完全に守る')
+  out.push('  - 16:9 のアスペクト比')
+  out.push('  - 文字・ロゴ・透かし・数字を一切含めない')
+  out.push('  - 出力時に「ファイル名: xxx.png」と一行添える')
+  out.push('  - 一回のメッセージで 1 枚ずつ生成 (ペースを守って続けてください)')
+  out.push('')
+  out.push('完成後、このチャット内のすべての画像を順次保存します。')
+  out.push('')
+  out.push('━━━ 共通スタイル（全画像共通） ━━━')
+  out.push('')
+  out.push(STYLE_SUFFIX)
+  out.push('')
+  out.push(`━━━ コース ${COURSE_PROMPTS.length}枚 ━━━`)
+  out.push('')
+  let n = 1
+  for (const e of COURSE_PROMPTS) {
+    out.push(`${String(n).padStart(2, '0')}. ファイル名: ${e.filename}`)
+    out.push(`    題材: ${e.title}`)
+    out.push(`    プロンプト: ${e.prompt}`)
+    out.push('')
+    n++
+  }
+  out.push(`━━━ レッスン ${LESSON_PROMPTS.length}枚 ━━━`)
+  out.push('')
+  for (const e of LESSON_PROMPTS) {
+    out.push(`${String(n).padStart(2, '0')}. ファイル名: ${e.filename}`)
+    out.push(`    題材: ${e.title}`)
+    out.push(`    プロンプト: ${e.prompt}`)
+    out.push('')
+    n++
+  }
+  out.push('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━')
+  out.push(`合計 ${COURSE_PROMPTS.length + LESSON_PROMPTS.length} 枚。準備ができたら 1 番から順に生成を始めてください。`)
+  out.push('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━')
+  return out.join('\n')
+}
+
+async function main() {
+  const text = render()
+  const write = process.argv.includes('--write')
+  if (write) {
+    const __filename = fileURLToPath(import.meta.url)
+    const __dirname = dirname(__filename)
+    const repoRoot = resolve(__dirname, '..')
+    const out = resolve(repoRoot, 'docs/BATCH_PROMPT.txt')
+    await writeFile(out, text)
+    console.log(`written ${out} (${text.length} bytes)`)
+  } else {
+    process.stdout.write(text)
+  }
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/scripts/print-prompts-md.ts
+++ b/scripts/print-prompts-md.ts
@@ -1,0 +1,129 @@
+/**
+ * imagePrompts.ts から docs/IMAGE_GENERATION.md を再生成する。
+ *
+ * 使い方:
+ *   npx tsx scripts/print-prompts-md.ts            # 標準出力に書く
+ *   npx tsx scripts/print-prompts-md.ts --write    # docs/IMAGE_GENERATION.md に書き出し
+ */
+
+import { writeFile } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  STYLE_SUFFIX,
+  COURSE_PROMPTS,
+  LESSON_PROMPTS,
+  type ImagePromptEntry,
+} from './imagePrompts.ts'
+
+function renderEntry(kind: 'コース' | 'レッスン', e: ImagePromptEntry): string {
+  return [
+    `### ${e.id} — ${e.title}`,
+    `**保存先**: \`public/images/v3/${e.filename}\`  `,
+    `**種別**: ${kind}`,
+    '',
+    '```text',
+    e.prompt,
+    '```',
+    '',
+  ].join('\n')
+}
+
+function render(): string {
+  const out: string[] = []
+  out.push('# コース・レッスン画像生成ガイド')
+  out.push('')
+  out.push('Gemini で各コース／レッスンのイラストを生成し、 `public/images/v3/` 以下に')
+  out.push('規約のファイル名で保存すれば `npm run wire:images` で自動的に')
+  out.push('`courseData.ts` / `lessonSlides.ts` の参照が更新される。')
+  out.push('')
+  out.push('> このドキュメントは `scripts/imagePrompts.ts` から自動生成されています。')
+  out.push('> 編集する場合は `imagePrompts.ts` を直して `npm run prompts:md` を実行してください。')
+  out.push('')
+  out.push('## 手順')
+  out.push('')
+  out.push('1. Gemini を開く（推奨: Imagen 4 が使えるモード）')
+  out.push('2. 最初に「共通スタイル指示」を一度送る')
+  out.push('3. 各コース／レッスンのプロンプトを順次送り、生成された画像を保存先のファイル名でダウンロード')
+  out.push('4. `public/images/v3/` 以下に保存')
+  out.push('5. リポジトリで `npm run wire:images` を実行 → `courseData.ts` / `lessonSlides.ts` の参照が PNG に切り替わる')
+  out.push('')
+  out.push('## 共通スタイル指示（最初に Gemini に送る）')
+  out.push('')
+  out.push('```text')
+  out.push('これから複数の画像を生成してもらいます。')
+  out.push('全画像とも以下の共通スタイルを必ず守ってください:')
+  out.push('')
+  out.push(STYLE_SUFFIX)
+  out.push('')
+  out.push('アスペクト比は 16:9。各回ひとつだけ画像を生成してください。')
+  out.push('```')
+  out.push('')
+  out.push(`## コース (${COURSE_PROMPTS.length}枚)`)
+  out.push('')
+  out.push('| ID | タイトル | 保存ファイル |')
+  out.push('|----|---------|-------------|')
+  for (const e of COURSE_PROMPTS) {
+    out.push(`| \`${e.id}\` | ${e.title} | \`${e.filename}\` |`)
+  }
+  out.push('')
+  for (const e of COURSE_PROMPTS) {
+    out.push(renderEntry('コース', e))
+  }
+  out.push(`## レッスン (${LESSON_PROMPTS.length}枚)`)
+  out.push('')
+  out.push('| ID | タイトル | 保存ファイル |')
+  out.push('|----|---------|-------------|')
+  for (const e of LESSON_PROMPTS) {
+    out.push(`| \`${e.id}\` | ${e.title} | \`${e.filename}\` |`)
+  }
+  out.push('')
+  for (const e of LESSON_PROMPTS) {
+    out.push(renderEntry('レッスン', e))
+  }
+  out.push('## 紐付け（自動）')
+  out.push('')
+  out.push('```bash')
+  out.push('# 何が更新されるかプレビュー')
+  out.push('npm run wire:images -- --dry-run')
+  out.push('')
+  out.push('# 実行（src/courseData.ts と src/lessonSlides.ts を書き換え）')
+  out.push('npm run wire:images')
+  out.push('```')
+  out.push('')
+  out.push('`public/images/v3/course-{id}.png` または `lesson-{id}.png` が見つかった ID')
+  out.push('についてのみ、それぞれの参照を `.png` パスに更新する。')
+  out.push('保存していないコース／レッスンの参照は変更されない。')
+  out.push('')
+  out.push('## 自動 API 経由で一括生成したい場合')
+  out.push('')
+  out.push('```bash')
+  out.push('export GEMINI_API_KEY=AIza...')
+  out.push('npm run gen:images -- --target=courses        # コース 24 枚')
+  out.push('npm run gen:images -- --target=all            # コース + レッスン 全 ' +
+    `${COURSE_PROMPTS.length + LESSON_PROMPTS.length} 枚`)
+  out.push('npm run gen:images -- --only=logic-01,fermi-01 # 特定だけ')
+  out.push('```')
+  out.push('')
+  return out.join('\n')
+}
+
+async function main() {
+  const md = render()
+  const write = process.argv.includes('--write')
+  if (write) {
+    const __filename = fileURLToPath(import.meta.url)
+    const __dirname = dirname(__filename)
+    const repoRoot = resolve(__dirname, '..')
+    const out = resolve(repoRoot, 'docs/IMAGE_GENERATION.md')
+    await writeFile(out, md)
+    console.log(`written ${out} (${md.length} bytes)`)
+  } else {
+    process.stdout.write(md)
+  }
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/scripts/wire-images.ts
+++ b/scripts/wire-images.ts
@@ -1,0 +1,194 @@
+/**
+ * 紐付けスクリプト: 生成済みの PNG を courseData / lessonSlides に反映する
+ *
+ * 使い方:
+ *   npx tsx scripts/wire-images.ts
+ *   npx tsx scripts/wire-images.ts --dry-run
+ *
+ * 動作:
+ *   1. public/images/v3/ を走査して course-{id}.png / lesson-{id}.png を検出
+ *   2. 検出したコース ID について src/courseData.ts の image: フィールドを
+ *      .png パスに更新（image: フィールドがなければ description: の直後に挿入）
+ *   3. 検出したレッスン ID について src/lessonSlides.ts の LESSON_IMAGES マップを
+ *      .png パスに更新（既存エントリのみ）
+ *
+ * オプション:
+ *   --dry-run        差分プレビューのみ。ファイルを書き換えない
+ *   --images-dir=    画像ディレクトリ (default: public/images/v3)
+ *
+ * imagePrompts.ts に登録されている ID のみが対象。それ以外のファイルは無視。
+ */
+
+import { readFile, writeFile, readdir } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { COURSE_PROMPTS, LESSON_PROMPTS } from './imagePrompts.ts'
+
+type Args = {
+  dryRun: boolean
+  imagesDir: string
+}
+
+function parseArgs(argv: string[]): Args {
+  const get = (key: string): string | undefined => {
+    const arg = argv.find((a) => a.startsWith(`--${key}=`))
+    return arg ? arg.slice(`--${key}=`.length) : undefined
+  }
+  const has = (key: string): boolean => argv.includes(`--${key}`)
+  return {
+    dryRun: has('dry-run'),
+    imagesDir: get('images-dir') ?? 'public/images/v3',
+  }
+}
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const repoRoot = resolve(__dirname, '..')
+
+// ────────────────────────────────────────────────────────────────────────────
+// courseData.ts 更新
+// ────────────────────────────────────────────────────────────────────────────
+function updateCourseSrc(
+  src: string,
+  courseId: string,
+  newImagePath: string,
+): { src: string; action: 'updated' | 'inserted' | 'not-found' } {
+  // 1. 既存 image: フィールドを置換
+  const reUpdate = new RegExp(
+    `(id:\\s*'${escapeRe(courseId)}',[\\s\\S]*?image:\\s*')[^']+(')`,
+  )
+  if (reUpdate.test(src)) {
+    return { src: src.replace(reUpdate, `$1${newImagePath}$2`), action: 'updated' }
+  }
+
+  // 2. image: フィールドがなければ description: の直後に挿入
+  const reInsert = new RegExp(
+    `(id:\\s*'${escapeRe(courseId)}',[\\s\\S]*?description:\\s*'[^']*',)(\\n)(\\s*})`,
+  )
+  if (reInsert.test(src)) {
+    return {
+      src: src.replace(reInsert, `$1$2    image: '${newImagePath}',$2$3`),
+      action: 'inserted',
+    }
+  }
+
+  return { src, action: 'not-found' }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// lessonSlides.ts 更新
+// ────────────────────────────────────────────────────────────────────────────
+function updateLessonSrc(
+  src: string,
+  lessonId: string,
+  newImagePath: string,
+): { src: string; action: 'updated' | 'not-found' } {
+  // LESSON_IMAGES マップ内の `20: '/images/v3/lesson-20.webp',` 形式を対象
+  const re = new RegExp(`(^\\s*${escapeRe(lessonId)}:\\s*')[^']+(',)`, 'm')
+  if (re.test(src)) {
+    return { src: src.replace(re, `$1${newImagePath}$2`), action: 'updated' }
+  }
+  return { src, action: 'not-found' }
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// main
+// ────────────────────────────────────────────────────────────────────────────
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const imagesDir = resolve(repoRoot, args.imagesDir)
+  const coursePath = resolve(repoRoot, 'src/courseData.ts')
+  const lessonPath = resolve(repoRoot, 'src/lessonSlides.ts')
+
+  const allFiles = await readdir(imagesDir).catch(() => [] as string[])
+  const filesSet = new Set(allFiles)
+
+  let courseSrc = await readFile(coursePath, 'utf-8')
+  let lessonSrc = await readFile(lessonPath, 'utf-8')
+
+  let coursesUpdated = 0
+  let coursesInserted = 0
+  let coursesMissing = 0
+  let coursesNotFound = 0
+  let lessonsUpdated = 0
+  let lessonsMissing = 0
+  let lessonsNotFound = 0
+
+  console.log(`[scan] imagesDir=${imagesDir} (${allFiles.length} files)`)
+
+  // コース
+  for (const entry of COURSE_PROMPTS) {
+    if (!filesSet.has(entry.filename)) {
+      coursesMissing++
+      continue
+    }
+    const newPath = `/images/v3/${entry.filename}`
+    const result = updateCourseSrc(courseSrc, entry.id, newPath)
+    if (result.action === 'updated') {
+      coursesUpdated++
+      courseSrc = result.src
+      console.log(`[course updated]  ${entry.id} → ${newPath}`)
+    } else if (result.action === 'inserted') {
+      coursesInserted++
+      courseSrc = result.src
+      console.log(`[course inserted] ${entry.id} → ${newPath} (image field added)`)
+    } else {
+      coursesNotFound++
+      console.warn(
+        `[course MISS]    ${entry.id}: id not found in courseData.ts`,
+      )
+    }
+  }
+
+  // レッスン
+  for (const entry of LESSON_PROMPTS) {
+    if (!filesSet.has(entry.filename)) {
+      lessonsMissing++
+      continue
+    }
+    const newPath = `/images/v3/${entry.filename}`
+    const result = updateLessonSrc(lessonSrc, entry.id, newPath)
+    if (result.action === 'updated') {
+      lessonsUpdated++
+      lessonSrc = result.src
+      console.log(`[lesson updated]  ${entry.id} → ${newPath}`)
+    } else {
+      lessonsNotFound++
+      console.warn(
+        `[lesson MISS]    ${entry.id}: not in LESSON_IMAGES map (manual add required)`,
+      )
+    }
+  }
+
+  // 書き出し
+  if (args.dryRun) {
+    console.log('\n[dry-run] no files written')
+  } else {
+    if (coursesUpdated + coursesInserted > 0) {
+      await writeFile(coursePath, courseSrc)
+    }
+    if (lessonsUpdated > 0) {
+      await writeFile(lessonPath, lessonSrc)
+    }
+  }
+
+  console.log(
+    [
+      '',
+      `[summary]`,
+      `  courses: updated=${coursesUpdated} inserted=${coursesInserted} ` +
+        `missing-png=${coursesMissing} not-found-in-src=${coursesNotFound}`,
+      `  lessons: updated=${lessonsUpdated} ` +
+        `missing-png=${lessonsMissing} not-in-map=${lessonsNotFound}`,
+    ].join('\n'),
+  )
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
## 概要

各コース・レッスンの内容に沿った **3D アイソメトリック調イラスト** を Gemini で生成するためのスクリプトを追加しました。

```bash
GEMINI_API_KEY=AIza... npm run gen:images -- --target=courses
```

## 追加したもの

- `scripts/generate-course-images.ts`
  - コース 24 件・レッスン 44 件 ぶんの題材プロンプトを定義
  - 共通の世界観（deep navy + warm glow / isometric / no-text）は `STYLE_SUFFIX` に集約
  - Gemini API を直叩き（fetch）。`imagen-*` 系は `:predict`、`gemini-*-flash-image` 系は `:generateContent` に自動分岐
- `package.json` に `gen:images` script
- `.env.example` に `GEMINI_API_KEY`

## 使い方

| オプション | 説明 |
| --- | --- |
| `--target=courses\|lessons\|all` | 生成対象（既定: courses） |
| `--only=logic-01,critical-01` | 特定 ID のみ |
| `--skip-existing` | 既存ファイルをスキップ |
| `--model=<id>` | 既定 `imagen-4.0-generate-preview-06-06`。`imagen-3.0-generate-002` / `gemini-2.5-flash-image-preview` も指定可 |
| `--aspect=<ratio>` | 既定 `16:9` |
| `--concurrency=<n>` | 既定 `2` |
| `--out=<dir>` | 既定 `public/images/v3` |
| `--dry-run` | API は呼ばずプロンプトだけ表示 |

## ためし方

```bash
# プロンプトだけ確認
npx tsx scripts/generate-course-images.ts --dry-run --target=courses

# 1 枚だけ試す
GEMINI_API_KEY=xxx npm run gen:images -- --only=logic-01

# コース 24 枚を一括生成
GEMINI_API_KEY=xxx npm run gen:images -- --target=courses
```

## 出力

- コース: `public/images/v3/course-{id}.png` （例: `course-logic-01.png`）
- レッスン: `public/images/v3/lesson-{id}.png` （例: `lesson-20.png`）

## 補足

- 既存の `course-*.svg` / `lesson-*.webp` を上書きはしない（PNG として並行配置）。生成後に `courseData.ts` / `lessonSlides.ts` の参照パスを `.png` に切り替える運用を想定
- プロンプト微調整・画風差し替えは `STYLE_SUFFIX` と `COURSE_PROMPTS` / `LESSON_PROMPTS` を直接編集

## Test plan

- [ ] `npx tsx scripts/generate-course-images.ts --dry-run --target=all` でプロンプトが想定どおり出力されること
- [ ] `GEMINI_API_KEY=...` を設定して 1 枚だけ生成し、画像が `public/images/v3/` に保存されること
- [ ] `--skip-existing` で既存ファイルがスキップされること
- [ ] 生成画像のスタイル/題材レビュー（コース×レッスンの内容と整合しているか）

https://claude.ai/code/session_01FDKHtPf6wFwGPV8HupwDX6


---
_Generated by [Claude Code](https://claude.ai/code/session_01FDKHtPf6wFwGPV8HupwDX6)_