### PR TITLE
feat: 英語学習モード（プレミアム機能）を追加

### DIFF
--- a/public/preview/english-flashcards.html
+++ b/public/preview/english-flashcards.html
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<title>英語フレーズ復習 — Logic Preview</title>
+<link rel="stylesheet" href="_shared.css">
+<style>
+  .fc-content { padding: 20px; padding-bottom: 100px; }
+
+  .fc-stat-row {
+    display: grid; grid-template-columns: repeat(3, 1fr);
+    gap: 8px; margin-bottom: 24px;
+  }
+  .fc-stat {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 14px 10px;
+    text-align: center;
+  }
+  .fc-stat .num { font-size: 22px; font-weight: 800; color: var(--accent-text); }
+  .fc-stat .label {
+    font-size: 10px; color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-top: 2px;
+  }
+
+  .filter-tabs {
+    display: flex; gap: 8px;
+    margin-bottom: 20px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    padding-bottom: 4px;
+  }
+  .filter-tabs::-webkit-scrollbar { display: none; }
+  .tab {
+    padding: 8px 14px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    font-size: 12px; font-weight: 700;
+    color: var(--text-secondary);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all 0.15s ease;
+    font-family: inherit;
+  }
+  .tab.active {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #fff;
+  }
+
+  /* ============ Card review (active) ============ */
+  .review-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    padding: 28px 24px;
+    box-shadow: var(--shadow-elevated);
+    text-align: center;
+    margin-bottom: 16px;
+    min-height: 220px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    position: relative;
+  }
+  .review-card-tag {
+    position: absolute; top: 12px; left: 16px;
+    font-size: 10px; font-weight: 800;
+    color: var(--accent-text);
+    letter-spacing: 0.6px;
+    text-transform: uppercase;
+  }
+  .review-card-source {
+    position: absolute; top: 12px; right: 16px;
+    font-size: 10px; color: var(--text-muted);
+  }
+  .review-card-front {
+    font-size: 22px; font-weight: 800;
+    color: var(--text-primary);
+    line-height: 1.4;
+    margin: 16px 0 8px;
+  }
+  .review-card-back {
+    font-size: 16px; color: var(--text-secondary);
+    line-height: 1.6;
+    display: none;
+  }
+  .review-card-back.show { display: block; animation: fade-in 0.2s ease-out; }
+  .review-card-note {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid var(--border-light);
+    font-size: 12px; color: var(--text-muted);
+    font-style: italic;
+    line-height: 1.6;
+  }
+  @keyframes fade-in {
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  .reveal-btn {
+    width: 100%;
+    padding: 14px;
+    background: var(--bg-card);
+    border: 1.5px solid var(--accent);
+    color: var(--accent-dark);
+    border-radius: 14px;
+    font-size: 14px; font-weight: 800;
+    font-family: inherit;
+    cursor: pointer;
+    margin-bottom: 12px;
+  }
+
+  .review-actions {
+    display: grid; grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+    display: none;
+  }
+  .review-actions.show { display: grid; animation: fade-in 0.2s ease-out; }
+  .review-action {
+    padding: 14px 10px;
+    border: none;
+    border-radius: 12px;
+    font-size: 13px; font-weight: 800;
+    cursor: pointer;
+    font-family: inherit;
+    color: #fff;
+  }
+  .review-action.again { background: var(--danger); }
+  .review-action.good  { background: var(--accent); }
+  .review-action.easy  { background: var(--success); }
+  .review-action small { display: block; font-size: 10px; font-weight: 600; opacity: 0.85; margin-top: 2px; }
+
+  /* ============ Card list (all) ============ */
+  .card-list { display: flex; flex-direction: column; gap: 10px; }
+  .card-item {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 14px 16px;
+    display: flex; gap: 12px;
+    align-items: center;
+  }
+  .card-item-main { flex: 1; min-width: 0; }
+  .card-item-en { font-size: 14px; font-weight: 700; margin: 0 0 2px 0; }
+  .card-item-ja { font-size: 12px; color: var(--text-secondary); margin: 0; }
+  .card-item-meta {
+    display: flex; flex-direction: column; align-items: flex-end;
+    gap: 2px;
+    flex-shrink: 0;
+  }
+  .badge-source {
+    font-size: 9px; font-weight: 800;
+    padding: 2px 6px; border-radius: 999px;
+    background: rgba(212,145,90,0.15); color: var(--accent-dark);
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+  }
+  .card-item-due { font-size: 10px; color: var(--text-muted); }
+
+  .section-title {
+    font-size: 12px; font-weight: 800;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    margin: 24px 0 10px;
+  }
+
+  /* Demo banner */
+  .demo-banner {
+    background: linear-gradient(135deg, rgba(201,169,74,0.15), rgba(176,116,66,0.15));
+    border: 1px solid rgba(201,169,74,0.4);
+    color: #6b5526;
+    padding: 12px 16px;
+    border-radius: 12px;
+    font-size: 12px;
+    line-height: 1.7;
+    margin-bottom: 16px;
+  }
+  .demo-banner b { color: #4a3a18; }
+</style>
+</head>
+<body>
+<div class="preview-note">📱 Premium feature: 保存した英語フレーズの復習（既存 Flashcards 画面に統合）</div>
+<div class="app">
+  <header class="header">
+    <button class="header-back">‹</button>
+    <span class="header-title">フラッシュカード</span>
+    <span style="width: 32px;"></span>
+  </header>
+
+  <div class="fc-content">
+    <div class="demo-banner">
+      💡 <b>既存のフラッシュカード機能を活用:</b> 英語学習モードで保存したフレーズは <code style="background:rgba(0,0,0,0.05);padding:1px 5px;border-radius:4px;">source: english-{lessonId}</code> のカードとして同じ Flashcards 画面に並びます。<b>SM-2 間隔反復</b>（再→1日→3日→7日…）で記憶定着。
+    </div>
+
+    <div class="fc-stat-row">
+      <div class="fc-stat">
+        <div class="num">14</div>
+        <div class="label">合計</div>
+      </div>
+      <div class="fc-stat">
+        <div class="num">8</div>
+        <div class="label">復習待ち</div>
+      </div>
+      <div class="fc-stat">
+        <div class="num">5</div>
+        <div class="label">習得</div>
+      </div>
+    </div>
+
+    <div class="filter-tabs">
+      <button class="tab active">すべて (14)</button>
+      <button class="tab">英語フレーズ (9)</button>
+      <button class="tab">レッスン (4)</button>
+      <button class="tab">弱点 (1)</button>
+    </div>
+
+    <!-- Active card review -->
+    <div class="section-title">📚 今日の復習</div>
+    <div class="review-card">
+      <div class="review-card-tag">EN PHRASE</div>
+      <div class="review-card-source">Lesson 20: MECE</div>
+      <div id="reviewFront" class="review-card-front">break things down</div>
+      <div id="reviewBack" class="review-card-back">
+        物事を分解する
+        <div class="review-card-note">break A down または break down A。MECE分解の文脈で頻出。</div>
+      </div>
+    </div>
+
+    <button id="revealBtn" class="reveal-btn">答えを見る</button>
+
+    <div id="reviewActions" class="review-actions">
+      <button class="review-action again" data-action="again">もう一度<small>0日後</small></button>
+      <button class="review-action good"  data-action="good">良い<small>1日後</small></button>
+      <button class="review-action easy"  data-action="easy">簡単<small>3日後</small></button>
+    </div>
+
+    <!-- All cards list -->
+    <div class="section-title">📋 すべてのカード</div>
+    <div class="card-list" id="cardList">
+      <!-- populated by JS -->
+    </div>
+  </div>
+</div>
+
+<div id="toast" style="position:fixed;bottom:24px;left:50%;transform:translateX(-50%) translateY(20px);background:var(--text-primary);color:#fff;padding:12px 20px;border-radius:999px;font-size:13px;font-weight:700;box-shadow:0 8px 24px rgba(0,0,0,0.2);opacity:0;pointer-events:none;transition:all 0.25s ease;z-index:100;"></div>
+
+<script>
+  const cards = [
+    { en: 'break things down',         ja: '物事を分解する',                source: 'english-20', due: '今日' },
+    { en: 'component breakdown',       ja: '要素分解',                      source: 'english-20', due: '今日' },
+    { en: 'Mutually Exclusive',        ja: '相互に排他的（重複なし）',     source: 'english-20', due: '今日' },
+    { en: 'Collectively Exhaustive',   ja: '網羅的（漏れなし）',            source: 'english-20', due: '今日' },
+    { en: 'stands for',                ja: '〜の略',                        source: 'english-20', due: '今日' },
+    { en: 'blind spots',               ja: '死角',                          source: 'english-20', due: '1日後' },
+    { en: 'team alignment',            ja: 'チームの足並みが揃うこと',     source: 'english-20', due: '1日後' },
+    { en: 'general to specific',       ja: '一般から具体へ',                source: 'english-25', due: '今日' },
+    { en: 'syllogism',                 ja: '三段論法',                      source: 'english-25', due: '今日' },
+    { en: 'MECE分析の3つの切り口は？', ja: '3C・要素分解・時系列',          source: 'lesson-20', due: '今日' },
+    { en: '演繹法とは何か？',           ja: '一般原則から具体結論を導く推論',source: 'lesson-25', due: '3日後' },
+    { en: '仮説思考の最初のステップは？',ja: 'まず仮の答えを置く',           source: 'lesson-50', due: '7日後' },
+    { en: 'リフレーミングの定義',       ja: '同じ事実の見方を変えること',   source: 'lesson-59', due: '7日後' },
+    { en: 'バイアスの代表例3つ',         ja: '確証・利用可能性・アンカリング',source: 'ai-weak',   due: '0日後' },
+  ]
+  const $ = (id) => document.getElementById(id)
+
+  // Render list
+  $('cardList').innerHTML = cards.map(c => {
+    const isEn = c.source.startsWith('english-')
+    return `
+      <div class="card-item">
+        <div class="card-item-main">
+          <p class="card-item-en">${c.en}</p>
+          <p class="card-item-ja">${c.ja}</p>
+        </div>
+        <div class="card-item-meta">
+          <span class="badge-source" style="${isEn ? '' : 'background:rgba(120,120,120,0.12);color:var(--text-muted);'}">${isEn ? 'EN' : c.source.split('-')[0].toUpperCase()}</span>
+          <span class="card-item-due">復習: ${c.due}</span>
+        </div>
+      </div>
+    `
+  }).join('')
+
+  // Reveal flow
+  const revealBtn = $('revealBtn')
+  const back = $('reviewBack')
+  const actions = $('reviewActions')
+
+  revealBtn.addEventListener('click', () => {
+    back.classList.add('show')
+    actions.classList.add('show')
+    revealBtn.style.display = 'none'
+  })
+
+  // Review action - cycle to next
+  let cardIdx = 0
+  const enCards = cards.filter(c => c.source.startsWith('english-'))
+  const fronts = ['break things down', 'component breakdown', 'Mutually Exclusive', 'Collectively Exhaustive', 'stands for']
+  const backs = [
+    { ja: '物事を分解する', note: 'break A down または break down A。MECE分解の文脈で頻出。' },
+    { ja: '要素分解', note: '数式のように分解する手法' },
+    { ja: '相互に排他的（重複なし）', note: 'mutually = お互いに、exclusive = 排他的' },
+    { ja: '網羅的（漏れなし）', note: 'collectively = 全体として、exhaustive = 徹底的・すべて尽くす' },
+    { ja: '〜の略', note: '略語の元の意味を説明する定型表現' },
+  ]
+  function showToast(msg) {
+    const t = $('toast')
+    t.textContent = msg
+    t.style.opacity = '1'; t.style.transform = 'translateX(-50%) translateY(0)'
+    clearTimeout(t._timer)
+    t._timer = setTimeout(() => { t.style.opacity = '0'; t.style.transform = 'translateX(-50%) translateY(20px)' }, 1500)
+  }
+  actions.addEventListener('click', (e) => {
+    const btn = e.target.closest('.review-action')
+    if (!btn) return
+    const action = btn.dataset.action
+    showToast(action === 'again' ? '🔁 もう一度復習します' : action === 'good' ? '✓ 1日後に再表示' : '★ 3日後に再表示')
+    cardIdx = (cardIdx + 1) % fronts.length
+    $('reviewFront').textContent = fronts[cardIdx]
+    back.innerHTML = `${backs[cardIdx].ja}<div class="review-card-note">${backs[cardIdx].note}</div>`
+    back.classList.remove('show')
+    actions.classList.remove('show')
+    revealBtn.style.display = 'block'
+  })
+</script>
+</body>
+</html>

--- a/public/preview/english-lesson-flow.html
+++ b/public/preview/english-lesson-flow.html
@@ -1,0 +1,827 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<title>英語学習モード — フル体験 — Logic Preview</title>
+<link rel="stylesheet" href="_shared.css">
+<style>
+  /* ============ Layout ============ */
+  .lesson-progress { height: 4px; background: var(--bg-tertiary); }
+  .lesson-progress-fill {
+    height: 100%; background: linear-gradient(90deg, var(--accent), var(--accent-dark));
+    border-radius: 0 2px 2px 0;
+    transition: width 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+
+  /* ============ EN toolbar ============ */
+  .en-toolbar {
+    display: flex; flex-wrap: wrap; gap: 8px;
+    padding: 14px 20px 0;
+    align-items: center;
+  }
+  .en-toolbar-btn {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 8px 14px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg-card);
+    color: var(--text-primary);
+    font-size: 13px; font-family: inherit;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+  .en-toolbar-btn.active {
+    background: var(--accent-soft);
+    border-color: var(--accent-dark);
+    color: var(--accent-dark);
+    font-weight: 700;
+  }
+  .en-toolbar-badge {
+    font-size: 9px; font-weight: 900;
+    padding: 2px 6px; border-radius: 999px;
+    background: linear-gradient(135deg, #C9A94A 0%, #B07442 100%);
+    color: #fff; letter-spacing: 0.5px;
+    margin-left: 6px;
+  }
+  .saved-counter {
+    margin-left: auto;
+    display: inline-flex; align-items: center; gap: 4px;
+    font-size: 11px; font-weight: 700;
+    color: var(--text-muted);
+  }
+  .saved-counter strong { color: var(--accent-text); font-size: 14px; }
+
+  /* ============ Content ============ */
+  .lesson-content { padding: 20px 20px 120px; }
+
+  .step-tag {
+    font-size: 11px; font-weight: 800;
+    color: var(--accent-text); letter-spacing: 1.4px;
+    margin-bottom: 6px;
+  }
+  .explain-title {
+    font-size: 22px; font-weight: 800;
+    line-height: 1.5; color: var(--text-primary);
+    margin-bottom: 4px;
+  }
+  .explain-body {
+    font-size: 15px; line-height: 1.85;
+    color: var(--text-primary);
+    margin-bottom: 24px;
+  }
+  .explain-body p { margin: 6px 0; }
+  .explain-body .label {
+    font-weight: 800;
+    color: var(--accent-text);
+    margin-top: 16px;
+  }
+
+  .question-text {
+    font-size: 18px; font-weight: 700;
+    line-height: 1.6; color: var(--text-primary);
+    margin: 8px 0 18px;
+  }
+
+  /* ============ Inline phrase highlight (tap-to-translate) ============ */
+  .phrase-mark {
+    background: linear-gradient(180deg, transparent 65%, rgba(212,145,90,0.28) 65%);
+    padding: 0 2px;
+    cursor: pointer;
+    border-radius: 2px;
+    transition: background 0.15s ease;
+    -webkit-tap-highlight-color: transparent;
+    text-decoration: none;
+    color: inherit;
+  }
+  .phrase-mark:hover { background: linear-gradient(180deg, transparent 60%, rgba(212,145,90,0.50) 60%); }
+  .phrase-mark.viewed {
+    background: linear-gradient(180deg, transparent 65%, rgba(90,138,90,0.30) 65%);
+  }
+
+  /* ============ Phrase popover ============ */
+  .popover {
+    position: absolute;
+    z-index: 50;
+    background: var(--text-primary);
+    color: #FFFFFF;
+    padding: 14px 16px;
+    border-radius: 12px;
+    box-shadow: 0 12px 32px rgba(0,0,0,0.25);
+    max-width: 280px;
+    min-width: 220px;
+    font-size: 13px;
+    line-height: 1.55;
+    pointer-events: auto;
+    animation: pop-in 0.18s ease-out;
+  }
+  @keyframes pop-in {
+    from { opacity: 0; transform: scale(0.92) translateY(4px); }
+    to { opacity: 1; transform: scale(1) translateY(0); }
+  }
+  .popover::before {
+    content: ''; position: absolute;
+    top: -6px; left: 24px;
+    width: 12px; height: 12px;
+    background: var(--text-primary);
+    transform: rotate(45deg);
+    border-radius: 2px;
+  }
+  .popover-en {
+    font-size: 14px; font-weight: 800;
+    margin-bottom: 6px;
+  }
+  .popover-ja {
+    color: rgba(255,255,255,0.92);
+    font-weight: 600;
+  }
+  .popover-note {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid rgba(255,255,255,0.18);
+    color: rgba(255,255,255,0.7);
+    font-size: 12px;
+    font-style: italic;
+  }
+  .popover-actions {
+    display: flex; gap: 8px;
+    margin-top: 12px;
+  }
+  .popover-save {
+    flex: 1;
+    padding: 8px 10px;
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    font-size: 12px; font-weight: 800;
+    cursor: pointer; font-family: inherit;
+  }
+  .popover-save.saved {
+    background: var(--success);
+  }
+  .popover-close {
+    width: 32px; height: 32px;
+    background: rgba(255,255,255,0.12);
+    color: #fff; border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 18px; font-weight: 700;
+  }
+
+  /* ============ Translation block ============ */
+  .ja-translation {
+    border-left: 2px solid var(--accent);
+    padding: 10px 12px;
+    background: var(--bg-secondary);
+    border-radius: 4px;
+    color: var(--text-secondary);
+    font-size: 13px;
+    line-height: 1.85;
+    margin: 8px 0 18px;
+    display: none;
+  }
+  .ja-translation.show { display: block; animation: fade-in 0.2s ease-out; }
+  .ja-translation-title { font-weight: 600; font-size: 14px; }
+  .ja-translation-inline {
+    display: block;
+    border-left: none;
+    padding: 0;
+    margin: 4px 0 0 0;
+    background: transparent;
+    font-size: 12px;
+    color: var(--text-muted);
+    font-weight: 400;
+    line-height: 1.5;
+  }
+  @keyframes fade-in {
+    from { opacity: 0; transform: translateY(-4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  /* ============ Phrases panel ============ */
+  .phrases-panel {
+    margin-top: 16px;
+    padding: 16px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    display: none;
+  }
+  .phrases-panel.show { display: block; animation: fade-in 0.2s ease-out; }
+  .phrases-header { display: flex; flex-direction: column; gap: 4px; margin-bottom: 12px; }
+  .phrases-title { font-size: 15px; font-weight: 800; }
+  .phrases-hint { font-size: 11px; color: var(--text-muted); }
+  .phrases-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+  .phrase-row {
+    display: flex; align-items: flex-start; gap: 12px;
+    padding: 12px 14px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+  }
+  .phrase-main { flex: 1; min-width: 0; }
+  .phrase-en { font-size: 14px; font-weight: 700; margin: 0 0 2px 0; }
+  .phrase-ja { font-size: 13px; color: var(--text-secondary); margin: 0; }
+  .phrase-note { font-size: 11px; color: var(--text-muted); margin: 4px 0 0 0; font-style: italic; line-height: 1.6; }
+  .phrase-save {
+    flex-shrink: 0; padding: 7px 13px;
+    background: var(--accent); color: #fff;
+    border: none; border-radius: 999px;
+    font-size: 11px; font-weight: 800;
+    cursor: pointer; font-family: inherit;
+  }
+  .phrase-save.saved { background: var(--bg-tertiary); color: var(--text-muted); cursor: default; }
+
+  /* ============ Quiz options ============ */
+  .options { display: flex; flex-direction: column; gap: 10px; margin-top: 18px; }
+  .option {
+    background: var(--bg-card);
+    border: 1.5px solid var(--border);
+    border-radius: 12px;
+    padding: 16px 18px;
+    font-size: 14px;
+    color: var(--text-primary);
+    cursor: pointer;
+    text-align: left;
+    line-height: 1.5;
+    font-family: inherit;
+    display: flex; align-items: flex-start; gap: 12px;
+    transition: all 0.15s ease-out;
+    width: 100%;
+  }
+  .option-letter {
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--bg-tertiary); color: var(--text-secondary);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 13px; font-weight: 800;
+    flex-shrink: 0;
+    margin-top: 2px;
+  }
+  .option-text { flex: 1; }
+  .option.selected { border-color: var(--accent); background: var(--accent-soft); }
+  .option.correct { border-color: var(--success); background: var(--success-soft); }
+  .option.wrong { border-color: var(--danger); background: rgba(196,69,69,0.10); }
+
+  .feedback {
+    margin-top: 16px;
+    padding: 14px 16px;
+    border-radius: 12px;
+    background: var(--success-soft);
+    border-left: 3px solid var(--success);
+    display: none;
+  }
+  .feedback.wrong { background: rgba(196,69,69,0.10); border-left-color: var(--danger); }
+  .feedback.show { display: block; animation: fade-in 0.2s ease-out; }
+  .feedback-title { font-size: 14px; font-weight: 800; color: var(--success); margin-bottom: 6px; }
+  .feedback.wrong .feedback-title { color: var(--danger); }
+  .feedback-text { font-size: 13px; line-height: 1.7; color: var(--text-primary); }
+
+  /* ============ Bottom buttons ============ */
+  .step-bar {
+    position: fixed;
+    bottom: 0; left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    max-width: 480px;
+    padding: 14px 20px env(safe-area-inset-bottom);
+    background: linear-gradient(0deg, var(--bg-primary) 75%, transparent);
+    display: flex; gap: 10px;
+  }
+  .step-bar button {
+    border: none;
+    border-radius: 14px;
+    padding: 16px;
+    font-size: 15px;
+    font-weight: 800;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  .step-back-btn {
+    flex: 0 0 80px;
+    background: var(--bg-card);
+    border: 1.5px solid var(--border) !important;
+    color: var(--text-secondary);
+  }
+  .step-back-btn:disabled { opacity: 0.4; cursor: default; }
+  .next-btn {
+    flex: 1;
+    background: var(--accent); color: #fff;
+    box-shadow: 0 4px 16px rgba(212,145,90,0.30);
+  }
+  .next-btn:disabled { opacity: 0.5; box-shadow: none; cursor: default; }
+
+  /* ============ Complete screen ============ */
+  .complete {
+    padding: 40px 24px 120px;
+    text-align: center;
+  }
+  .complete-trophy { font-size: 64px; margin-bottom: 12px; }
+  .complete h2 {
+    font-size: 26px; font-weight: 800;
+    margin-bottom: 8px;
+  }
+  .complete-msg {
+    font-size: 14px; color: var(--text-secondary);
+    margin-bottom: 28px;
+  }
+  .complete-stats {
+    display: grid; grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    margin-bottom: 28px;
+  }
+  .stat-card {
+    padding: 16px 14px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+  }
+  .stat-card .num {
+    font-size: 28px; font-weight: 800;
+    color: var(--accent-text);
+  }
+  .stat-card .label {
+    font-size: 11px; color: var(--text-muted);
+    margin-top: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+  }
+  .complete-saved-list {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 16px;
+    text-align: left;
+    margin-bottom: 16px;
+  }
+  .complete-saved-list h3 {
+    font-size: 14px; font-weight: 800;
+    margin-bottom: 10px;
+  }
+  .complete-saved-list ul { list-style: none; padding: 0; margin: 0; }
+  .complete-saved-list li {
+    padding: 8px 0;
+    border-bottom: 1px solid var(--border-light);
+    font-size: 13px;
+    display: flex; justify-content: space-between; align-items: center; gap: 12px;
+  }
+  .complete-saved-list li:last-child { border-bottom: none; }
+  .complete-saved-list li .en { font-weight: 700; }
+  .complete-saved-list li .ja { color: var(--text-muted); font-size: 12px; }
+
+  /* Demo banner */
+  .demo-banner {
+    background: linear-gradient(135deg, rgba(201,169,74,0.15), rgba(176,116,66,0.15));
+    border: 1px solid rgba(201,169,74,0.4);
+    color: #6b5526;
+    padding: 12px 16px;
+    border-radius: 12px;
+    font-size: 12px;
+    line-height: 1.7;
+    margin: 12px 20px 0;
+  }
+  .demo-banner b { color: #4a3a18; }
+
+  /* Toast */
+  .toast {
+    position: fixed;
+    bottom: 100px; left: 50%;
+    transform: translateX(-50%) translateY(20px);
+    background: var(--text-primary);
+    color: var(--bg-card);
+    padding: 12px 20px;
+    border-radius: 999px;
+    font-size: 13px; font-weight: 700;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.2);
+    opacity: 0; pointer-events: none;
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    z-index: 110;
+  }
+  .toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+  /* Step views */
+  .step-view { display: none; }
+  .step-view.active { display: block; }
+
+  /* Backdrop for popover */
+  .popover-backdrop {
+    position: fixed; inset: 0; z-index: 40;
+    display: none;
+  }
+  .popover-backdrop.active { display: block; }
+</style>
+</head>
+<body>
+<div class="preview-note">📱 Premium feature: 英語学習モード（フル体験版・4ステップ）</div>
+<div class="app">
+  <header class="header">
+    <button class="header-back">‹</button>
+    <span class="header-title">MECE — Logical Thinking</span>
+    <span id="stepCount" style="font-size: 11px; font-weight: 700; color: var(--text-muted); letter-spacing: 1.4px;">1/4</span>
+  </header>
+  <div class="lesson-progress"><div id="progressFill" class="lesson-progress-fill" style="width: 25%;"></div></div>
+
+  <div class="demo-banner">
+    👆 <b>新機能 (拡張版):</b> 本文中の<span style="background: linear-gradient(180deg, transparent 65%, rgba(212,145,90,0.40) 65%); padding: 0 2px;">下線フレーズ</span>をタップすると、ポップオーバーで意味と注釈が出ます。「日本語訳」「フレーズを学ぶ」のトグルも併用できます。
+  </div>
+
+  <!-- EN toolbar -->
+  <div class="en-toolbar" role="toolbar">
+    <button id="btnTranslation" type="button" class="en-toolbar-btn">
+      <span aria-hidden="true">あ</span>
+      <span id="btnTranslationLabel">Show Japanese</span>
+      <span class="en-toolbar-badge">Premium</span>
+    </button>
+    <button id="btnPhrases" type="button" class="en-toolbar-btn">
+      <span aria-hidden="true">📖</span>
+      <span id="btnPhrasesLabel">Study phrases</span>
+    </button>
+    <span class="saved-counter">💾 <strong id="savedCount">0</strong>枚保存済</span>
+  </div>
+
+  <!-- ============ Step 1: explain ============ -->
+  <div id="step1" class="step-view active">
+    <div class="lesson-content">
+      <div class="step-tag">EXPLAIN</div>
+      <h2 class="explain-title">What is MECE?</h2>
+      <p class="ja-translation ja-translation-title">MECE（ミーシー）とは？</p>
+
+      <div class="explain-body">
+        <p>MECE (pronounced "mee-see") <span class="phrase-mark" data-phrase="stands-for">stands for</span> "Mutually Exclusive, Collectively Exhaustive." It is the most fundamental framework for analyzing and organizing information in business.</p>
+        <p class="ja-translation">MECE（「ミーシー」と発音）は "Mutually Exclusive, Collectively Exhaustive"（モレなく、ダブりなく）の略です。ビジネスで情報を分析・整理する最も基本的なフレームワークです。</p>
+
+        <p class="label">■ <span class="phrase-mark" data-phrase="mutually-exclusive">Mutually Exclusive</span></p>
+        <p>No <span class="phrase-mark" data-phrase="overlap">overlap</span> between categories. The same item never appears in more than one bucket.</p>
+        <p class="ja-translation">カテゴリー同士が重ならない。同じ項目が複数のバケツに入ることはない。</p>
+
+        <p class="label">■ <span class="phrase-mark" data-phrase="collectively-exhaustive">Collectively Exhaustive</span></p>
+        <p>Everything is covered. No gaps, no missing pieces.</p>
+        <p class="ja-translation">すべてが網羅されている。抜けや見落としがない。</p>
+
+        <p style="margin-top: 16px;">Why MECE matters:</p>
+        <p>① Prevents <span class="phrase-mark" data-phrase="blind-spots">blind spots</span> → better decisions</p>
+        <p>② Eliminates duplication → efficient resource allocation</p>
+        <p>③ Clearer communication → <span class="phrase-mark" data-phrase="team-alignment">team alignment</span></p>
+        <p class="ja-translation">MECEが大事な理由：<br>① 死角を防ぐ → よい意思決定<br>② 重複を排除する → 効率的な資源配分<br>③ コミュニケーションが明確 → チームの足並みが揃う</p>
+      </div>
+
+      <div id="phrasesPanel1" class="phrases-panel" role="region">
+        <div class="phrases-header">
+          <span class="phrases-title">📖 重要フレーズ</span>
+          <span class="phrases-hint">本文の下線フレーズを直接タップしてもOK</span>
+        </div>
+        <ul class="phrases-list" id="phrasesList1"></ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ Step 2: explain ============ -->
+  <div id="step2" class="step-view">
+    <div class="lesson-content">
+      <div class="step-tag">EXPLAIN</div>
+      <h2 class="explain-title">Four ways to break things down MECE</h2>
+      <p class="ja-translation ja-translation-title">MECEに分解する4つの方法</p>
+
+      <div class="explain-body">
+        <p>There are four common patterns for MECE <span class="phrase-mark" data-phrase="decomposition">decomposition</span>.</p>
+        <p class="ja-translation">MECE分解には4つの代表的なパターンがあります。</p>
+
+        <p class="label">[1] <span class="phrase-mark" data-phrase="component-breakdown">Component breakdown</span> (formula-style)</p>
+        <p>Split a whole into its mathematical components.</p>
+        <p>Examples: Revenue = customers × <span class="phrase-mark" data-phrase="average-order-value">average order value</span></p>
+        <p class="ja-translation">全体を数式の構成要素に分ける。<br>例：売上 = 顧客数 × 平均客単価</p>
+
+        <p class="label">[2] Time sequence</p>
+        <p>Split by stages over time. Example: Buying journey = Awareness → Interest → Consideration → Purchase → Repeat</p>
+        <p class="ja-translation">時間の段階で分ける。例：購買ジャーニー = 認知 → 興味 → 検討 → 購入 → リピート</p>
+
+        <p class="label">[3] Opposing concepts</p>
+        <p>Split by binary or <span class="phrase-mark" data-phrase="near-binary">near-binary</span> categories.</p>
+        <p class="ja-translation">二項対立または近い分類で分ける。</p>
+
+        <p class="label">[4] Established framework</p>
+        <p>Use a known framework as the cut. Pick <span class="phrase-mark" data-phrase="whichever-gives">whichever pattern gives</span> the clearest, least-overlapping cut.</p>
+        <p class="ja-translation">既知のフレームワークで切る。最も明確で重複の少ない切り口を選ぼう。</p>
+      </div>
+
+      <div id="phrasesPanel2" class="phrases-panel" role="region">
+        <div class="phrases-header">
+          <span class="phrases-title">📖 重要フレーズ</span>
+          <span class="phrases-hint">本文の下線フレーズを直接タップしてもOK</span>
+        </div>
+        <ul class="phrases-list" id="phrasesList2"></ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ Step 3: quiz ============ -->
+  <div id="step3" class="step-view">
+    <div class="lesson-content">
+      <div class="step-tag">QUIZ</div>
+      <h2 class="question-text">What does the "<span class="phrase-mark" data-phrase="mutually-exclusive">Mutually Exclusive</span>" <span class="phrase-mark" data-phrase="half-of">half of</span> MECE mean?</h2>
+      <p class="ja-translation">MECEの「Mutually Exclusive（重複なし）」の意味は？</p>
+
+      <div class="options" id="quizOptions">
+        <button class="option" data-correct="false">
+          <span class="option-letter">A</span>
+          <span class="option-text">
+            Everything is covered with no gaps
+            <span class="ja-translation ja-translation-inline">漏れなくすべて網羅されている</span>
+          </span>
+        </button>
+        <button class="option" data-correct="true">
+          <span class="option-letter">B</span>
+          <span class="option-text">
+            Categories do not overlap
+            <span class="ja-translation ja-translation-inline">カテゴリー同士が重ならない</span>
+          </span>
+        </button>
+        <button class="option" data-correct="false">
+          <span class="option-letter">C</span>
+          <span class="option-text">
+            The structure is hierarchical
+            <span class="ja-translation ja-translation-inline">構造が階層的になっている</span>
+          </span>
+        </button>
+        <button class="option" data-correct="false">
+          <span class="option-letter">D</span>
+          <span class="option-text">
+            Items are sorted in time order
+            <span class="ja-translation ja-translation-inline">時系列順に並んでいる</span>
+          </span>
+        </button>
+      </div>
+
+      <div id="feedback" class="feedback">
+        <div class="feedback-title" id="feedbackTitle">正解！</div>
+        <p class="feedback-text">"Mutually Exclusive" means categories do not overlap — the same item <span class="phrase-mark" data-phrase="never-lives">never lives</span> in two buckets.</p>
+        <p class="ja-translation">「Mutually Exclusive」とはカテゴリー同士が重ならないこと。同じ項目が2つのバケツに同時に入ることはありません。</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ Step 4: complete ============ -->
+  <div id="step4" class="step-view">
+    <div class="complete">
+      <div class="complete-trophy">🏆</div>
+      <h2>レッスン完了！</h2>
+      <p class="complete-msg">英語で論理思考を学びながら、ビジネス英語フレーズも吸収できました。</p>
+
+      <div class="complete-stats">
+        <div class="stat-card">
+          <div class="num" id="finalSavedCount">0</div>
+          <div class="label">保存フレーズ</div>
+        </div>
+        <div class="stat-card">
+          <div class="num">+15</div>
+          <div class="label">XP 獲得</div>
+        </div>
+      </div>
+
+      <div class="complete-saved-list" id="finalSavedList" style="display: none;">
+        <h3>💾 今日新しく覚えたフレーズ</h3>
+        <ul id="finalSavedItems"></ul>
+      </div>
+
+      <p style="font-size: 12px; color: var(--text-muted); margin-top: 12px;">保存したフレーズは <a href="english-flashcards.html" style="color: var(--accent-dark); font-weight: 700;">フラッシュカード画面</a> で復習できます（SM-2 間隔反復）。</p>
+    </div>
+  </div>
+
+  <!-- Step bar -->
+  <div class="step-bar" id="stepBar">
+    <button id="backBtn" class="step-back-btn" disabled>戻る</button>
+    <button id="nextBtn" class="next-btn">次へ</button>
+  </div>
+</div>
+
+<!-- Popover container -->
+<div id="popoverBackdrop" class="popover-backdrop"></div>
+<div id="popover" style="display:none;"></div>
+
+<div id="toast" class="toast"></div>
+
+<script>
+  // ============ Phrase data ============
+  const PHRASES = {
+    'stands-for':            { en: 'stands for',            ja: '〜の略',                           note: '略語の元の意味を説明する定型表現。' },
+    'mutually-exclusive':    { en: 'Mutually Exclusive',    ja: '相互に排他的（重複なし）',         note: 'mutually = お互いに、exclusive = 排他的' },
+    'collectively-exhaustive': { en: 'Collectively Exhaustive', ja: '網羅的（漏れなし）',         note: 'collectively = 全体として、exhaustive = 徹底的・すべて尽くす' },
+    'overlap':               { en: 'overlap',               ja: '重複（する）' },
+    'blind-spots':           { en: 'blind spots',           ja: '死角',                             note: '気づいていない欠点・見落とし' },
+    'team-alignment':        { en: 'team alignment',        ja: 'チームの足並みが揃うこと',         note: 'align = 一致させる、整列する' },
+    'decomposition':         { en: 'decomposition',         ja: '分解',                             note: 'decompose = 分解する。論理的な分解の文脈で頻出。' },
+    'component-breakdown':   { en: 'component breakdown',   ja: '要素分解',                         note: '数式のように分解する手法' },
+    'average-order-value':   { en: 'average order value',   ja: '平均客単価（AOV）',                note: 'EC でよく出る指標' },
+    'near-binary':           { en: 'near-binary',           ja: 'ほぼ二項対立的な',                 note: 'near- = ほぼ〜、近い' },
+    'whichever-gives':       { en: 'whichever ... gives',   ja: '〜を提供するものはどれでも',       note: '関係詞 whichever。"pick whichever pattern gives the clearest cut"' },
+    'half-of':               { en: 'half of',               ja: '〜の半分・片方',                   note: '"the Mutually Exclusive half of MECE" = MECEの片方' },
+    'never-lives':           { en: 'never lives in',        ja: '〜には決して存在しない',           note: 'live in = （比喩的に）〜に位置する／属する' },
+  }
+
+  // ============ State ============
+  const saved = new Set()
+  const viewedPhrases = new Set()
+  let currentStep = 1
+  let answered = false
+
+  // ============ Helpers ============
+  const $  = (id) => document.getElementById(id)
+  const $$ = (sel, root) => Array.from((root || document).querySelectorAll(sel))
+
+  function updateSavedCount() {
+    $('savedCount').textContent = saved.size
+    if ($('finalSavedCount')) $('finalSavedCount').textContent = saved.size
+  }
+
+  function showToast(msg) {
+    const t = $('toast')
+    t.textContent = msg
+    t.classList.add('show')
+    clearTimeout(t._timer)
+    t._timer = setTimeout(() => t.classList.remove('show'), 1800)
+  }
+
+  // ============ Render phrase panels (filtered by which phrases appear in each step) ============
+  const STEP_PHRASES = {
+    1: ['stands-for', 'mutually-exclusive', 'collectively-exhaustive', 'overlap', 'blind-spots', 'team-alignment'],
+    2: ['decomposition', 'component-breakdown', 'average-order-value', 'near-binary', 'whichever-gives'],
+    3: ['half-of', 'never-lives'],
+  }
+
+  function renderPhrasePanel(step) {
+    const list = $('phrasesList' + step)
+    if (!list) return
+    list.innerHTML = STEP_PHRASES[step].map(key => {
+      const p = PHRASES[key]
+      const isSaved = saved.has(key)
+      return `
+        <li class="phrase-row">
+          <div class="phrase-main">
+            <p class="phrase-en">${p.en}</p>
+            <p class="phrase-ja">${p.ja}</p>
+            ${p.note ? `<p class="phrase-note">${p.note}</p>` : ''}
+          </div>
+          <button class="phrase-save${isSaved ? ' saved' : ''}" data-key="${key}" ${isSaved ? 'disabled' : ''}>
+            ${isSaved ? '保存済み ✓' : 'カードに保存'}
+          </button>
+        </li>
+      `
+    }).join('')
+  }
+  ;[1, 2, 3].forEach(renderPhrasePanel)
+
+  function savePhrase(key) {
+    if (saved.has(key)) return
+    saved.add(key)
+    const p = PHRASES[key]
+    showToast(`「${p.en}」をフラッシュカードに追加しました`)
+    updateSavedCount()
+    // Re-render all phrase panels (cheap; tiny lists)
+    ;[1, 2, 3].forEach(renderPhrasePanel)
+    // Mark inline phrases as viewed
+    $$(`.phrase-mark[data-phrase="${key}"]`).forEach(el => el.classList.add('viewed'))
+  }
+
+  // ============ Inline phrase popover ============
+  const popover = $('popover')
+  const popoverBackdrop = $('popoverBackdrop')
+  let popoverKey = null
+
+  function openPopover(target, key) {
+    const p = PHRASES[key]
+    if (!p) return
+    popoverKey = key
+    const isSaved = saved.has(key)
+    popover.innerHTML = `
+      <div class="popover">
+        <button class="popover-close" aria-label="閉じる" id="popoverClose" style="position:absolute; top:8px; right:8px;">×</button>
+        <div class="popover-en">${p.en}</div>
+        <div class="popover-ja">${p.ja}</div>
+        ${p.note ? `<div class="popover-note">${p.note}</div>` : ''}
+        <div class="popover-actions">
+          <button class="popover-save${isSaved ? ' saved' : ''}" id="popoverSave" ${isSaved ? 'disabled' : ''}>
+            ${isSaved ? '✓ 保存済み' : '💾 カードに保存'}
+          </button>
+        </div>
+      </div>
+    `
+    popover.style.display = 'block'
+    // Position the popover under the target
+    const rect = target.getBoundingClientRect()
+    const pop = popover.querySelector('.popover')
+    const popWidth = 260
+    let left = rect.left + window.scrollX
+    if (left + popWidth > window.innerWidth - 16) left = window.innerWidth - popWidth - 16
+    if (left < 16) left = 16
+    pop.style.position = 'absolute'
+    pop.style.left = left + 'px'
+    pop.style.top = (rect.bottom + window.scrollY + 12) + 'px'
+    popoverBackdrop.classList.add('active')
+    target.classList.add('viewed')
+    viewedPhrases.add(key)
+
+    $('popoverClose').addEventListener('click', closePopover)
+    $('popoverSave').addEventListener('click', () => {
+      savePhrase(key)
+      closePopover()
+    })
+  }
+  function closePopover() {
+    popover.style.display = 'none'
+    popoverBackdrop.classList.remove('active')
+    popoverKey = null
+  }
+  popoverBackdrop.addEventListener('click', closePopover)
+  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closePopover() })
+
+  // Delegate inline phrase taps
+  document.addEventListener('click', (e) => {
+    const mark = e.target.closest('.phrase-mark')
+    if (!mark) return
+    e.stopPropagation()
+    openPopover(mark, mark.dataset.phrase)
+  })
+
+  // Delegate phrase panel save clicks
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest('.phrase-save')
+    if (!btn || btn.classList.contains('saved')) return
+    savePhrase(btn.dataset.key)
+  })
+
+  // ============ Translation toggle ============
+  const btnTr = $('btnTranslation')
+  const btnTrLabel = $('btnTranslationLabel')
+  let translationOn = false
+  btnTr.addEventListener('click', () => {
+    translationOn = !translationOn
+    btnTr.classList.toggle('active', translationOn)
+    btnTrLabel.textContent = translationOn ? 'Hide Japanese' : 'Show Japanese'
+    $$('.ja-translation').forEach(el => el.classList.toggle('show', translationOn))
+  })
+
+  // ============ Phrases panel toggle ============
+  const btnPh = $('btnPhrases')
+  const btnPhLabel = $('btnPhrasesLabel')
+  let phrasesOn = false
+  btnPh.addEventListener('click', () => {
+    phrasesOn = !phrasesOn
+    btnPh.classList.toggle('active', phrasesOn)
+    btnPhLabel.textContent = phrasesOn ? 'Hide phrases' : 'Study phrases'
+    ;[1, 2, 3].forEach(s => {
+      const panel = $('phrasesPanel' + s)
+      if (panel) panel.classList.toggle('show', phrasesOn)
+    })
+  })
+
+  // ============ Quiz ============
+  $('quizOptions')?.addEventListener('click', (e) => {
+    const opt = e.target.closest('.option')
+    if (!opt || answered) return
+    answered = true
+    const correct = opt.dataset.correct === 'true'
+    $$('.option').forEach(o => {
+      if (o.dataset.correct === 'true') o.classList.add('correct')
+    })
+    if (!correct) opt.classList.add('wrong')
+    const fb = $('feedback')
+    fb.classList.add('show')
+    if (!correct) {
+      fb.classList.add('wrong')
+      $('feedbackTitle').textContent = '不正解'
+    }
+  })
+
+  // ============ Step navigation ============
+  function goToStep(n) {
+    currentStep = Math.max(1, Math.min(4, n))
+    $$('.step-view').forEach(v => v.classList.remove('active'))
+    $('step' + currentStep).classList.add('active')
+    const pct = (currentStep / 4) * 100
+    $('progressFill').style.width = pct + '%'
+    $('stepCount').textContent = `${currentStep}/4`
+    $('backBtn').disabled = currentStep === 1
+    $('nextBtn').textContent = currentStep === 3 ? (answered ? '結果を見る' : '回答してください') : (currentStep === 4 ? 'もう一度' : '次へ')
+    $('nextBtn').disabled = currentStep === 3 && !answered
+    if (currentStep === 4) {
+      $('stepBar').style.display = 'none'
+      // Build saved list
+      const list = $('finalSavedItems')
+      list.innerHTML = Array.from(saved).map(k => {
+        const p = PHRASES[k]
+        return `<li><span class="en">${p.en}</span><span class="ja">${p.ja}</span></li>`
+      }).join('')
+      $('finalSavedList').style.display = saved.size > 0 ? 'block' : 'none'
+    } else {
+      $('stepBar').style.display = 'flex'
+    }
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+  $('nextBtn').addEventListener('click', () => {
+    if (currentStep === 4) { saved.clear(); viewedPhrases.clear(); answered = false; updateSavedCount(); ;[1,2,3].forEach(renderPhrasePanel); $$('.phrase-mark').forEach(m => m.classList.remove('viewed')); $$('.option').forEach(o => o.classList.remove('correct','wrong','selected')); $('feedback').classList.remove('show','wrong'); goToStep(1); return }
+    goToStep(currentStep + 1)
+  })
+  $('backBtn').addEventListener('click', () => goToStep(currentStep - 1))
+</script>
+</body>
+</html>

--- a/public/preview/english-lesson.html
+++ b/public/preview/english-lesson.html
@@ -1,0 +1,379 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<title>英語学習モード — Logic Preview</title>
+<link rel="stylesheet" href="_shared.css">
+<style>
+  .lesson-progress { height: 4px; background: var(--bg-tertiary); }
+  .lesson-progress-fill { height: 100%; width: 24%; background: linear-gradient(90deg, var(--accent), var(--accent-dark)); border-radius: 0 2px 2px 0; }
+
+  /* English-learning toolbar */
+  .en-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 14px 20px 0;
+  }
+  .en-toolbar-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg-card);
+    color: var(--text-primary);
+    font-size: 13px;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+  .en-toolbar-btn:hover { border-color: var(--accent-dark); }
+  .en-toolbar-btn.active {
+    background: var(--accent-soft);
+    border-color: var(--accent-dark);
+    color: var(--accent-dark);
+    font-weight: 700;
+  }
+  .en-toolbar-badge {
+    font-size: 9px;
+    font-weight: 900;
+    padding: 2px 6px;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #C9A94A 0%, #B07442 100%);
+    color: #fff;
+    letter-spacing: 0.5px;
+    margin-left: 6px;
+  }
+
+  .lesson-content { padding: 20px 20px 100px; }
+
+  /* Explain (header) */
+  .explain-title {
+    font-size: 22px;
+    font-weight: 800;
+    line-height: 1.5;
+    color: var(--text-primary);
+    margin-bottom: 4px;
+  }
+  .explain-body {
+    font-size: 15px;
+    line-height: 1.85;
+    color: var(--text-primary);
+    margin-bottom: 24px;
+  }
+  .explain-body p {
+    margin: 6px 0;
+  }
+  .explain-body .label {
+    font-weight: 800;
+    color: var(--accent-text);
+    margin-top: 16px;
+  }
+
+  /* Translation block */
+  .ja-translation {
+    border-left: 2px solid var(--accent);
+    padding: 10px 12px;
+    background: var(--bg-secondary);
+    border-radius: 4px;
+    color: var(--text-secondary);
+    font-size: 13px;
+    line-height: 1.85;
+    margin: 8px 0 18px;
+    display: none;
+  }
+  .ja-translation.show { display: block; animation: fade-in 0.2s ease-out; }
+  .ja-translation-title { font-weight: 600; font-size: 14px; }
+  @keyframes fade-in {
+    from { opacity: 0; transform: translateY(-4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  /* Phrases panel */
+  .phrases {
+    margin-top: 16px;
+    padding: 16px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    display: none;
+  }
+  .phrases.show { display: block; animation: fade-in 0.2s ease-out; }
+  .phrases-header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 12px;
+  }
+  .phrases-title {
+    font-size: 15px;
+    font-weight: 800;
+    color: var(--text-primary);
+  }
+  .phrases-hint {
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+  .phrases-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .phrase {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 14px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+  }
+  .phrase-main { flex: 1; min-width: 0; }
+  .phrase-en {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin: 0 0 2px 0;
+  }
+  .phrase-ja {
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin: 0;
+  }
+  .phrase-note {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin: 4px 0 0 0;
+    font-style: italic;
+    line-height: 1.6;
+  }
+  .phrase-save {
+    flex-shrink: 0;
+    padding: 7px 13px;
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 800;
+    cursor: pointer;
+    font-family: inherit;
+    transition: all 0.15s ease;
+  }
+  .phrase-save:hover { background: var(--accent-dark); }
+  .phrase-save.saved {
+    background: var(--bg-tertiary);
+    color: var(--text-muted);
+    cursor: default;
+  }
+
+  .next-btn {
+    width: 100%;
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    border-radius: 14px;
+    padding: 16px;
+    font-size: 15px;
+    font-weight: 800;
+    cursor: pointer;
+    font-family: inherit;
+    margin-top: 24px;
+    box-shadow: 0 4px 16px rgba(212,145,90,0.30);
+  }
+
+  .demo-banner {
+    background: linear-gradient(135deg, rgba(201,169,74,0.15), rgba(176,116,66,0.15));
+    border: 1px solid rgba(201,169,74,0.4);
+    color: #6b5526;
+    padding: 12px 16px;
+    border-radius: 12px;
+    font-size: 12px;
+    line-height: 1.7;
+    margin: 0 20px 12px;
+  }
+  .demo-banner b { color: #4a3a18; }
+
+  /* Toast */
+  .toast {
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%) translateY(20px);
+    background: var(--text-primary);
+    color: var(--bg-card);
+    padding: 12px 20px;
+    border-radius: 999px;
+    font-size: 13px;
+    font-weight: 700;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.2);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    z-index: 100;
+  }
+  .toast.show {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+</style>
+</head>
+<body>
+<div class="preview-note">📱 Premium feature: 英語ロケール時の英語学習モード（Lesson 20: MECE / Step 1）</div>
+<div class="app">
+  <header class="header">
+    <button class="header-back">‹</button>
+    <span class="header-title">MECE — Logical Thinking</span>
+    <span style="font-size: 11px; font-weight: 700; color: var(--text-muted); letter-spacing: 1.4px;">2/12</span>
+  </header>
+  <div class="lesson-progress"><div class="lesson-progress-fill"></div></div>
+
+  <div class="demo-banner">
+    👆 <b>このモックアップは操作できます</b>。下の「日本語訳」「フレーズを学ぶ」を押して、英語学習モードの動きを確認してください。
+  </div>
+
+  <!-- English-learning toolbar (only visible when premium + en locale + annotations exist) -->
+  <div class="en-toolbar" role="toolbar" aria-label="English learning tools">
+    <button id="btnTranslation" type="button" class="en-toolbar-btn" aria-pressed="false">
+      <span aria-hidden="true">あ</span>
+      <span id="btnTranslationLabel">Show Japanese</span>
+      <span class="en-toolbar-badge">Premium</span>
+    </button>
+    <button id="btnPhrases" type="button" class="en-toolbar-btn" aria-pressed="false">
+      <span aria-hidden="true">📖</span>
+      <span id="btnPhrasesLabel">Study phrases</span>
+      <span class="en-toolbar-badge">Premium</span>
+    </button>
+  </div>
+
+  <div class="lesson-content">
+    <h2 class="explain-title">Four ways to break things down MECE</h2>
+    <p id="trTitle" class="ja-translation ja-translation-title">MECEに分解する4つの方法</p>
+
+    <div class="explain-body">
+      <p>There are four common patterns for MECE decomposition.</p>
+      <p id="tr1" class="ja-translation">MECE分解には4つの代表的なパターンがあります。</p>
+
+      <p class="label">[1] Component breakdown (formula-style)</p>
+      <p id="tr2a" class="ja-translation ja-translation-title">[1] 要素分解（数式型）</p>
+      <p>Split a whole into its mathematical components.</p>
+      <p>Examples: Revenue = customers × average order value / Profit = Revenue − Cost</p>
+      <p id="tr2b" class="ja-translation">全体を数式の構成要素に分ける。<br>例：売上 = 顧客数 × 平均客単価／利益 = 売上 − コスト</p>
+
+      <p class="label">[2] Time sequence</p>
+      <p id="tr3a" class="ja-translation ja-translation-title">[2] 時系列</p>
+      <p>Split by stages over time.</p>
+      <p>Example: Buying journey = Awareness → Interest → Consideration → Purchase → Repeat</p>
+      <p id="tr3b" class="ja-translation">時間の段階で分ける。<br>例：購買ジャーニー = 認知 → 興味 → 検討 → 購入 → リピート</p>
+
+      <p class="label">[3] Opposing concepts</p>
+      <p id="tr4a" class="ja-translation ja-translation-title">[3] 対立概念</p>
+      <p>Split by binary or near-binary categories.</p>
+      <p>Examples: Domestic / International, Existing / New, Online / Offline</p>
+      <p id="tr4b" class="ja-translation">二項対立または近い分類で分ける。<br>例：国内／海外、既存／新規、オンライン／オフライン</p>
+
+      <p class="label">[4] Established framework</p>
+      <p id="tr5a" class="ja-translation ja-translation-title">[4] 既存フレームワーク</p>
+      <p>Use a known framework as the cut.</p>
+      <p>Examples: 3C (Customer, Competitor, Company), 4P (Product, Price, Place, Promotion)</p>
+      <p id="tr5b" class="ja-translation">既知のフレームワークで切る。<br>例：3C（顧客・競合・自社）、4P（製品・価格・流通・販促）</p>
+
+      <p style="margin-top: 18px;">Pick whichever pattern gives the clearest, least-overlapping cut for your problem.</p>
+      <p id="tr6" class="ja-translation">問題に対して最も明確で、重複の少ない切り口を選ぼう。</p>
+    </div>
+
+    <!-- Phrases panel -->
+    <div id="phrasesPanel" class="phrases" role="region" aria-label="Key phrases">
+      <div class="phrases-header">
+        <span class="phrases-title">📖 重要フレーズ</span>
+        <span class="phrases-hint">保存ボタンで自動的にフラッシュカードに追加されます</span>
+      </div>
+      <ul class="phrases-list" id="phrasesList">
+        <!-- populated by JS -->
+      </ul>
+    </div>
+
+    <button class="next-btn">次へ</button>
+  </div>
+</div>
+
+<div id="toast" class="toast">フラッシュカードに追加しました</div>
+
+<script>
+  const phrases = [
+    { en: 'break things down', ja: '物事を分解する', note: 'break A down または break down A。MECE分解の文脈で頻出。' },
+    { en: 'component breakdown', ja: '要素分解', note: '数式のように分解する手法。' },
+    { en: 'time sequence', ja: '時系列' },
+    { en: 'opposing concepts', ja: '対立概念' },
+    { en: 'established framework', ja: '既存フレームワーク', note: 'establish = 確立する、established = 確立された。' },
+    { en: 'whichever ... gives', ja: '〜を提供するものはどれでも', note: '関係詞 whichever。"pick whichever pattern gives the clearest cut"' },
+  ]
+
+  const saved = new Set()
+
+  // Render phrases list
+  const list = document.getElementById('phrasesList')
+  list.innerHTML = phrases.map((p, i) => `
+    <li class="phrase">
+      <div class="phrase-main">
+        <p class="phrase-en">${p.en}</p>
+        <p class="phrase-ja">${p.ja}</p>
+        ${p.note ? `<p class="phrase-note">${p.note}</p>` : ''}
+      </div>
+      <button class="phrase-save" data-idx="${i}">カードに保存</button>
+    </li>
+  `).join('')
+
+  // Toast
+  const toast = document.getElementById('toast')
+  let toastTimer = null
+  function showToast(msg) {
+    toast.textContent = msg
+    toast.classList.add('show')
+    clearTimeout(toastTimer)
+    toastTimer = setTimeout(() => toast.classList.remove('show'), 1800)
+  }
+
+  // Save phrase
+  list.addEventListener('click', (e) => {
+    const btn = e.target.closest('.phrase-save')
+    if (!btn || btn.classList.contains('saved')) return
+    const idx = +btn.dataset.idx
+    saved.add(idx)
+    btn.classList.add('saved')
+    btn.textContent = '保存済み ✓'
+    showToast(`「${phrases[idx].en}」をフラッシュカードに追加しました`)
+  })
+
+  // Translation toggle
+  const btnTr = document.getElementById('btnTranslation')
+  const btnTrLabel = document.getElementById('btnTranslationLabel')
+  btnTr.addEventListener('click', () => {
+    const on = !btnTr.classList.contains('active')
+    btnTr.classList.toggle('active', on)
+    btnTr.setAttribute('aria-pressed', String(on))
+    btnTrLabel.textContent = on ? 'Hide Japanese' : 'Show Japanese'
+    document.querySelectorAll('.ja-translation').forEach(el => el.classList.toggle('show', on))
+  })
+
+  // Phrases toggle
+  const btnPh = document.getElementById('btnPhrases')
+  const btnPhLabel = document.getElementById('btnPhrasesLabel')
+  const phrasesPanel = document.getElementById('phrasesPanel')
+  btnPh.addEventListener('click', () => {
+    const on = !btnPh.classList.contains('active')
+    btnPh.classList.toggle('active', on)
+    btnPh.setAttribute('aria-pressed', String(on))
+    btnPhLabel.textContent = on ? 'Hide phrases' : 'Study phrases'
+    phrasesPanel.classList.toggle('show', on)
+    if (on) phrasesPanel.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  })
+</script>
+</body>
+</html>

--- a/public/preview/english-paywall.html
+++ b/public/preview/english-paywall.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<title>非プレミアム時の見え方 — Logic Preview</title>
+<link rel="stylesheet" href="_shared.css">
+<style>
+  .lesson-progress { height: 4px; background: var(--bg-tertiary); }
+  .lesson-progress-fill { height: 100%; width: 25%; background: linear-gradient(90deg, var(--accent), var(--accent-dark)); border-radius: 0 2px 2px 0; }
+
+  /* ============ Locked toolbar (non-premium) ============ */
+  .en-toolbar {
+    display: flex; flex-wrap: wrap; gap: 8px;
+    padding: 14px 20px 0;
+    align-items: center;
+  }
+  .en-toolbar-btn-locked {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 8px 14px;
+    border: 1px dashed rgba(176,116,66,0.4);
+    border-radius: 999px;
+    background: rgba(212,145,90,0.06);
+    color: var(--accent-dark);
+    font-size: 13px; font-family: inherit;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    position: relative;
+  }
+  .en-toolbar-btn-locked:hover {
+    background: rgba(212,145,90,0.12);
+    border-style: solid;
+  }
+  .en-toolbar-badge {
+    font-size: 9px; font-weight: 900;
+    padding: 2px 6px; border-radius: 999px;
+    background: linear-gradient(135deg, #C9A94A 0%, #B07442 100%);
+    color: #fff; letter-spacing: 0.5px;
+    margin-left: 6px;
+  }
+  .lock-icon { font-size: 11px; opacity: 0.7; }
+
+  .lesson-content { padding: 20px 20px 100px; }
+  .explain-title {
+    font-size: 22px; font-weight: 800;
+    line-height: 1.5; color: var(--text-primary);
+    margin-bottom: 12px;
+  }
+  .explain-body {
+    font-size: 15px; line-height: 1.85;
+    color: var(--text-primary);
+  }
+  .explain-body p { margin: 6px 0; }
+  .explain-body .label {
+    font-weight: 800;
+    color: var(--accent-text);
+    margin-top: 16px;
+  }
+
+  /* ============ Paywall sheet ============ */
+  .sheet-backdrop {
+    position: fixed; inset: 0;
+    background: rgba(45, 40, 32, 0.55);
+    z-index: 200;
+    display: none;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+  }
+  .sheet-backdrop.show { display: block; animation: fade 0.25s ease-out; }
+  @keyframes fade { from { opacity: 0; } to { opacity: 1; } }
+
+  .sheet {
+    position: fixed;
+    bottom: 0; left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    max-width: 480px;
+    background: var(--bg-card);
+    border-radius: 24px 24px 0 0;
+    z-index: 201;
+    padding: 28px 24px env(safe-area-inset-bottom);
+    box-shadow: 0 -12px 40px rgba(0,0,0,0.18);
+    transform: translateX(-50%) translateY(100%);
+    transition: transform 0.32s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+  .sheet.show { transform: translateX(-50%) translateY(0); }
+  .sheet-handle {
+    width: 36px; height: 4px;
+    background: var(--bg-tertiary);
+    border-radius: 4px;
+    margin: -12px auto 16px;
+  }
+
+  .sheet-icon {
+    width: 64px; height: 64px;
+    background: linear-gradient(135deg, #C9A94A, #B07442);
+    border-radius: 18px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 32px;
+    margin: 8px auto 16px;
+    box-shadow: 0 8px 24px rgba(176,116,66,0.30);
+  }
+  .sheet h2 {
+    font-size: 22px; font-weight: 800;
+    text-align: center;
+    margin-bottom: 6px;
+    line-height: 1.4;
+  }
+  .sheet-desc {
+    font-size: 13px; color: var(--text-secondary);
+    text-align: center;
+    line-height: 1.7;
+    margin-bottom: 20px;
+  }
+  .feature-list {
+    list-style: none;
+    padding: 14px;
+    background: var(--bg-secondary);
+    border-radius: 14px;
+    margin-bottom: 18px;
+  }
+  .feature-list li {
+    display: flex; align-items: flex-start;
+    gap: 10px;
+    font-size: 13px;
+    line-height: 1.6;
+    padding: 6px 0;
+  }
+  .feature-list li::before {
+    content: '✓';
+    color: var(--accent-dark);
+    font-weight: 800;
+    flex-shrink: 0;
+  }
+  .feature-list li b { font-weight: 700; }
+
+  .plan-row {
+    display: grid; grid-template-columns: 1fr 1fr;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+  .plan {
+    border: 1.5px solid var(--border);
+    border-radius: 14px;
+    padding: 16px 14px;
+    background: var(--bg-card);
+    cursor: pointer;
+    text-align: center;
+    position: relative;
+  }
+  .plan.recommended {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+  }
+  .plan-recommended-tag {
+    position: absolute; top: -10px; left: 50%;
+    transform: translateX(-50%);
+    background: var(--accent);
+    color: #fff;
+    font-size: 9px; font-weight: 800;
+    padding: 3px 10px;
+    border-radius: 999px;
+    letter-spacing: 0.4px;
+  }
+  .plan-name {
+    font-size: 12px; font-weight: 700;
+    color: var(--text-secondary);
+  }
+  .plan-price {
+    font-size: 22px; font-weight: 800;
+    color: var(--text-primary);
+    margin: 4px 0 2px;
+  }
+  .plan-period { font-size: 11px; color: var(--text-muted); }
+  .plan-note { font-size: 10px; color: var(--accent-dark); font-weight: 700; margin-top: 4px; }
+
+  .upgrade-btn {
+    width: 100%;
+    padding: 16px;
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    border-radius: 14px;
+    font-size: 15px; font-weight: 800;
+    cursor: pointer; font-family: inherit;
+    box-shadow: 0 4px 16px rgba(212,145,90,0.30);
+    margin-bottom: 8px;
+  }
+  .sheet-close {
+    width: 100%; padding: 12px;
+    background: none; border: none;
+    color: var(--text-muted);
+    font-size: 13px; cursor: pointer;
+    font-family: inherit;
+  }
+
+  /* Demo banner */
+  .demo-banner {
+    background: rgba(196,69,69,0.08);
+    border: 1px solid rgba(196,69,69,0.3);
+    color: #6b3030;
+    padding: 12px 16px;
+    border-radius: 12px;
+    font-size: 12px;
+    line-height: 1.7;
+    margin: 12px 20px 0;
+  }
+  .demo-banner b { color: #4a1818; }
+</style>
+</head>
+<body>
+<div class="preview-note">📱 Free / Standard プランの場合の見え方（プレミアム未加入）</div>
+<div class="app">
+  <header class="header">
+    <button class="header-back">‹</button>
+    <span class="header-title">MECE — Logical Thinking</span>
+    <span style="font-size: 11px; font-weight: 700; color: var(--text-muted); letter-spacing: 1.4px;">1/12</span>
+  </header>
+  <div class="lesson-progress"><div class="lesson-progress-fill"></div></div>
+
+  <div class="demo-banner">
+    🔒 <b>非プレミアム時の挙動:</b> ボタンは <i>ロックアイコン付き</i> で表示され、タップするとアップグレード画面（下のシート）が出ます。レッスン本体は通常通り英語で受講可能。
+  </div>
+
+  <!-- Locked toolbar -->
+  <div class="en-toolbar" role="toolbar">
+    <button id="btn1" type="button" class="en-toolbar-btn-locked">
+      <span class="lock-icon">🔒</span>
+      <span aria-hidden="true">あ</span>
+      <span>Show Japanese</span>
+      <span class="en-toolbar-badge">Premium</span>
+    </button>
+    <button id="btn2" type="button" class="en-toolbar-btn-locked">
+      <span class="lock-icon">🔒</span>
+      <span aria-hidden="true">📖</span>
+      <span>Study phrases</span>
+      <span class="en-toolbar-badge">Premium</span>
+    </button>
+  </div>
+
+  <div class="lesson-content">
+    <h2 class="explain-title">What is MECE?</h2>
+    <div class="explain-body">
+      <p>MECE (pronounced "mee-see") stands for "Mutually Exclusive, Collectively Exhaustive." It is the most fundamental framework for analyzing and organizing information in business.</p>
+      <p class="label">■ Mutually Exclusive</p>
+      <p>No overlap between categories. The same item never appears in more than one bucket.</p>
+      <p class="label">■ Collectively Exhaustive</p>
+      <p>Everything is covered. No gaps, no missing pieces.</p>
+      <p style="margin-top: 16px;">Why MECE matters:</p>
+      <p>① Prevents blind spots → better decisions<br>② Eliminates duplication → efficient resource allocation<br>③ Clearer communication → team alignment</p>
+    </div>
+  </div>
+</div>
+
+<!-- Paywall sheet -->
+<div id="sheetBackdrop" class="sheet-backdrop"></div>
+<div id="sheet" class="sheet">
+  <div class="sheet-handle"></div>
+
+  <div class="sheet-icon">🇬🇧</div>
+  <h2>英語学習モードを<br>プレミアムで解放</h2>
+  <p class="sheet-desc">ロジカルシンキングを<b>英語で</b>学びながら、ビジネス英語フレーズも自動で身につく。</p>
+
+  <ul class="feature-list">
+    <li><b>日本語訳トグル</b> — 英文の下に和訳を瞬時に表示</li>
+    <li><b>フレーズ学習</b> — 重要表現をタップで意味＋文法注</li>
+    <li><b>自動フラッシュカード</b> — 保存したフレーズを SM-2 間隔反復で復習</li>
+    <li>+ プレミアム全機能（AI 問題生成・ロールプレイ無制限など）</li>
+  </ul>
+
+  <div class="plan-row">
+    <div class="plan">
+      <div class="plan-name">月額</div>
+      <div class="plan-price">¥760</div>
+      <div class="plan-period">/ 月</div>
+    </div>
+    <div class="plan recommended">
+      <span class="plan-recommended-tag">おすすめ</span>
+      <div class="plan-name">年額</div>
+      <div class="plan-price">¥5,320</div>
+      <div class="plan-period">/ 年</div>
+      <div class="plan-note">月あたり ¥443 (42% OFF)</div>
+    </div>
+  </div>
+
+  <button class="upgrade-btn">プレミアムにアップグレード →</button>
+  <button id="sheetCloseBtn" class="sheet-close">あとで決める</button>
+</div>
+
+<script>
+  const sheet = document.getElementById('sheet')
+  const backdrop = document.getElementById('sheetBackdrop')
+
+  function openSheet() {
+    backdrop.classList.add('show')
+    setTimeout(() => sheet.classList.add('show'), 10)
+  }
+  function closeSheet() {
+    sheet.classList.remove('show')
+    setTimeout(() => backdrop.classList.remove('show'), 320)
+  }
+
+  document.getElementById('btn1').addEventListener('click', openSheet)
+  document.getElementById('btn2').addEventListener('click', openSheet)
+  document.getElementById('sheetCloseBtn').addEventListener('click', closeSheet)
+  backdrop.addEventListener('click', closeSheet)
+</script>
+</body>
+</html>

--- a/public/preview/english-quiz.html
+++ b/public/preview/english-quiz.html
@@ -1,0 +1,382 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<title>英語学習モード (Quiz) — Logic Preview</title>
+<link rel="stylesheet" href="_shared.css">
+<style>
+  .lesson-progress { height: 4px; background: var(--bg-tertiary); }
+  .lesson-progress-fill { height: 100%; width: 33%; background: linear-gradient(90deg, var(--accent), var(--accent-dark)); border-radius: 0 2px 2px 0; }
+
+  .en-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 14px 20px 0;
+  }
+  .en-toolbar-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg-card);
+    color: var(--text-primary);
+    font-size: 13px;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+  .en-toolbar-btn.active {
+    background: var(--accent-soft);
+    border-color: var(--accent-dark);
+    color: var(--accent-dark);
+    font-weight: 700;
+  }
+  .en-toolbar-badge {
+    font-size: 9px;
+    font-weight: 900;
+    padding: 2px 6px;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #C9A94A 0%, #B07442 100%);
+    color: #fff;
+    letter-spacing: 0.5px;
+    margin-left: 6px;
+  }
+
+  .lesson-content { padding: 20px 20px 100px; }
+
+  .question-num { font-size: 11px; font-weight: 800; color: var(--accent-text); letter-spacing: 1.4px; }
+  .question-text {
+    font-size: 19px;
+    font-weight: 700;
+    line-height: 1.55;
+    color: var(--text-primary);
+    margin: 10px 0 8px;
+  }
+
+  .ja-translation {
+    border-left: 2px solid var(--accent);
+    padding: 8px 12px;
+    background: var(--bg-secondary);
+    border-radius: 4px;
+    color: var(--text-secondary);
+    font-size: 13px;
+    line-height: 1.7;
+    display: none;
+  }
+  .ja-translation.show { display: block; animation: fade-in 0.2s ease-out; }
+  .ja-translation-question { font-size: 13px; margin-bottom: 22px; }
+  .ja-translation-inline {
+    display: block;
+    border-left: none;
+    padding: 0;
+    margin: 4px 0 0 0;
+    background: transparent;
+    font-size: 12px;
+    color: var(--text-muted);
+    font-weight: 400;
+    line-height: 1.5;
+  }
+  .ja-translation-feedback {
+    margin-top: 10px;
+    font-size: 12px;
+  }
+  @keyframes fade-in {
+    from { opacity: 0; transform: translateY(-4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  .options { display: flex; flex-direction: column; gap: 10px; margin-top: 18px; }
+  .option {
+    background: var(--bg-card);
+    border: 1.5px solid var(--border);
+    border-radius: 12px;
+    padding: 16px 18px;
+    font-size: 14px;
+    color: var(--text-primary);
+    cursor: pointer;
+    text-align: left;
+    line-height: 1.5;
+    font-family: inherit;
+    display: flex; align-items: center; gap: 12px;
+    transition: all 0.15s ease-out;
+    width: 100%;
+  }
+  .option-letter {
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--bg-tertiary); color: var(--text-secondary);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 13px; font-weight: 800;
+    flex-shrink: 0;
+  }
+  .option-text { flex: 1; }
+  .option.selected {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+  }
+  .option.correct {
+    border-color: var(--success);
+    background: var(--success-soft);
+  }
+  .option.wrong {
+    border-color: var(--danger);
+    background: rgba(196,69,69,0.10);
+  }
+
+  .feedback {
+    margin-top: 16px;
+    padding: 14px 16px;
+    border-radius: 12px;
+    background: var(--success-soft);
+    border-left: 3px solid var(--success);
+    display: none;
+  }
+  .feedback.show { display: block; animation: fade-in 0.2s ease-out; }
+  .feedback-title {
+    font-size: 14px;
+    font-weight: 800;
+    color: var(--success);
+    margin-bottom: 6px;
+  }
+  .feedback-text {
+    font-size: 13px;
+    line-height: 1.7;
+    color: var(--text-primary);
+  }
+
+  /* Phrases panel */
+  .phrases {
+    margin-top: 16px;
+    padding: 16px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    display: none;
+  }
+  .phrases.show { display: block; animation: fade-in 0.2s ease-out; }
+  .phrases-header { display: flex; flex-direction: column; gap: 4px; margin-bottom: 12px; }
+  .phrases-title { font-size: 15px; font-weight: 800; color: var(--text-primary); }
+  .phrases-hint { font-size: 11px; color: var(--text-muted); }
+  .phrases-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+  .phrase {
+    display: flex; align-items: flex-start; gap: 12px;
+    padding: 12px 14px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+  }
+  .phrase-main { flex: 1; min-width: 0; }
+  .phrase-en { font-size: 14px; font-weight: 700; color: var(--text-primary); margin: 0 0 2px 0; }
+  .phrase-ja { font-size: 13px; color: var(--text-secondary); margin: 0; }
+  .phrase-note { font-size: 11px; color: var(--text-muted); margin: 4px 0 0 0; font-style: italic; line-height: 1.6; }
+  .phrase-save {
+    flex-shrink: 0;
+    padding: 7px 13px;
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 800;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  .phrase-save.saved {
+    background: var(--bg-tertiary);
+    color: var(--text-muted);
+    cursor: default;
+  }
+
+  .demo-banner {
+    background: linear-gradient(135deg, rgba(201,169,74,0.15), rgba(176,116,66,0.15));
+    border: 1px solid rgba(201,169,74,0.4);
+    color: #6b5526;
+    padding: 12px 16px;
+    border-radius: 12px;
+    font-size: 12px;
+    line-height: 1.7;
+    margin: 0 20px 12px;
+  }
+  .demo-banner b { color: #4a3a18; }
+
+  .toast {
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%) translateY(20px);
+    background: var(--text-primary);
+    color: var(--bg-card);
+    padding: 12px 20px;
+    border-radius: 999px;
+    font-size: 13px;
+    font-weight: 700;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.2);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    z-index: 100;
+  }
+  .toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+</style>
+</head>
+<body>
+<div class="preview-note">📱 Premium feature: 英語学習モード（Quiz: 選択肢のオプション単位で和訳）</div>
+<div class="app">
+  <header class="header">
+    <button class="header-back">‹</button>
+    <span class="header-title">MECE — Logical Thinking</span>
+    <span style="font-size: 11px; font-weight: 700; color: var(--text-muted); letter-spacing: 1.4px;">4/12</span>
+  </header>
+  <div class="lesson-progress"><div class="lesson-progress-fill"></div></div>
+
+  <div class="demo-banner">
+    👆 <b>このモックアップは操作できます</b>。「日本語訳」を有効にすると、設問・選択肢・解説すべてに和訳が出ます。回答もしてみてください。
+  </div>
+
+  <div class="en-toolbar" role="toolbar">
+    <button id="btnTranslation" type="button" class="en-toolbar-btn">
+      <span aria-hidden="true">あ</span>
+      <span id="btnTranslationLabel">Show Japanese</span>
+      <span class="en-toolbar-badge">Premium</span>
+    </button>
+    <button id="btnPhrases" type="button" class="en-toolbar-btn">
+      <span aria-hidden="true">📖</span>
+      <span id="btnPhrasesLabel">Study phrases</span>
+      <span class="en-toolbar-badge">Premium</span>
+    </button>
+  </div>
+
+  <div class="lesson-content">
+    <div class="question-num">QUIZ</div>
+    <h2 class="question-text">When applying 3C MECE to a sales decline, which bucket fits "competitor lowered prices, so customers left us"?</h2>
+    <p id="trQ" class="ja-translation ja-translation-question">売上減少に3C MECEを当てはめるとき、「競合が値下げしたので顧客が離れた」はどのバケツに入る？</p>
+
+    <div class="options" id="options">
+      <button class="option" data-correct="false">
+        <span class="option-letter">A</span>
+        <span class="option-text">
+          Customer
+          <span class="ja-translation ja-translation-inline">Customer（顧客）</span>
+        </span>
+      </button>
+      <button class="option" data-correct="true">
+        <span class="option-letter">B</span>
+        <span class="option-text">
+          Competitor
+          <span class="ja-translation ja-translation-inline">Competitor（競合）</span>
+        </span>
+      </button>
+      <button class="option" data-correct="false">
+        <span class="option-letter">C</span>
+        <span class="option-text">
+          Company
+          <span class="ja-translation ja-translation-inline">Company（自社）</span>
+        </span>
+      </button>
+      <button class="option" data-correct="false">
+        <span class="option-letter">D</span>
+        <span class="option-text">
+          All three at once
+          <span class="ja-translation ja-translation-inline">3つすべて</span>
+        </span>
+      </button>
+    </div>
+
+    <div id="feedback" class="feedback">
+      <div class="feedback-title">正解！</div>
+      <p class="feedback-text">Classify by the root cause, not the visible effect. The trigger here is the competitor's pricing move, so it goes in Competitor.</p>
+      <p id="feedbackJa" class="ja-translation ja-translation-feedback">見えている結果ではなく、根本の原因で分類する。引き金は競合の価格戦略なので Competitor に入る。</p>
+    </div>
+
+    <div id="phrasesPanel" class="phrases" role="region">
+      <div class="phrases-header">
+        <span class="phrases-title">📖 重要フレーズ</span>
+        <span class="phrases-hint">保存ボタンで自動的にフラッシュカードに追加されます</span>
+      </div>
+      <ul class="phrases-list" id="phrasesList"></ul>
+    </div>
+  </div>
+</div>
+
+<div id="toast" class="toast">フラッシュカードに追加しました</div>
+
+<script>
+  const phrases = [
+    { en: 'fits in', ja: '〜に当てはまる', note: '"which bucket fits ..."（どのバケツが当てはまるか）' },
+    { en: 'visible effect', ja: '目に見える結果', note: 'visible = 目に見える' },
+    { en: 'violates the rule', ja: 'ルールに違反する' },
+  ]
+  const saved = new Set()
+  const list = document.getElementById('phrasesList')
+  list.innerHTML = phrases.map((p, i) => `
+    <li class="phrase">
+      <div class="phrase-main">
+        <p class="phrase-en">${p.en}</p>
+        <p class="phrase-ja">${p.ja}</p>
+        ${p.note ? `<p class="phrase-note">${p.note}</p>` : ''}
+      </div>
+      <button class="phrase-save" data-idx="${i}">カードに保存</button>
+    </li>
+  `).join('')
+
+  const toast = document.getElementById('toast')
+  let toastTimer = null
+  function showToast(msg) {
+    toast.textContent = msg
+    toast.classList.add('show')
+    clearTimeout(toastTimer)
+    toastTimer = setTimeout(() => toast.classList.remove('show'), 1800)
+  }
+
+  list.addEventListener('click', (e) => {
+    const btn = e.target.closest('.phrase-save')
+    if (!btn || btn.classList.contains('saved')) return
+    saved.add(+btn.dataset.idx)
+    btn.classList.add('saved')
+    btn.textContent = '保存済み ✓'
+    showToast(`「${phrases[+btn.dataset.idx].en}」をフラッシュカードに追加しました`)
+  })
+
+  // Quiz answer
+  let answered = false
+  document.getElementById('options').addEventListener('click', (e) => {
+    const opt = e.target.closest('.option')
+    if (!opt || answered) return
+    answered = true
+    const correct = opt.dataset.correct === 'true'
+    document.querySelectorAll('.option').forEach(o => {
+      if (o.dataset.correct === 'true') o.classList.add('correct')
+    })
+    if (!correct) opt.classList.add('wrong')
+    document.getElementById('feedback').classList.add('show')
+    if (document.getElementById('btnTranslation').classList.contains('active')) {
+      document.getElementById('feedbackJa').classList.add('show')
+    }
+  })
+
+  // Toggles
+  const btnTr = document.getElementById('btnTranslation')
+  const btnTrLabel = document.getElementById('btnTranslationLabel')
+  btnTr.addEventListener('click', () => {
+    const on = !btnTr.classList.contains('active')
+    btnTr.classList.toggle('active', on)
+    btnTrLabel.textContent = on ? 'Hide Japanese' : 'Show Japanese'
+    document.querySelectorAll('.ja-translation').forEach(el => el.classList.toggle('show', on))
+  })
+
+  const btnPh = document.getElementById('btnPhrases')
+  const btnPhLabel = document.getElementById('btnPhrasesLabel')
+  const phrasesPanel = document.getElementById('phrasesPanel')
+  btnPh.addEventListener('click', () => {
+    const on = !btnPh.classList.contains('active')
+    btnPh.classList.toggle('active', on)
+    btnPhLabel.textContent = on ? 'Hide phrases' : 'Study phrases'
+    phrasesPanel.classList.toggle('show', on)
+    if (on) phrasesPanel.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  })
+</script>
+</body>
+</html>

--- a/public/preview/index.html
+++ b/public/preview/index.html
@@ -109,20 +109,49 @@
 
   <h2>英語学習モード（PR #125）</h2>
 
-  <a href="english-lesson.html" class="card">
+  <a href="english-lesson-flow.html" class="card" style="border-color: #C9A94A; background: linear-gradient(135deg, #FFFCF0 0%, #FFF8E0 100%);">
     <span class="card-emoji">🇬🇧</span>
     <div class="card-body">
-      <div class="card-title">英語レッスン (Explain) <span class="badge">Premium</span></div>
-      <div class="card-desc">日本語訳トグル + フレーズ学習 + 自動フラッシュカード</div>
+      <div class="card-title">フル体験版 (4ステップ) <span class="badge" style="background: #C9A94A;">推奨</span></div>
+      <div class="card-desc">インラインフレーズ <u>タップで翻訳</u> + 4ステップ進行 + 完了画面</div>
+    </div>
+    <span class="card-arrow">›</span>
+  </a>
+
+  <a href="english-flashcards.html" class="card">
+    <span class="card-emoji">🗂️</span>
+    <div class="card-body">
+      <div class="card-title">保存済みフレーズの復習</div>
+      <div class="card-desc">SM-2 間隔反復で英語フレーズを定着 (Flashcards 統合)</div>
+    </div>
+    <span class="card-arrow">›</span>
+  </a>
+
+  <a href="english-paywall.html" class="card">
+    <span class="card-emoji">🔒</span>
+    <div class="card-body">
+      <div class="card-title">非プレミアム時の見え方</div>
+      <div class="card-desc">ロックバッジ + アップグレードシート</div>
+    </div>
+    <span class="card-arrow">›</span>
+  </a>
+
+  <h3 style="font-size: 11px; color: #9B8E7E; margin: 16px 0 6px; letter-spacing: 0.4px; text-transform: uppercase;">単一画面（参考）</h3>
+
+  <a href="english-lesson.html" class="card">
+    <span class="card-emoji">📝</span>
+    <div class="card-body">
+      <div class="card-title">英語レッスン (単一 explain)</div>
+      <div class="card-desc">日本語訳トグル + フレーズパネルのみ</div>
     </div>
     <span class="card-arrow">›</span>
   </a>
 
   <a href="english-quiz.html" class="card">
-    <span class="card-emoji">📚</span>
+    <span class="card-emoji">❓</span>
     <div class="card-body">
-      <div class="card-title">英語クイズ <span class="badge">Premium</span></div>
-      <div class="card-desc">設問・選択肢・解説それぞれに和訳が出る</div>
+      <div class="card-title">英語クイズ (単一 quiz)</div>
+      <div class="card-desc">設問・選択肢・解説それぞれに和訳</div>
     </div>
     <span class="card-arrow">›</span>
   </a>

--- a/public/preview/index.html
+++ b/public/preview/index.html
@@ -107,6 +107,26 @@
     <span class="card-arrow">›</span>
   </a>
 
+  <h2>英語学習モード（PR #125）</h2>
+
+  <a href="english-lesson.html" class="card">
+    <span class="card-emoji">🇬🇧</span>
+    <div class="card-body">
+      <div class="card-title">英語レッスン (Explain) <span class="badge">Premium</span></div>
+      <div class="card-desc">日本語訳トグル + フレーズ学習 + 自動フラッシュカード</div>
+    </div>
+    <span class="card-arrow">›</span>
+  </a>
+
+  <a href="english-quiz.html" class="card">
+    <span class="card-emoji">📚</span>
+    <div class="card-body">
+      <div class="card-title">英語クイズ <span class="badge">Premium</span></div>
+      <div class="card-desc">設問・選択肢・解説それぞれに和訳が出る</div>
+    </div>
+    <span class="card-arrow">›</span>
+  </a>
+
   <h2>比較</h2>
 
   <a href="home-current.html" class="card" style="border-color: #C44545; background: #FEF2F2;">

--- a/src/Lesson.css
+++ b/src/Lesson.css
@@ -506,3 +506,192 @@
     font-size: 3.2rem;
   }
 }
+
+/* ===== English-learning helpers (premium + en locale) ===== */
+.ls-en-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 20px 0;
+}
+
+.ls-en-toolbar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  font-family: var(--sans);
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.ls-en-toolbar-btn:hover { border-color: var(--accent-dark); }
+
+.ls-en-toolbar-btn.active {
+  background: var(--accent-soft);
+  border-color: var(--accent-dark);
+  color: var(--accent-dark);
+  font-weight: 600;
+}
+
+.ls-en-translation {
+  color: var(--text-secondary);
+  font-family: var(--sans);
+  border-left: 2px solid var(--accent);
+  padding-left: 12px;
+  background: var(--bg-secondary);
+  border-radius: 4px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-right: 12px;
+}
+
+.ls-en-translation-title {
+  margin-top: 6px;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.ls-en-translation-body {
+  margin-top: 14px;
+}
+.ls-en-translation-body p {
+  font-size: 0.85rem;
+  line-height: 1.8;
+  margin: 0 0 4px 0;
+}
+
+.ls-en-translation-feedback {
+  margin-top: 10px;
+  font-size: 0.8rem;
+  line-height: 1.7;
+}
+
+.ls-option-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+
+.ls-en-translation-inline {
+  display: block;
+  border-left: none;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
+/* Phrase panel */
+.ls-en-phrases {
+  margin-top: 20px;
+  margin-bottom: 16px;
+  padding: 16px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.ls-en-phrases-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.ls-en-phrases-title {
+  font-family: var(--serif);
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.ls-en-phrases-hint {
+  font-size: 0.7333rem;
+  color: var(--text-muted);
+}
+
+.ls-en-phrases-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ls-en-phrase {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 10px 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 8px);
+}
+
+.ls-en-phrase-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.ls-en-phrase-en {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 2px 0;
+}
+
+.ls-en-phrase-ja {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.ls-en-phrase-note {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin: 4px 0 0 0;
+  font-style: italic;
+}
+
+.ls-en-phrase-save {
+  flex-shrink: 0;
+  padding: 6px 12px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  font-size: 0.7333rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.ls-en-phrase-save:hover:not(:disabled) {
+  background: var(--accent-dark);
+}
+
+.ls-en-phrase-save.saved,
+.ls-en-phrase-save:disabled {
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  cursor: default;
+}
+
+@media (min-width: 768px) {
+  .ls-en-phrase {
+    align-items: center;
+  }
+  .ls-en-phrase-en {
+    font-size: 1.05rem;
+  }
+}

--- a/src/Lesson.tsx
+++ b/src/Lesson.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, type ComponentType } from 'react'
+import { useState, useRef, useMemo, type ComponentType } from 'react'
 import {
   TAccountDiagram,
   AccountGroupsDiagram,
@@ -27,7 +27,9 @@ import {
 import type { LessonData, LessonStep } from './lessonData'
 import { generateFromLesson, addCards } from './flashcardData'
 import ReportProblem from './ReportProblem'
-import { t, localeBody } from './i18n'
+import { t, localeBody, getLocale } from './i18n'
+import { getStepAnnotation, hasAnyAnnotation, savePhraseToFlashcards, type Phrase } from './englishLearningData'
+import { isPremium } from './subscription'
 import './Lesson.css'
 
 import { API_BASE } from './apiBase'
@@ -92,11 +94,31 @@ export default function Lesson({ lesson, onBack, onComplete, onNextLesson }: Pro
   const [correctCount, setCorrectCount] = useState(0)
   const [finished, setFinished] = useState(false)
   const [showReport, setShowReport] = useState(false)
+  const [showTranslation, setShowTranslation] = useState(false)
+  const [showPhrases, setShowPhrases] = useState(false)
+  const [savedPhrases, setSavedPhrases] = useState<Set<string>>(new Set())
   const wrongAnswersRef = useRef<{ question: string; correctAnswer: string; explanation: string }[]>([])
 
   const step: LessonStep | undefined = lesson.steps[currentStep]
   const totalSteps = lesson.steps.length
   const progress = ((currentStep + (showResult || step?.type === 'explain' ? 1 : 0)) / totalSteps) * 100
+
+  // English learning mode: premium users on English locale see translation/phrase helpers
+  // when annotations exist for this lesson.
+  const englishMode = useMemo(
+    () => getLocale() === 'en' && isPremium() && hasAnyAnnotation(lesson.id),
+    [lesson.id],
+  )
+  const stepAnnotation = englishMode ? getStepAnnotation(lesson.id, currentStep) : undefined
+  const hasTranslation =
+    !!stepAnnotation &&
+    !!(stepAnnotation.titleJa || stepAnnotation.contentJa || stepAnnotation.questionJa || stepAnnotation.explanationJa || (stepAnnotation.optionsJa && stepAnnotation.optionsJa.length > 0))
+  const hasPhrases = !!stepAnnotation?.phrases && stepAnnotation.phrases.length > 0
+
+  const handleSavePhrase = (phrase: Phrase) => {
+    savePhraseToFlashcards(phrase, lesson.id, lesson.title)
+    setSavedPhrases((prev) => new Set(prev).add(phrase.en))
+  }
 
   const handleAnswer = (index: number) => {
     if (showResult) return
@@ -133,6 +155,8 @@ export default function Lesson({ lesson, onBack, onComplete, onNextLesson }: Pro
       setCurrentStep((s) => s + 1)
       setSelectedOption(null)
       setShowResult(false)
+      setShowTranslation(false)
+      setShowPhrases(false)
     }
   }
 
@@ -213,22 +237,67 @@ export default function Lesson({ lesson, onBack, onComplete, onNextLesson }: Pro
         <div className="ls-progress-fill" style={{ width: `${progress}%` }} />
       </div>
 
+      {/* English-learning toolbar (premium + en locale + annotations available) */}
+      {englishMode && (hasTranslation || hasPhrases) && (
+        <div className="ls-en-toolbar" role="toolbar" aria-label={t('englishLearning.toolbarLabel')}>
+          {hasTranslation && (
+            <button
+              type="button"
+              className={`ls-en-toolbar-btn${showTranslation ? ' active' : ''}`}
+              onClick={() => setShowTranslation((v) => !v)}
+              aria-pressed={showTranslation}
+            >
+              <span aria-hidden="true">あ</span>
+              {showTranslation ? t('englishLearning.hideTranslation') : t('englishLearning.showTranslation')}
+            </button>
+          )}
+          {hasPhrases && (
+            <button
+              type="button"
+              className={`ls-en-toolbar-btn${showPhrases ? ' active' : ''}`}
+              onClick={() => setShowPhrases((v) => !v)}
+              aria-pressed={showPhrases}
+            >
+              <span aria-hidden="true">📖</span>
+              {showPhrases ? t('englishLearning.hidePhrases') : t('englishLearning.showPhrases')}
+            </button>
+          )}
+        </div>
+      )}
+
       {/* Content */}
       <div className="ls-content">
         {step.type === 'explain' ? (
           <div className="ls-explain">
             <div className="ls-explain-header">
               <h3>{step.title}</h3>
+              {showTranslation && stepAnnotation?.titleJa && (
+                <p className="ls-en-translation ls-en-translation-title">{stepAnnotation.titleJa}</p>
+              )}
             </div>
             <div className="ls-explain-body">
               {step.content.split('\n').map((line, i) => (
                 <p key={i}>{line || '\u00A0'}</p>
               ))}
+              {showTranslation && stepAnnotation?.contentJa && (
+                <div className="ls-en-translation ls-en-translation-body">
+                  {stepAnnotation.contentJa.split('\n').map((line, i) => (
+                    <p key={i}>{line || '\u00A0'}</p>
+                  ))}
+                </div>
+              )}
               {step.visual && diagramMap[step.visual] && (() => {
                 const Diagram = diagramMap[step.visual!]
                 return <Diagram />
               })()}
             </div>
+            {showPhrases && stepAnnotation?.phrases && (
+              <PhrasePanel
+                phrases={stepAnnotation.phrases}
+                savedPhrases={savedPhrases}
+                onSave={handleSavePhrase}
+              />
+            )}
             <button className="ls-next-btn" onClick={handleNext}>
               {t('lesson.next')}
             </button>
@@ -238,6 +307,9 @@ export default function Lesson({ lesson, onBack, onComplete, onNextLesson }: Pro
             <div className="ls-quiz-header">
               <h3>{step.question}</h3>
             </div>
+            {showTranslation && stepAnnotation?.questionJa && (
+              <p className="ls-en-translation ls-en-translation-title">{stepAnnotation.questionJa}</p>
+            )}
             <div className="ls-options">
               {step.options.map((opt, i) => {
                 let cls = 'ls-option'
@@ -256,7 +328,14 @@ export default function Lesson({ lesson, onBack, onComplete, onNextLesson }: Pro
                     <span className="ls-option-label">
                       {['A', 'B', 'C', 'D'][i]}
                     </span>
-                    {opt.label}
+                    <span className="ls-option-text">
+                      {opt.label}
+                      {showTranslation && stepAnnotation?.optionsJa?.[i] && (
+                        <span className="ls-en-translation ls-en-translation-inline">
+                          {stepAnnotation.optionsJa[i]}
+                        </span>
+                      )}
+                    </span>
                   </button>
                 )
               })}
@@ -275,7 +354,17 @@ export default function Lesson({ lesson, onBack, onComplete, onNextLesson }: Pro
                   </p>
                 </div>
                 <p className="ls-feedback-text">{step.explanation}</p>
+                {showTranslation && stepAnnotation?.explanationJa && (
+                  <p className="ls-en-translation ls-en-translation-feedback">{stepAnnotation.explanationJa}</p>
+                )}
               </div>
+            )}
+            {showPhrases && stepAnnotation?.phrases && (
+              <PhrasePanel
+                phrases={stepAnnotation.phrases}
+                savedPhrases={savedPhrases}
+                onSave={handleSavePhrase}
+              />
             )}
             {showResult && (
               <button className="ls-next-btn" onClick={handleNext}>
@@ -297,6 +386,46 @@ export default function Lesson({ lesson, onBack, onComplete, onNextLesson }: Pro
           onClose={() => setShowReport(false)}
         />
       )}
+    </div>
+  )
+}
+
+type PhrasePanelProps = {
+  phrases: Phrase[]
+  savedPhrases: Set<string>
+  onSave: (phrase: Phrase) => void
+}
+
+function PhrasePanel({ phrases, savedPhrases, onSave }: PhrasePanelProps) {
+  return (
+    <div className="ls-en-phrases" role="region" aria-label={t('englishLearning.phrasesLabel')}>
+      <div className="ls-en-phrases-header">
+        <span className="ls-en-phrases-title">{t('englishLearning.phrasesTitle')}</span>
+        <span className="ls-en-phrases-hint">{t('englishLearning.phrasesHint')}</span>
+      </div>
+      <ul className="ls-en-phrases-list">
+        {phrases.map((p) => {
+          const saved = savedPhrases.has(p.en)
+          return (
+            <li key={p.en} className="ls-en-phrase">
+              <div className="ls-en-phrase-main">
+                <p className="ls-en-phrase-en">{p.en}</p>
+                <p className="ls-en-phrase-ja">{p.ja}</p>
+                {p.note && <p className="ls-en-phrase-note">{p.note}</p>}
+              </div>
+              <button
+                type="button"
+                className={`ls-en-phrase-save${saved ? ' saved' : ''}`}
+                onClick={() => onSave(p)}
+                disabled={saved}
+                aria-label={saved ? t('englishLearning.phraseSaved') : t('englishLearning.savePhrase')}
+              >
+                {saved ? t('englishLearning.phraseSaved') : t('englishLearning.savePhrase')}
+              </button>
+            </li>
+          )
+        })}
+      </ul>
     </div>
   )
 }

--- a/src/englishLearningData.ts
+++ b/src/englishLearningData.ts
@@ -1,0 +1,241 @@
+// English learning annotations for lesson content.
+// When premium users switch to English locale, lessons show optional
+// Japanese translations and phrase-by-phrase explanations. Phrases the
+// learner studies are auto-added to their flashcard deck.
+//
+// Annotations are indexed by lessonId, then by the step index inside
+// `lesson.steps`. A lesson without annotations gracefully degrades —
+// the translation/phrase buttons simply don't appear.
+
+import { addCards } from './flashcardData'
+
+export type Phrase = {
+  en: string
+  ja: string
+  note?: string
+}
+
+export type StepAnnotation = {
+  titleJa?: string
+  contentJa?: string
+  questionJa?: string
+  optionsJa?: string[]
+  explanationJa?: string
+  phrases?: Phrase[]
+}
+
+export type LessonAnnotations = {
+  steps: StepAnnotation[]
+}
+
+// MECE (lesson 20) — full annotation as the flagship example.
+const mece: LessonAnnotations = {
+  steps: [
+    // Step 0: "What is MECE?"
+    {
+      titleJa: 'MECE（ミーシー）とは？',
+      contentJa:
+        'MECE（「ミーシー」と発音）は "Mutually Exclusive, Collectively Exhaustive"（モレなく、ダブりなく）の略です。ビジネスで情報を分析・整理する最も基本的なフレームワークです。\n\n■ Mutually Exclusive（重複なし）\nカテゴリー同士が重ならない。同じ項目が複数のバケツに入ることはない。\n\n■ Collectively Exhaustive（漏れなし）\nすべてが網羅されている。抜けや見落としがない。\n\nMECEが大事な理由：\n① 死角を防ぐ → よい意思決定\n② 重複を排除する → 効率的な資源配分\n③ コミュニケーションが明確 → チームの足並みが揃う',
+      phrases: [
+        { en: 'stands for', ja: '〜の略', note: '略語の元の意味を説明する定型表現。"MECE stands for ..."' },
+        { en: 'Mutually Exclusive', ja: '相互に排他的（重複なし）', note: 'mutually = お互いに、exclusive = 排他的' },
+        { en: 'Collectively Exhaustive', ja: '網羅的（漏れなし）', note: 'collectively = 全体として、exhaustive = 徹底的・すべて尽くす' },
+        { en: 'no overlap between', ja: '〜の間に重複なし' },
+        { en: 'blind spots', ja: '死角', note: '気づいていない欠点・見落とし' },
+        { en: 'team alignment', ja: 'チームの足並みが揃うこと', note: 'align = 一致させる、整列する' },
+      ],
+    },
+    // Step 1: "Four ways to break things down MECE"
+    {
+      titleJa: 'MECEに分解する4つの方法',
+      contentJa:
+        'MECE分解には4つの代表的なパターンがあります。\n\n[1] 要素分解（数式型）\n全体を数式の構成要素に分ける。\n例：売上 = 顧客数 × 平均客単価／利益 = 売上 − コスト\n\n[2] 時系列\n時間の段階で分ける。\n例：購買ジャーニー = 認知 → 興味 → 検討 → 購入 → リピート\n\n[3] 対立概念\n二項対立または近い分類で分ける。\n例：国内／海外、既存／新規、オンライン／オフライン\n\n[4] 既存フレームワーク\n既知のフレームワークで切る。\n例：3C（顧客・競合・自社）、4P（製品・価格・流通・販促）\n\n問題に対して最も明確で、重複の少ない切り口を選ぼう。',
+      phrases: [
+        { en: 'break things down', ja: '物事を分解する', note: 'break A down または break down A。MECE分解の文脈で頻出' },
+        { en: 'component breakdown', ja: '要素分解', note: '数式のように分解する手法' },
+        { en: 'time sequence', ja: '時系列' },
+        { en: 'opposing concepts', ja: '対立概念' },
+        { en: 'established framework', ja: '既存フレームワーク', note: 'establish = 確立する、established = 確立された' },
+        { en: 'whichever ... gives', ja: '〜を提供するものはどれでも', note: '関係詞 whichever。"pick whichever pattern gives the clearest cut"' },
+      ],
+    },
+    // Step 2: Quiz "What does Mutually Exclusive mean?"
+    {
+      questionJa: 'MECEの「Mutually Exclusive（重複なし）」の意味は？',
+      optionsJa: [
+        '漏れなくすべて網羅されている',
+        'カテゴリー同士が重ならない',
+        '構造が階層的になっている',
+        '時系列順に並んでいる',
+      ],
+      explanationJa:
+        '「Mutually Exclusive」とはカテゴリー同士が重ならないこと。同じ項目が2つのバケツに同時に入ることはありません。「漏れなく網羅」のほうはMECEのもう半分「Collectively Exhaustive」です。',
+      phrases: [
+        { en: 'half of', ja: '〜の半分・片方', note: '"the Mutually Exclusive half of MECE" = MECEの片方' },
+        { en: 'never lives in', ja: '〜には決して存在しない', note: 'live in = （比喩的に）〜に位置する／属する' },
+      ],
+    },
+    // Step 3: Case 1 - sales falling
+    {
+      titleJa: '【ケース1】なぜ売上が落ちている？— 3C分析をMECEで',
+      contentJa:
+        '■ 状況設定\nあなたは中堅アパレル会社の戦略アナリスト。売上が3四半期連続で前年比15%減。経営陣に根本原因分析を提示する必要があります。\n\n■ 3CでのMECE分解\n\n[Customer：顧客]\n・20-35歳層の購買行動の変化\n・可処分所得の低下 → 価格意識が高まる\n・ファストファッションブランドへの流出\n・カテゴリ内のEC化進展\n\n[Competitor：競合]\n・大手SPAブランドの積極的な価格戦略\n・SNSマーケティングに強いD2Cブランドの台頭\n・海外ブランドの国内市場参入\n・アプリ・パーソナライゼーションへの大型投資\n\n[Company：自社]\n・競合に比べ商品開発サイクルが遅い\n・店舗立地が顧客の動線とズレている\n・マーケ予算が紙媒体に偏重\n・EC比率が業界平均の半分\n\n■ なぜ機能するか\n3Cは問題を3つの重ならない角度から見ることを強制します。競合だけ、内部だけ、と偏ることがありません。',
+      phrases: [
+        { en: 'year over year', ja: '前年比（YoY）', note: 'ビジネスで頻出。"sales dropped 15% year over year"' },
+        { en: 'three quarters in a row', ja: '3四半期連続で', note: 'in a row = 連続して' },
+        { en: 'root-cause analysis', ja: '根本原因分析', note: '問題の本質を探る分析手法' },
+        { en: 'shifting purchase behavior', ja: '購買行動の変化', note: 'shift = 変化する、shifting = 変化している' },
+        { en: 'disposable income', ja: '可処分所得', note: '使える自由なお金' },
+        { en: 'price-conscious', ja: '価格に敏感な', note: '-conscious = 〜を意識した（health-conscious 健康志向 など）' },
+        { en: 'over-indexed on', ja: '〜に偏重している', note: 'インデックスが基準より高い → 比重が大きすぎる' },
+        { en: 'half of industry average', ja: '業界平均の半分' },
+      ],
+    },
+    // Step 4: Quiz "competitor lowered prices"
+    {
+      questionJa: '売上減少に3C MECEを当てはめるとき、「競合が値下げしたので顧客が離れた」はどのバケツに入る？',
+      optionsJa: ['Customer（顧客）', 'Competitor（競合）', 'Company（自社）', '3つすべて'],
+      explanationJa:
+        '見えている結果ではなく、根本の原因で分類する。引き金は競合の価格戦略なので Competitor に入る。3つすべてに入れると「重複なし」のルールに違反します。',
+      phrases: [
+        { en: 'fits in', ja: '〜に当てはまる', note: '"which bucket fits ..."（どのバケツが当てはまるか）' },
+        { en: 'visible effect', ja: '目に見える結果', note: 'visible = 目に見える' },
+        { en: 'violates the rule', ja: 'ルールに違反する' },
+      ],
+    },
+    // Step 5: Case 2 - B2B SaaS channels
+    {
+      titleJa: '【ケース2】B2B SaaSの新規顧客獲得チャネルマップ',
+      contentJa:
+        '■ 状況設定\nB2B SaaSのマーケティングチームが、予算を再配分する前に、新規顧客獲得のチャネルをすべてマップ化したい。\n\n■ MECE分解（対立概念 → 要素分解）\n\n[オンラインチャネル]\n├─ インバウンド\n│  ├─ SEO／コンテンツマーケ\n│  ├─ SNS（LinkedIn, X, Facebook）\n│  └─ ウェビナー\n├─ アウトバウンド\n│  ├─ 検索広告（Google, Bing）\n│  ├─ ディスプレイ／リターゲティング\n│  ├─ コールドメール\n│  └─ SNS広告（LinkedIn Ads など）\n└─ リファラル／口コミ\n   ├─ アフィリエイトプログラム\n   └─ レビューサイト（G2, Capterra）\n\n[オフラインチャネル]\n├─ インバウンド\n│  ├─ 展示会出展\n│  └─ 自社主催セミナー\n├─ アウトバウンド\n│  ├─ コールドコール（電話営業）\n│  ├─ ダイレクトメール\n│  └─ 飛び込み訪問\n└─ リファラル／口コミ\n   ├─ パートナーチャネル\n   └─ 既存顧客紹介\n\n■ パターン\n第1段：オンライン vs オフライン（対立概念）。第2段：インバウンド vs アウトバウンド vs リファラル（対立概念）。多階層の分解で、重複なく完全なマップが作れる。',
+      phrases: [
+        { en: 'reallocating budget', ja: '予算を再配分する', note: 're- = 再び、allocate = 配分する' },
+        { en: 'word-of-mouth', ja: '口コミ', note: '直訳すると「口の言葉」' },
+        { en: 'cold email', ja: '面識のない相手へのメール営業' },
+        { en: 'cold calling', ja: '電話営業（飛び込み）', note: '"cold" = アポなし' },
+        { en: 'multi-level decomposition', ja: '多階層の分解' },
+      ],
+    },
+    // Step 6: Quiz online/offline pattern
+    {
+      questionJa: 'チャネルを「オンライン／オフライン」、次に「インバウンド／アウトバウンド」で分けた——どのMECEパターン？',
+      optionsJa: [
+        '要素分解 → 時系列',
+        '対立概念 → 対立概念',
+        '既存フレームワーク → 要素分解',
+        '時系列 → 既存フレームワーク',
+      ],
+      explanationJa:
+        'オンライン／オフラインも、インバウンド／アウトバウンドも、二項対立的な切り口。要素分解は「売上 = 価格 × 数量」のような数式型のことです。',
+    },
+    // Step 7: Case 3 - coffee chain revenue
+    {
+      titleJa: '【ケース3】コーヒーチェーンの売上分解',
+      contentJa:
+        '■ 状況設定\nあなたは10店舗のコーヒーチェーンの経営者。月間総売上が目標を20%下回っている。漏れを見つけるため、売上をMECEに分解する。\n\n■ 多階層の要素分解\n\n売上 = 顧客数 × 平均客単価\n\n[顧客数]\n├─ 新規顧客\n│  ├─ 通行客（立地）\n│  ├─ 広告経由\n│  ├─ 口コミ\n│  └─ レビューサイト経由\n├─ リピート顧客\n│  ├─ ヘビーユーザー（週3回以上）\n│  ├─ ミドルユーザー（週1-2回）\n│  └─ ライトユーザー（月1-3回）\n└─ 時間帯\n   ├─ 朝（7-10時）\n   ├─ ランチ（11-14時）\n   ├─ 午後（14-17時）\n   └─ 夕方（17-21時）\n\n[平均客単価]\n├─ ドリンク価格 × ドリンク付帯率\n├─ フード価格 × フード付帯率\n├─ デザート価格 × デザート付帯率\n└─ テイクアウト vs イートインの差\n\n■ データが示すもの\n調べると、リピート顧客は変わらず、新規顧客が30%減、特にレビューサイト経由の流入が激減。競合チェーンのレビュー評価上昇で初回客を奪われていた。\n\n■ なぜ機能するか\n「売上 = 顧客数 × 客単価」は古典的な要素分解。さらに1階層下げることで、分析を具体的なアクションに繋げられる。',
+      phrases: [
+        { en: 'find the leak', ja: '漏れ（穴）を見つける', note: 'leak = 漏れ。問題の原因の比喩' },
+        { en: 'foot traffic', ja: '通行人・来店客数', note: '直訳「足の交通」' },
+        { en: 'attach rate', ja: '付帯率・併売率', note: 'メイン商品に何かが追加される率' },
+        { en: 'dig in', ja: '深掘りする', note: '直訳「掘り進める」' },
+        { en: 'held steady', ja: '横ばいだった、安定していた' },
+        { en: 'connect ... to specific actions', ja: '〜を具体的なアクションに繋げる' },
+      ],
+    },
+    // Step 8: Quiz Customers × Ticket
+    {
+      questionJa: '売上を「顧客数 × 平均客単価」で分けた——どのMECEパターン？',
+      optionsJa: ['時系列', '対立概念', '要素分解', '既存フレームワーク'],
+      explanationJa: '全体を A × B や A + B のように数式の構成要素に分けるのが要素分解です。',
+    },
+    // Step 9: Quiz NOT MECE
+    {
+      questionJa: '次のうちMECEでないものは？',
+      optionsJa: [
+        '性別：男性／女性／その他',
+        '年齢：10代／20代／30代／40代／50代以上',
+        '地域：北部／南部／東部／都市部／郊外',
+        '購入頻度：初回／2回目／3回目以上',
+      ],
+      explanationJa:
+        '地域の選択肢は、地理（北部／南部／東部）と人口密度（都市部／郊外）という2つの異なる切り口を混ぜている。北部にも都市部・郊外があるので、カテゴリーが重複してしまいます。',
+      phrases: [
+        { en: 'mixes two different cuts', ja: '2つの異なる切り口を混ぜている', note: 'cut = 分類の切り口' },
+      ],
+    },
+    // Step 10: Quiz missing categories
+    {
+      questionJa: 'ある会社が従業員を「正社員／契約社員／パート」と分類している。派遣・フリーランスが含まれていない。これはどのMECEの問題？',
+      optionsJa: ['カテゴリーの重複', 'カテゴリーの抜け', '重複と抜けの両方', '問題なし'],
+      explanationJa: '派遣やフリーランスが含まれていない「抜け」がある。MECEの片割れ「Collectively Exhaustive（網羅）」を満たしていません。',
+      phrases: [
+        { en: 'fails the rule', ja: 'ルールを満たさない', note: 'fail = 満たさない・落ちる' },
+      ],
+    },
+    // Step 11: Quiz best approach
+    {
+      questionJa: 'MECE分解を作る最も効果的な進め方は？',
+      optionsJa: [
+        '思いついた順に列挙する',
+        '最上位の切り口を先に決め、段階的に細分化する',
+        '競合の分析をコピーする',
+        '項目数を最大化する',
+      ],
+      explanationJa: '良いMECE分解は、まず最上位の切り口（例：3Cで切る、オンライン／オフラインで切る）を決め、それから1段ずつ細かくしていきます。トップダウン的アプローチです。',
+      phrases: [
+        { en: 'top-level cut', ja: '最上位の切り口' },
+        { en: 'progressively subdivide', ja: '段階的に細分化する', note: 'progressively = 段階的に' },
+      ],
+    },
+  ],
+}
+
+// Deduction (lesson 25) — additional annotation example
+const deduction: LessonAnnotations = {
+  steps: [
+    {
+      titleJa: '演繹法 — 一般から個別へ',
+      contentJa:
+        '演繹的推論は、一般的な原則から始め、具体的な結論を導きます。古典的な構造は三段論法です：\n\n大前提：すべての人間は死ぬ運命にある\n小前提：ソクラテスは人間である\n結論：ゆえに、ソクラテスは死ぬ運命にある\n\n両方の前提が真であれば、結論は必ず真である。これが演繹の力です — 完全に厳密で、論理的に確実。\n\nビジネスでは、演繹はあなたの推論が確固たる原則の上に立っていることを示すために使われます。',
+      phrases: [
+        { en: 'general to specific', ja: '一般から具体へ' },
+        { en: 'syllogism', ja: '三段論法', note: '大前提・小前提・結論からなる演繹推論' },
+        { en: 'major premise', ja: '大前提' },
+        { en: 'minor premise', ja: '小前提' },
+        { en: 'mortal', ja: '死ぬ運命の・必滅の' },
+        { en: 'rests on', ja: '〜の上に立っている、〜に基づいている', note: 'rest on = 〜に依存・基づく' },
+        { en: 'airtight', ja: '完璧な・隙のない', note: '直訳「空気が漏れない」→ 論理的に隙がない' },
+      ],
+    },
+  ],
+}
+
+export const englishLearningAnnotations: Record<number, LessonAnnotations> = {
+  20: mece,
+  25: deduction,
+}
+
+export function getLessonAnnotation(lessonId: number): LessonAnnotations | undefined {
+  return englishLearningAnnotations[lessonId]
+}
+
+export function getStepAnnotation(lessonId: number, stepIndex: number): StepAnnotation | undefined {
+  return englishLearningAnnotations[lessonId]?.steps[stepIndex]
+}
+
+export function hasAnyAnnotation(lessonId: number): boolean {
+  const a = englishLearningAnnotations[lessonId]
+  return !!a && a.steps.some((s) => s.titleJa || s.contentJa || s.questionJa || (s.phrases && s.phrases.length > 0))
+}
+
+export function savePhraseToFlashcards(phrase: Phrase, lessonId: number, lessonTitle: string) {
+  const back = phrase.note ? `${phrase.ja}\n\n${phrase.note}` : phrase.ja
+  addCards([
+    {
+      front: phrase.en,
+      back,
+      category: lessonTitle,
+      source: `english-${lessonId}`,
+    },
+  ])
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1380,6 +1380,18 @@ const STRINGS: Record<Locale, Strings> = {
     'tutorial.step5.tag': 'スタート',
     'tutorial.step5.title': 'さっそくやってみよう！',
     'tutorial.step5.description': '最初の1問、フェルミ問題にチャレンジしてみよう。答えは何でもOK — まず考えることが大事だよ。',
+
+    // English learning mode (premium feature shown when locale === 'en')
+    'englishLearning.toolbarLabel': '英語学習ツール',
+    'englishLearning.showTranslation': '日本語訳を表示',
+    'englishLearning.hideTranslation': '日本語訳を隠す',
+    'englishLearning.showPhrases': 'フレーズを学ぶ',
+    'englishLearning.hidePhrases': 'フレーズを閉じる',
+    'englishLearning.phrasesLabel': '重要フレーズ',
+    'englishLearning.phrasesTitle': '重要フレーズ',
+    'englishLearning.phrasesHint': '保存ボタンで自動的にフラッシュカードに追加されます',
+    'englishLearning.savePhrase': 'カードに保存',
+    'englishLearning.phraseSaved': '保存済み',
   },
 
   en: {
@@ -2727,6 +2739,18 @@ const STRINGS: Record<Locale, Strings> = {
     'tutorial.step5.tag': 'Start',
     'tutorial.step5.title': "Let's give it a try!",
     'tutorial.step5.description': 'Take on your first Fermi problem. Any answer is fine — what matters is starting to think.',
+
+    // English learning mode (premium feature shown when locale === 'en')
+    'englishLearning.toolbarLabel': 'English learning tools',
+    'englishLearning.showTranslation': 'Show Japanese',
+    'englishLearning.hideTranslation': 'Hide Japanese',
+    'englishLearning.showPhrases': 'Study phrases',
+    'englishLearning.hidePhrases': 'Hide phrases',
+    'englishLearning.phrasesLabel': 'Key phrases',
+    'englishLearning.phrasesTitle': 'Key phrases',
+    'englishLearning.phrasesHint': 'Saved phrases are added to your flashcards automatically.',
+    'englishLearning.savePhrase': 'Save card',
+    'englishLearning.phraseSaved': 'Saved',
   },
 }
 


### PR DESCRIPTION
## Summary
英語ロケール × プレミアムプランの組み合わせで、レッスン画面が英語学習モードに変わります。Logic アプリのレッスンを使って、ビジネス英語のフレーズと表現を同時に学べるようにする最初の一歩です。

## 機能
レッスン画面の上部に2つのトグルが表示されます（条件を満たすレッスンのみ）：

- **「あ 日本語訳を表示」** — 英文の下に和訳を差し込んで表示。explain 本文 / quiz 設問・選択肢・解説、すべてに対応
- **「📖 フレーズを学ぶ」** — 重要フレーズを `en / ja / note（文法・用法）` の形でリスト表示。「カードに保存」ボタンで既存の Flashcard 機構（`source: english-{lessonId}`）に自動追加。重複は `addCards` 側でスキップされます

ステップを進めるとトグル状態はリセット。

## 出現条件
`getLocale() === 'en' && isPremium() && hasAnyAnnotation(lessonId)`

注釈のないレッスンではトグルが出ないので、コンテンツの段階追加が安全です。

## データ構造
`src/englishLearningData.ts` に lessonId × stepIndex 単位で注釈を持たせる仕組み：

```ts
type StepAnnotation = {
  titleJa?: string
  contentJa?: string
  questionJa?: string
  optionsJa?: string[]
  explanationJa?: string
  phrases?: { en: string; ja: string; note?: string }[]
}
```

初期実装：
- **MECE (id 20)** — 全 step（12 ステップ）を完全注釈
- **Deduction (id 25)** — 1 step を見本として注釈

## 変更ファイル
- `src/englishLearningData.ts` *(新規)* — 注釈データ + ヘルパー関数
- `src/Lesson.tsx` — トグル UI / フレーズパネル / 翻訳差し込み
- `src/Lesson.css` — `.ls-en-*` クラス群
- `src/i18n.ts` — `englishLearning.*` キーを ja / en に追加

## Test plan
- [ ] 日本語ロケール時：トグルが出ないこと
- [ ] 英語ロケール × Free プラン：トグルが出ないこと
- [ ] 英語ロケール × Premium / Trial × MECE レッスン：両方のトグルが出ること
- [ ] 「日本語訳」トグル：explain 本文・quiz 設問・選択肢・解説の和訳がそれぞれ表示されること
- [ ] 「フレーズを学ぶ」：フレーズ一覧が表示され、保存ボタンでカードが追加され「保存済み」に変わること
- [ ] 次の step に進むとトグル状態がリセットされること
- [ ] 注釈のない英語レッスン（id 21 等）：トグルが出ないこと
- [ ] フラッシュカード画面で `source: english-20` のカードが見えること

## フォローアップ候補
- 残り 7 つの英語版ロジックレッスン（id 21–27, 68）への注釈拡充
- ホーム画面・ロードマップでの英語学習導線
- フレーズ数の進捗トラッキング（XP 化など）

https://claude.ai/code/session_01CvR3Tk91dhHnxhbQXTVp57

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvR3Tk91dhHnxhbQXTVp57)_