### PR TITLE
fix(daily-fermi): 電卓トグルをテキストエリア直上に移動・四角枠＆配色変更

### DIFF
--- a/src/screens/DailyFermiScreen.tsx
+++ b/src/screens/DailyFermiScreen.tsx
@@ -631,9 +631,9 @@ export function DailyFermiScreen({ onBack, onReport, onOpenRanking }: DailyFermi
             </div>
           </div>
 
-          {/* 別の問題を選ぶ（左）・電卓トグル（右） */}
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, padding: '0 2px' }}>
-            {canReroll && submitPhase === 'idle' ? (
+          {/* 別の問題を選ぶ（左） */}
+          {canReroll && submitPhase === 'idle' && (
+            <div style={{ display: 'flex', alignItems: 'center', padding: '0 2px' }}>
               <button
                 onClick={handleReroll}
                 style={{
@@ -647,36 +647,8 @@ export function DailyFermiScreen({ onBack, onReport, onOpenRanking }: DailyFermi
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" aria-hidden="true"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M8 16H3v5"/></svg>
                 別の問題を選ぶ
               </button>
-            ) : <span aria-hidden="true" />}
-            {submitPhase === 'idle' && (
-              <button
-                type="button"
-                onClick={() => setShowCalculator(s => !s)}
-                aria-expanded={showCalculator}
-                style={{
-                  display: 'flex', alignItems: 'center', gap: 5,
-                  background: showCalculator ? 'rgba(108,142,245,0.10)' : 'none',
-                  border: '1.5px solid var(--brand)',
-                  borderRadius: 20, padding: '6px 14px',
-                  color: 'var(--brand)', fontSize: 13, fontWeight: 700,
-                  cursor: 'pointer',
-                  fontFamily: 'inherit',
-                }}
-              >
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <rect x="4" y="3" width="16" height="18" rx="2" />
-                  <line x1="8" y1="7" x2="16" y2="7" />
-                  <line x1="8" y1="12" x2="9" y2="12" />
-                  <line x1="12" y1="12" x2="13" y2="12" />
-                  <line x1="16" y1="12" x2="16" y2="12" />
-                  <line x1="8" y1="16" x2="9" y2="16" />
-                  <line x1="12" y1="16" x2="13" y2="16" />
-                  <line x1="16" y1="16" x2="16" y2="16" />
-                </svg>
-                {showCalculator ? '電卓を閉じる' : '電卓を使う'}
-              </button>
-            )}
-          </div>
+            </div>
+          )}
           {!canAnswer && (
             <div style={{ padding: '0 2px', textAlign: 'right' }}>
               <span style={{ fontSize: 12, color: 'var(--danger)', fontWeight: 700 }}>
@@ -753,6 +725,37 @@ export function DailyFermiScreen({ onBack, onReport, onOpenRanking }: DailyFermi
           {/* 回答入力エリア */}
           {submitPhase === 'idle' && (
             <div className="stack-sm">
+              {/* 電卓トグル: テキストエリア右上 */}
+              <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '0 2px' }}>
+                <button
+                  type="button"
+                  onClick={() => setShowCalculator(s => !s)}
+                  aria-expanded={showCalculator}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 6,
+                    background: showCalculator ? 'rgba(112,216,189,0.12)' : 'rgba(255,255,255,0.04)',
+                    border: `1px solid ${showCalculator ? '#70D8BD' : 'var(--border)'}`,
+                    borderRadius: 6, padding: '6px 12px',
+                    color: showCalculator ? '#70D8BD' : 'var(--text-secondary)',
+                    fontSize: 13, fontWeight: 700,
+                    cursor: 'pointer',
+                    fontFamily: 'inherit',
+                    transition: 'background 0.15s ease, color 0.15s ease, border-color 0.15s ease',
+                  }}
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <rect x="4" y="3" width="16" height="18" rx="2" />
+                    <line x1="8" y1="7" x2="16" y2="7" />
+                    <line x1="8" y1="12" x2="9" y2="12" />
+                    <line x1="12" y1="12" x2="13" y2="12" />
+                    <line x1="16" y1="12" x2="16" y2="12" />
+                    <line x1="8" y1="16" x2="9" y2="16" />
+                    <line x1="12" y1="16" x2="13" y2="16" />
+                    <line x1="16" y1="16" x2="16" y2="16" />
+                  </svg>
+                  {showCalculator ? '電卓を閉じる' : '電卓を使う'}
+                </button>
+              </div>
               <div style={{ position: 'relative' }}>
                 <textarea
                   aria-label="フェルミ推定の解答"


### PR DESCRIPTION
## Summary

DailyFermiScreen の電卓トグルボタンをリデザイン:

- **位置**: 「別の問題を選ぶ」と同じ行ではなく、テキストエリア直上（右端）に独立配置
- **形状**: borderRadius 20 (ピル) → 6 (角丸い四角)
- **配色**: ブランド色（青）→ ニュートラル（`var(--text-secondary)` + 半透明背景）。アクティブ時のみ `#70D8BD` (mint) でハイライト
- 「別の問題を選ぶ」は独立行で左端配置のまま

## Test plan

- [ ] `/daily-fermi` で 電卓を使う がテキストエリア直上の右端に配置される
- [ ] ボタンが四角枠（角丸 6px）で、ニュートラル系の配色になる
- [ ] クリックで mint 色にトグルし、再クリックで元に戻る
- [ ] 「別の問題を選ぶ」は別行で左端に表示される

https://claude.ai/code/session_01ExncNeimSYRgTcKeRoYxGc

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExncNeimSYRgTcKeRoYxGc)_