### PR TITLE
fix(daily-fermi): 「別の問題を選ぶ」を左端に配置

### DIFF
--- a/src/screens/DailyFermiScreen.tsx
+++ b/src/screens/DailyFermiScreen.tsx
@@ -631,9 +631,9 @@ export function DailyFermiScreen({ onBack, onReport, onOpenRanking }: DailyFermi
             </div>
           </div>
 
-          {/* 別の問題を選ぶ・電卓トグル / 上限到達時の警告 */}
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 8, padding: '0 2px' }}>
-            {canReroll && submitPhase === 'idle' && (
+          {/* 別の問題を選ぶ（左）・電卓トグル（右） */}
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, padding: '0 2px' }}>
+            {canReroll && submitPhase === 'idle' ? (
               <button
                 onClick={handleReroll}
                 style={{
@@ -647,7 +647,7 @@ export function DailyFermiScreen({ onBack, onReport, onOpenRanking }: DailyFermi
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" aria-hidden="true"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M8 16H3v5"/></svg>
                 別の問題を選ぶ
               </button>
-            )}
+            ) : <span aria-hidden="true" />}
             {submitPhase === 'idle' && (
               <button
                 type="button"
@@ -676,12 +676,14 @@ export function DailyFermiScreen({ onBack, onReport, onOpenRanking }: DailyFermi
                 {showCalculator ? '電卓を閉じる' : '電卓を使う'}
               </button>
             )}
-            {!canAnswer && (
+          </div>
+          {!canAnswer && (
+            <div style={{ padding: '0 2px', textAlign: 'right' }}>
               <span style={{ fontSize: 12, color: 'var(--danger)', fontWeight: 700 }}>
                 今日の回答数上限に達しました
               </span>
-            )}
-          </div>
+            </div>
+          )}
 
           {/* ヒント */}
           {hint && submitPhase === 'idle' && (


### PR DESCRIPTION
## Summary

DailyFermiScreen 入力画面のボタン配置を変更:

- 「別の問題を選ぶ」を**左端**に配置
- 「電卓を使う」は引き続き**右端**
- 縦積みから横並び (`justify-content: space-between`) へ変更
- リロール上限到達時はプレースホルダ `<span aria-hidden>` を入れて電卓ボタンを右端に保つ
- `今日の回答数上限に達しました` の警告は flex 行外に移動して右寄せ

## Test plan

- [ ] `/daily-fermi` で 別の問題を選ぶ が左端、電卓を使う が右端に並ぶ
- [ ] リロール上限到達後 (フリープラン等) も電卓ボタンは右端のまま
- [ ] 回答上限到達後の警告メッセージが正しく表示される

https://claude.ai/code/session_01ExncNeimSYRgTcKeRoYxGc

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExncNeimSYRgTcKeRoYxGc)_