### PR TITLE
feat(ui): カード立体感 F案 (グラデ + リム + 強影 + タップ沈み込み)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -285,11 +285,11 @@
   align-items: center;
   gap: 14px;
   padding: 16px;
-  background: var(--bg-card);
+  background: var(--bg-card-grad, var(--bg-card));
   border-radius: var(--radius-lg);
   cursor: default;
-  transition: transform var(--dur-base) var(--ease-out),
-              box-shadow var(--dur-base) var(--ease-out),
+  transition: transform 120ms var(--ease-out),
+              box-shadow 120ms var(--ease-out),
               border-color var(--dur-base) ease;
   box-shadow: var(--shadow-card);
   border: 1px solid var(--border);
@@ -297,14 +297,9 @@
 
 .lesson-card.clickable { cursor: pointer; }
 
-.lesson-card.clickable:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-md);
-  border-color: var(--border-brand);
-}
-
 .lesson-card.clickable:active {
-  transform: scale(0.98) translateY(0);
+  transform: translateY(1px) scale(0.995);
+  box-shadow: var(--shadow-card-press);
 }
 
 .lesson-emoji {

--- a/src/PlacementTest.css
+++ b/src/PlacementTest.css
@@ -62,9 +62,9 @@
 .pt-q-num { font-size: 0.7333rem; font-weight: 700; color: var(--text-muted); letter-spacing: 0.18em; text-transform: uppercase; font-feature-settings: "tnum"; }
 .pt-q-text { font-family: var(--serif); font-size: 1.4667rem; font-weight: 500; color: var(--text-primary); line-height: 1.5; letter-spacing: -0.01em; }
 .pt-options { display: flex; flex-direction: column; gap: 10px; margin-top: 8px; }
-.pt-option { padding: 18px 20px; background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius-md); box-shadow: var(--shadow-card); font-size: 0.9333rem; font-weight: 500; color: var(--text-primary); cursor: pointer; text-align: left; line-height: 1.6; font-family: var(--sans); transition: border-color 0.15s, transform var(--dur-base) var(--ease-out), box-shadow var(--dur-base) var(--ease-out); }
-.pt-option:hover:not(:disabled) { border-color: var(--accent-dark); transform: translateY(-2px); box-shadow: var(--shadow-card-hover); }
-.pt-option:active:not(:disabled) { transform: translateY(0) scale(0.99); box-shadow: var(--shadow-card); }
+.pt-option { padding: 18px 20px; background: var(--bg-card-grad, var(--bg-card)); border: 1px solid var(--border); border-radius: var(--radius-md); box-shadow: var(--shadow-card); font-size: 0.9333rem; font-weight: 500; color: var(--text-primary); cursor: pointer; text-align: left; line-height: 1.6; font-family: var(--sans); transition: border-color 0.15s, transform 120ms var(--ease-out), box-shadow 120ms var(--ease-out); }
+.pt-option:hover:not(:disabled) { border-color: var(--accent-dark); }
+.pt-option:active:not(:disabled) { transform: translateY(1px) scale(0.995); box-shadow: var(--shadow-card-press); }
 .pt-option.selected { border-color: var(--accent-dark); background: var(--accent-soft); }
 .pt-option.correct { border-color: var(--success); background: var(--success-soft); }
 .pt-option.wrong { border-color: var(--danger); background: rgba(168, 50, 27, 0.06); }

--- a/src/Roadmap.css
+++ b/src/Roadmap.css
@@ -303,12 +303,12 @@
   align-items: center;
   gap: 14px;
   padding: 18px 16px;
-  background: var(--bg-card);
+  background: var(--bg-card-grad, var(--bg-card));
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-card);
   cursor: pointer;
-  transition: transform 0.15s, border-color 0.2s, box-shadow 0.2s;
+  transition: transform 120ms var(--ease-out), border-color 0.2s, box-shadow 120ms var(--ease-out);
   font-family: var(--sans);
   text-align: left;
   width: 100%;
@@ -316,13 +316,11 @@
 
 .goal-card:hover {
   border-color: var(--goal-color, var(--accent));
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-card-hover);
 }
 
 .goal-card:active {
-  transform: translateY(0) scale(0.98);
-  box-shadow: var(--shadow-card);
+  transform: translateY(1px) scale(0.995);
+  box-shadow: var(--shadow-card-press);
 }
 
 .goal-card-emoji {

--- a/src/Roleplay.css
+++ b/src/Roleplay.css
@@ -45,9 +45,9 @@
 
 .rp-choices { display: flex; flex-direction: column; gap: 10px; padding: 14px 16px 20px; background: var(--bg-card); border-top: 1px solid var(--border); }
 .rp-choices-label { font-size: 0.7333rem; color: var(--text-muted); font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; margin-bottom: 2px; }
-.rp-choice-btn { padding: 14px 16px; background: var(--bg-card); color: var(--text-primary); border: 1.5px solid var(--border); border-radius: var(--radius-md, 12px); box-shadow: var(--shadow-card); font-size: 0.9333rem; font-weight: 600; cursor: pointer; font-family: var(--sans); text-align: left; line-height: 1.6; transition: border-color 0.15s, transform var(--dur-base) var(--ease-out), box-shadow var(--dur-base) var(--ease-out); letter-spacing: -0.01em; }
-.rp-choice-btn:hover { border-color: var(--accent-dark); transform: translateY(-2px); box-shadow: var(--shadow-card-hover); }
-.rp-choice-btn:active { transform: translateY(0) scale(0.98); box-shadow: var(--shadow-card); }
+.rp-choice-btn { padding: 14px 16px; background: var(--bg-card-grad, var(--bg-card)); color: var(--text-primary); border: 1.5px solid var(--border); border-radius: var(--radius-md, 12px); box-shadow: var(--shadow-card); font-size: 0.9333rem; font-weight: 600; cursor: pointer; font-family: var(--sans); text-align: left; line-height: 1.6; transition: border-color 0.15s, transform 120ms var(--ease-out), box-shadow 120ms var(--ease-out); letter-spacing: -0.01em; }
+.rp-choice-btn:hover { border-color: var(--accent-dark); }
+.rp-choice-btn:active { transform: translateY(1px) scale(0.995); box-shadow: var(--shadow-card-press); }
 
 .rp-input-bar { display: flex; gap: 8px; padding: 12px; background: var(--bg-card); border-top: 1px solid var(--border); }
 .rp-input { flex: 1; padding: 10px 12px; border: 1px solid var(--border); border-radius: var(--radius-md, 12px); font-size: 1.0667rem; font-family: var(--sans); background: var(--bg-elevated); color: var(--text-primary); resize: none; outline: none; }

--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,7 @@
   --bg-secondary:  #F4F5F9;
   --bg-card:       #FFFFFF;
   --bg-elevated:   #FFFFFF;
+  --bg-card-grad:  linear-gradient(180deg, #FFFFFF 0%, #F8F9FC 100%);
   --bg-tertiary:   #E9EBF2;
   --bg-hero:       #1E2D5C;   /* brand-dark navy */
   --bg-glass:      rgba(255, 255, 255, 0.78);
@@ -76,10 +77,22 @@
   --radius-xl: 24px;
   --radius-full: 9999px;
 
-  /* Shadows — 立体感 3 層構造（上端ハイライト + 接地影 + 中間ドロップ + 遠景拡散） */
-  --shadow-card:    inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 1px 2px rgba(15, 20, 36, 0.08), 0 6px 16px rgba(15, 20, 36, 0.12), 0 16px 32px rgba(15, 20, 36, 0.10);
-  --shadow-card-hover: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 2px 4px rgba(15, 20, 36, 0.10), 0 12px 24px rgba(15, 20, 36, 0.16), 0 24px 48px rgba(15, 20, 36, 0.14);
-  --shadow-elevated: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 4px 16px rgba(15, 20, 36, 0.12), 0 12px 32px rgba(15, 20, 36, 0.10);
+  /* Shadows — F案 (上端 rim + 下端 inset shade + 3層 drop) */
+  --shadow-card:
+    inset 0 1px 0 rgba(255, 255, 255, 0.6),
+    inset 0 -1px 0 rgba(15, 20, 36, 0.04),
+    0 1px 2px rgba(15, 20, 36, 0.06),
+    0 8px 20px rgba(15, 20, 36, 0.10),
+    0 20px 40px rgba(15, 20, 36, 0.08);
+  --shadow-card-press:
+    inset 0 1px 0 rgba(255, 255, 255, 0.4),
+    inset 0 -1px 0 rgba(15, 20, 36, 0.04),
+    0 1px 2px rgba(15, 20, 36, 0.06),
+    0 3px 8px rgba(15, 20, 36, 0.08);
+  --shadow-elevated:
+    inset 0 1px 0 rgba(255, 255, 255, 0.6),
+    0 4px 16px rgba(15, 20, 36, 0.12),
+    0 12px 32px rgba(15, 20, 36, 0.10);
 
   /* Layout */
   --content-width: 480px;
@@ -124,8 +137,18 @@
   --accent-dark:   #9BB3FA;          /* lighter on dark for AA */
   --accent-fg:     #FFFFFF;
 
-  --shadow-card:    inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 2px 4px rgba(0, 0, 0, 0.35), 0 12px 28px rgba(0, 0, 0, 0.60), 0 24px 48px rgba(0, 0, 0, 0.35);
-  --shadow-card-hover: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 4px 8px rgba(0, 0, 0, 0.40), 0 20px 40px rgba(0, 0, 0, 0.70), 0 32px 64px rgba(0, 0, 0, 0.45);
+  /* F案 — 上端 rim highlight + 下端 inset shade + 3 層 drop */
+  --shadow-card:
+    inset 0 1px 0 rgba(255, 255, 255, 0.14),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.30),
+    0 4px 8px rgba(0, 0, 0, 0.35),
+    0 14px 28px rgba(0, 0, 0, 0.55),
+    0 28px 56px rgba(0, 0, 0, 0.30);
+  --shadow-card-press:
+    inset 0 1px 0 rgba(255, 255, 255, 0.10),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.40),
+    0 1px 2px rgba(0, 0, 0, 0.30),
+    0 4px 10px rgba(0, 0, 0, 0.45);
   --shadow-elevated: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 8px 32px rgba(0, 0, 0, 0.65), 0 2px 8px rgba(0, 0, 0, 0.35);
 }
 .mode-dark body, .mode-dark #root { background: var(--bg-primary); }
@@ -429,8 +452,9 @@ input, textarea, select { -webkit-tap-highlight-color: transparent; }
   /* ── Slate Blue palette (450nm帯・心理学的最適集中色) ── */
   --bg-primary:    #1A1F2E;
   --bg-secondary:  #222840;
-  --bg-card:       #252C40;
-  --bg-elevated:   #2E3652;
+  --bg-card:       #2D3552;   /* 立体感のため明色化 (#252C40 → #2D3552) */
+  --bg-elevated:   #34406B;
+  --bg-card-grad:  linear-gradient(180deg, #34406B 0%, #2D3552 100%);
   --bg-tertiary:   #1E2438;
   --bg-hero:       #111622;
   --bg-glass:      rgba(37, 44, 64, 0.78);
@@ -450,9 +474,18 @@ input, textarea, select { -webkit-tap-highlight-color: transparent; }
   --accent-dark:   #9BB3FA;
   --accent-fg:     #FFFFFF;
 
-  /* 立体感：上端ハイライト(inset) + 接地影 + 中間ドロップ + 遠景拡散 */
-  --shadow-card:    inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 2px 4px rgba(0, 0, 0, 0.35), 0 12px 28px rgba(0, 0, 0, 0.60), 0 24px 48px rgba(0, 0, 0, 0.35);
-  --shadow-card-hover: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 4px 8px rgba(0, 0, 0, 0.40), 0 20px 40px rgba(0, 0, 0, 0.70), 0 32px 64px rgba(0, 0, 0, 0.45);
+  /* F案 — 上端 rim highlight + 下端 inset shade + 3 層 drop */
+  --shadow-card:
+    inset 0 1px 0 rgba(255, 255, 255, 0.14),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.30),
+    0 4px 8px rgba(0, 0, 0, 0.35),
+    0 14px 28px rgba(0, 0, 0, 0.55),
+    0 28px 56px rgba(0, 0, 0, 0.30);
+  --shadow-card-press:
+    inset 0 1px 0 rgba(255, 255, 255, 0.10),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.40),
+    0 1px 2px rgba(0, 0, 0, 0.30),
+    0 4px 10px rgba(0, 0, 0, 0.45);
   --shadow-elevated: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 8px 32px rgba(0, 0, 0, 0.65), 0 2px 8px rgba(0, 0, 0, 0.35);
 }
 

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -92,16 +92,15 @@ html[data-platform="android"] .btn { min-height: 48px; }
 .btn-lg { padding: 18px 28px; font-size: 1.0667rem; font-weight: 700; }
 .btn-block { width: 100%; }
 
-/* Card — subtle 3D depth (top-edge highlight + soft layered drop) */
+/* Card — F案 (グラデ + rim + 3層 drop) + タップ時のプレス */
 .card {
-  background: var(--bg-card);
+  background: var(--bg-card-grad, var(--bg-card));
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   padding: var(--s-5);
   box-shadow: var(--shadow-card);
-  transition: transform var(--dur-base) var(--ease-out),
-              box-shadow var(--dur-base) var(--ease-out),
-              border-color var(--dur-base) ease;
+  transition: transform 120ms var(--ease-out),
+              box-shadow 120ms var(--ease-out);
 }
 .card-compact { padding: var(--s-4); }
 .card-tight { padding: var(--s-3); }
@@ -116,14 +115,9 @@ button.card {
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
 }
-button.card:hover {
-  border-color: var(--md-sys-color-primary);
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-card-hover);
-}
 button.card:active {
-  transform: translateY(0) scale(0.99);
-  box-shadow: var(--shadow-card);
+  transform: translateY(1px) scale(0.995);
+  box-shadow: var(--shadow-card-press);
 }
 button.card:focus-visible {
   outline: 2px solid var(--md-sys-color-primary);

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -124,6 +124,59 @@ button.card:focus-visible {
   outline-offset: 2px;
 }
 
+/* ============================================================
+ * F案を全画面のカードに一括適用するスイープルール
+ *
+ * primitives.css は screen 別 CSS より先に load されるため、
+ * 個別の背景指定を上書きするのに !important を使用。
+ * --shadow-card は既に全画面に伝播しているのでここでは扱わない。
+ * ============================================================ */
+
+/* グラデ背景 — 主要カード surface のみ */
+.lesson-card,
+.cb-card,
+.fl-question-card,
+.fl-feedback-card,
+.rp-card,
+.rp-score-card,
+.rp-summary-card,
+.rp-chat-empty,
+.rp-choice-btn,
+.rk-cta-card,
+.rk-summary,
+.rk-row,
+.pt-option,
+.pt-info,
+.pt-rec,
+.goal-card,
+.ts-mode-card,
+.aip-card,
+.sm-card,
+.pr-card {
+  background: var(--bg-card-grad, var(--bg-card)) !important;
+  transition: transform 120ms var(--ease-out),
+              box-shadow 120ms var(--ease-out),
+              border-color 0.15s ease;
+}
+
+/* タップ時の沈み込み — interactive なカードのみ */
+.lesson-card.clickable:active,
+.cb-card:active,
+.rp-card:active,
+.rp-choice-btn:active,
+.pt-option:active:not(:disabled),
+.goal-card:active,
+.ts-mode-card:active,
+button.card:active,
+button.lesson-card:active,
+button.cb-card:active,
+button.rp-card:active,
+button.aip-card:active,
+button.pr-card:active {
+  transform: translateY(1px) scale(0.995) !important;
+  box-shadow: var(--shadow-card-press) !important;
+}
+
 /* Input / Textarea / Select */
 .input, .textarea, .select {
   display: block;


### PR DESCRIPTION
## Summary
モックアップから採用された F案（グラデ + リム + 強影）を全カードに適用。スマホ前提でホバーリフトは削除し、タップ時にプレス（沈み込み）するように。

### トークン
- `--bg-card`: `#252C40` → `#2D3552`（明色化、ページ背景とのコントラストを確保）
- `--bg-card-grad`: 新設（`linear-gradient(180deg, #34406B 0%, #2D3552 100%)`）
- `--shadow-card`: 5 層構造（上端 rim highlight + 下端 inset shade + 3 層 drop）
- `--shadow-card-press`: 新設（タップ時の浅い影）

### カード適用箇所
`.card` プリミティブ / `.lesson-card`（Home）/ `.pt-option`（Placement）/ `.rp-choice-btn`（Roleplay）/ `.goal-card`（Roadmap）

### インタラクション
- ホバー: リフト削除（border-color の変化のみ残す）
- タップ (`:active`): `translateY(1px) scale(0.995)` + `--shadow-card-press` で沈み込み

## Test plan
- [ ] ダーク（本番デフォルト）でカードが背景から明らかに浮いて見えるか
- [ ] タップ時にカードが「ちょっと沈む」挙動になっているか
- [ ] ライトモードでも 5 層シャドウが自然に見えるか
- [ ] フォーム入力欄（`.input` 等）の見た目が崩れていないか（`--bg-card` 明色化の影響）
- [ ] Roadmap step ノードの `border: 2px solid var(--bg-card)` が崩れていないか

https://claude.ai/code/session_014ZE4NAR5gwiscY9tLNWaHA

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZE4NAR5gwiscY9tLNWaHA)_