### PR TITLE
feat(ui): カードに立体感のある影とホバーリフトを追加

### DIFF
--- a/src/PlacementTest.css
+++ b/src/PlacementTest.css
@@ -35,6 +35,7 @@
   border: 1px solid var(--border);
   border-left: 3px solid var(--accent);
   border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
   font-size: 0.8rem;
   color: var(--text-secondary);
   margin: 12px 0;
@@ -61,8 +62,9 @@
 .pt-q-num { font-size: 0.7333rem; font-weight: 700; color: var(--text-muted); letter-spacing: 0.18em; text-transform: uppercase; font-feature-settings: "tnum"; }
 .pt-q-text { font-family: var(--serif); font-size: 1.4667rem; font-weight: 500; color: var(--text-primary); line-height: 1.5; letter-spacing: -0.01em; }
 .pt-options { display: flex; flex-direction: column; gap: 10px; margin-top: 8px; }
-.pt-option { padding: 18px 20px; background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius-md); font-size: 0.9333rem; font-weight: 500; color: var(--text-primary); cursor: pointer; text-align: left; line-height: 1.6; font-family: var(--sans); transition: border-color 0.15s; }
-.pt-option:hover:not(:disabled) { border-color: var(--accent-dark); }
+.pt-option { padding: 18px 20px; background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius-md); box-shadow: var(--shadow-card); font-size: 0.9333rem; font-weight: 500; color: var(--text-primary); cursor: pointer; text-align: left; line-height: 1.6; font-family: var(--sans); transition: border-color 0.15s, transform var(--dur-base) var(--ease-out), box-shadow var(--dur-base) var(--ease-out); }
+.pt-option:hover:not(:disabled) { border-color: var(--accent-dark); transform: translateY(-2px); box-shadow: var(--shadow-card-hover); }
+.pt-option:active:not(:disabled) { transform: translateY(0) scale(0.99); box-shadow: var(--shadow-card); }
 .pt-option.selected { border-color: var(--accent-dark); background: var(--accent-soft); }
 .pt-option.correct { border-color: var(--success); background: var(--success-soft); }
 .pt-option.wrong { border-color: var(--danger); background: rgba(168, 50, 27, 0.06); }
@@ -121,6 +123,7 @@
   border: 1px solid var(--border);
   border-left: 3px solid var(--accent);
   border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
   padding: 24px 22px;
   margin-top: 16px;
   text-align: left;

--- a/src/Ranking.css
+++ b/src/Ranking.css
@@ -9,7 +9,7 @@
 .rk-error { color: var(--danger); }
 
 /* CTA when no test done */
-.rk-cta-card { background: var(--bg-card); border: 2px dashed var(--accent); border-radius: var(--radius-lg); padding: 24px 20px; text-align: center; display: flex; flex-direction: column; align-items: center; gap: 10px; }
+.rk-cta-card { background: var(--bg-card); border: 2px dashed var(--accent); border-radius: var(--radius-lg); box-shadow: var(--shadow-card); padding: 24px 20px; text-align: center; display: flex; flex-direction: column; align-items: center; gap: 10px; }
 .rk-cta-emoji { font-size: 3.2rem; }
 .rk-cta-card h3 { font-size: 1.0667rem; font-weight: 800; color: var(--text-primary); }
 .rk-cta-card p { font-size: 0.8667rem; color: var(--text-secondary); }
@@ -27,7 +27,7 @@
 .rk-section-title { font-size: 0.8667rem; font-weight: 800; color: var(--text-secondary); letter-spacing: 0.5px; text-transform: uppercase; padding: 0 4px; }
 
 .rk-list { display: flex; flex-direction: column; gap: 8px; }
-.rk-row { display: flex; align-items: center; gap: 14px; padding: 12px 16px; background: var(--bg-card); border: 1.5px solid var(--border); border-radius: var(--radius-md); }
+.rk-row { display: flex; align-items: center; gap: 14px; padding: 12px 16px; background: var(--bg-card); border: 1.5px solid var(--border); border-radius: var(--radius-md); box-shadow: var(--shadow-card); }
 .rk-row.top { border-color: var(--accent-light); }
 .rk-row.you { border-color: var(--accent-dark); border-width: 2px; background: var(--accent-soft); }
 .rk-rank { width: 36px; text-align: center; font-size: 1.0667rem; font-weight: 900; color: var(--text-muted); flex-shrink: 0; }

--- a/src/Roadmap.css
+++ b/src/Roadmap.css
@@ -306,6 +306,7 @@
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
   cursor: pointer;
   transition: transform 0.15s, border-color 0.2s, box-shadow 0.2s;
   font-family: var(--sans);
@@ -315,12 +316,13 @@
 
 .goal-card:hover {
   border-color: var(--goal-color, var(--accent));
-  transform: translateY(-1px);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-card-hover);
 }
 
 .goal-card:active {
-  transform: scale(0.98);
+  transform: translateY(0) scale(0.98);
+  box-shadow: var(--shadow-card);
 }
 
 .goal-card-emoji {

--- a/src/Roleplay.css
+++ b/src/Roleplay.css
@@ -45,9 +45,9 @@
 
 .rp-choices { display: flex; flex-direction: column; gap: 10px; padding: 14px 16px 20px; background: var(--bg-card); border-top: 1px solid var(--border); }
 .rp-choices-label { font-size: 0.7333rem; color: var(--text-muted); font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; margin-bottom: 2px; }
-.rp-choice-btn { padding: 14px 16px; background: var(--bg-card); color: var(--text-primary); border: 1.5px solid var(--border); border-radius: var(--radius-md, 12px); font-size: 0.9333rem; font-weight: 600; cursor: pointer; font-family: var(--sans); text-align: left; line-height: 1.6; transition: border-color 0.15s, transform 0.1s; letter-spacing: -0.01em; }
-.rp-choice-btn:hover { border-color: var(--accent-dark); }
-.rp-choice-btn:active { transform: scale(0.98); }
+.rp-choice-btn { padding: 14px 16px; background: var(--bg-card); color: var(--text-primary); border: 1.5px solid var(--border); border-radius: var(--radius-md, 12px); box-shadow: var(--shadow-card); font-size: 0.9333rem; font-weight: 600; cursor: pointer; font-family: var(--sans); text-align: left; line-height: 1.6; transition: border-color 0.15s, transform var(--dur-base) var(--ease-out), box-shadow var(--dur-base) var(--ease-out); letter-spacing: -0.01em; }
+.rp-choice-btn:hover { border-color: var(--accent-dark); transform: translateY(-2px); box-shadow: var(--shadow-card-hover); }
+.rp-choice-btn:active { transform: translateY(0) scale(0.98); box-shadow: var(--shadow-card); }
 
 .rp-input-bar { display: flex; gap: 8px; padding: 12px; background: var(--bg-card); border-top: 1px solid var(--border); }
 .rp-input { flex: 1; padding: 10px 12px; border: 1px solid var(--border); border-radius: var(--radius-md, 12px); font-size: 1.0667rem; font-family: var(--sans); background: var(--bg-elevated); color: var(--text-primary); resize: none; outline: none; }

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -92,12 +92,16 @@ html[data-platform="android"] .btn { min-height: 48px; }
 .btn-lg { padding: 18px 28px; font-size: 1.0667rem; font-weight: 700; }
 .btn-block { width: 100%; }
 
-/* Card */
+/* Card — subtle 3D depth (top-edge highlight + soft layered drop) */
 .card {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   padding: var(--s-5);
+  box-shadow: var(--shadow-card);
+  transition: transform var(--dur-base) var(--ease-out),
+              box-shadow var(--dur-base) var(--ease-out),
+              border-color var(--dur-base) ease;
 }
 .card-compact { padding: var(--s-4); }
 .card-tight { padding: var(--s-3); }
@@ -111,12 +115,16 @@ button.card {
   color: inherit;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
-  transition: transform var(--dur-base) var(--ease-out, ease),
-              border-color var(--dur-base) ease,
-              background var(--dur-base) ease;
 }
-button.card:hover { border-color: var(--md-sys-color-primary); }
-button.card:active { transform: scale(0.99); }
+button.card:hover {
+  border-color: var(--md-sys-color-primary);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-card-hover);
+}
+button.card:active {
+  transform: translateY(0) scale(0.99);
+  box-shadow: var(--shadow-card);
+}
 button.card:focus-visible {
   outline: 2px solid var(--md-sys-color-primary);
   outline-offset: 2px;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -112,13 +112,14 @@
   --s-7: 48px;
   --s-8: 64px;
 
-  /* Shadows — brand-tinted, more layered */
-  --shadow-sm:       0 1px 3px rgba(13, 18, 32, 0.05), 0 1px 2px rgba(13, 18, 32, 0.04);
-  --shadow-md:       0 4px 16px rgba(13, 18, 32, 0.08), 0 2px 4px rgba(13, 18, 32, 0.04);
-  --shadow-lg:       0 16px 48px rgba(13, 18, 32, 0.12), 0 4px 8px rgba(13, 18, 32, 0.06);
+  /* Shadows — brand-tinted, more layered (3D feel: top-edge highlight + soft drop) */
+  --shadow-sm:       0 1px 2px rgba(13, 18, 32, 0.06), 0 2px 6px rgba(13, 18, 32, 0.05);
+  --shadow-md:       0 2px 4px rgba(13, 18, 32, 0.06), 0 8px 20px rgba(13, 18, 32, 0.10);
+  --shadow-lg:       0 4px 8px rgba(13, 18, 32, 0.08), 0 20px 48px rgba(13, 18, 32, 0.14);
   --shadow-cta:      0 6px 24px rgba(108, 142, 245, 0.36), 0 2px 6px rgba(108, 142, 245, 0.18);
   --shadow-cta-pop:  0 8px 32px rgba(108, 142, 245, 0.32), 0 2px 6px rgba(108, 142, 245, 0.20);
-  --shadow-card:     var(--shadow-sm);
+  --shadow-card:     0 1px 2px rgba(13, 18, 32, 0.05), 0 4px 12px rgba(13, 18, 32, 0.08);
+  --shadow-card-hover: 0 4px 8px rgba(13, 18, 32, 0.08), 0 12px 28px rgba(13, 18, 32, 0.14);
   --shadow-elevated: var(--shadow-md);
   --shadow-hero:     0 24px 64px rgba(13, 18, 32, 0.22), 0 8px 16px rgba(108, 142, 245, 0.14);
   --shadow-float:    0 8px 24px rgba(13, 18, 32, 0.12), 0 2px 4px rgba(13, 18, 32, 0.06);
@@ -206,7 +207,8 @@
   --cat-practice:   #22D3EE;
   --cat-practice-soft: rgba(34, 211, 238, 0.12);
 
-  --shadow-card:    0 1px 0 rgba(0, 0, 0, 0.40), 0 2px 8px rgba(0, 0, 0, 0.25);
+  --shadow-card:    0 2px 4px rgba(0, 0, 0, 0.30), 0 8px 20px rgba(0, 0, 0, 0.45);
+  --shadow-card-hover: 0 4px 8px rgba(0, 0, 0, 0.35), 0 16px 32px rgba(0, 0, 0, 0.55);
   --shadow-elevated: 0 8px 32px rgba(0, 0, 0, 0.60), 0 2px 8px rgba(0, 0, 0, 0.30);
   --shadow-cta:     0 6px 24px rgba(108, 142, 245, 0.30), 0 2px 6px rgba(108, 142, 245, 0.15);
   --shadow-hero:    0 24px 64px rgba(0, 0, 0, 0.50), 0 8px 16px rgba(108, 142, 245, 0.14);


### PR DESCRIPTION
## Summary
- アプリ全体のカードを「ちょっと立体的」に。`.card` プリミティブと共有シャドウトークンを強化することで全画面に一括適用。
- `--shadow-card` / `--shadow-md` / `--shadow-lg` を上下 2 層構造（接地影 + 浮遊影）に変更し、奥行きを表現。
- `--shadow-card-hover` トークンを新設。インタラクティブカードのホバー時に深い影でリフト感を演出。
- `.card` に既定の `box-shadow` と `transition` を付与。`button.card` に `:hover { translateY(-2px) }` と `:active` のプレスダウンを追加。
- ダークモードの影も同じ階層で再設計し、明暗双方で同じ立体感を維持。

## Test plan
- [ ] ライトモードでホーム / プロフィール / ロードマップ等の主要画面を確認し、カードに自然な影が出ているか
- [ ] 押下できるカード（`button.card` 系）でホバー時にリフト、タップ時にプレスが効くか
- [ ] ダークモードでも影が黒つぶれせず、立体感が保たれているか
- [ ] `prefers-reduced-motion` 有効時、過剰なアニメが発生しないか

https://claude.ai/code/session_014ZE4NAR5gwiscY9tLNWaHA

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZE4NAR5gwiscY9tLNWaHA)_