### PR TITLE
fix: 英語学習注釈の翻訳精度・ja/en parity を改善（content-reviewer 指摘反映）

### DIFF
--- a/src/englishLearningData.ts
+++ b/src/englishLearningData.ts
@@ -37,12 +37,12 @@ const mece: LessonAnnotations = {
       contentJa:
         'MECE（「ミーシー」と発音）は "Mutually Exclusive, Collectively Exhaustive"（モレなく、ダブりなく）の略です。ビジネスで情報を分析・整理する最も基本的なフレームワークです。\n\n■ Mutually Exclusive（重複なし）\nカテゴリー同士が重ならない。同じ項目が複数のバケツに入ることはない。\n\n■ Collectively Exhaustive（漏れなし）\nすべてが網羅されている。抜けや見落としがない。\n\nMECEが大事な理由：\n① 死角を防ぐ → よい意思決定\n② 重複を排除する → 効率的な資源配分\n③ コミュニケーションが明確 → チームの足並みが揃う',
       phrases: [
-        { en: 'stands for', ja: '〜の略', note: '略語の元の意味を説明する定型表現。"MECE stands for ..."' },
-        { en: 'Mutually Exclusive', ja: '相互に排他的（重複なし）', note: 'mutually = お互いに、exclusive = 排他的' },
-        { en: 'Collectively Exhaustive', ja: '網羅的（漏れなし）', note: 'collectively = 全体として、exhaustive = 徹底的・すべて尽くす' },
+        { en: 'stands for', ja: '〜の略', note: '略語の元の意味を説明する定型表現。例：MECE stands for "Mutually Exclusive, Collectively Exhaustive."' },
+        { en: 'Mutually Exclusive', ja: '互いに重ならない（重複なし）', note: '直訳は「相互に排他的」。mutually = お互いに、exclusive = 排他的。MECEの片割れ' },
+        { en: 'Collectively Exhaustive', ja: '網羅的（漏れなし）', note: 'collectively = 全体として、exhaustive = 徹底的・すべて尽くす。MECEのもう片割れ' },
         { en: 'no overlap between', ja: '〜の間に重複なし' },
         { en: 'blind spots', ja: '死角', note: '気づいていない欠点・見落とし' },
-        { en: 'team alignment', ja: 'チームの足並みが揃うこと', note: 'align = 一致させる、整列する' },
+        { en: 'team alignment', ja: 'チームの足並みが揃うこと', note: 'align = 一致させる、整列する。ビジネスでは「目標・戦略の方向性が一致する」意味でも頻出' },
       ],
     },
     // Step 1: "Four ways to break things down MECE"
@@ -56,7 +56,7 @@ const mece: LessonAnnotations = {
         { en: 'time sequence', ja: '時系列' },
         { en: 'opposing concepts', ja: '対立概念' },
         { en: 'established framework', ja: '既存フレームワーク', note: 'establish = 確立する、established = 確立された' },
-        { en: 'whichever ... gives', ja: '〜を提供するものはどれでも', note: '関係詞 whichever。"pick whichever pattern gives the clearest cut"' },
+        { en: 'whichever pattern gives', ja: '〜してくれるどのパターンでも（最も〜なパターン）', note: '複合関係形容詞 whichever ＋ 名詞。"pick whichever pattern gives the clearest cut" =「最もはっきり切ってくれるパターンを選べ」' },
       ],
     },
     // Step 2: Quiz "What does Mutually Exclusive mean?"
@@ -72,7 +72,7 @@ const mece: LessonAnnotations = {
         '「Mutually Exclusive」とはカテゴリー同士が重ならないこと。同じ項目が2つのバケツに同時に入ることはありません。「漏れなく網羅」のほうはMECEのもう半分「Collectively Exhaustive」です。',
       phrases: [
         { en: 'half of', ja: '〜の半分・片方', note: '"the Mutually Exclusive half of MECE" = MECEの片方' },
-        { en: 'never lives in', ja: '〜には決して存在しない', note: 'live in = （比喩的に）〜に位置する／属する' },
+        { en: 'never lives in', ja: '〜の中には決して入っていない（属していない）', note: 'live in = （比喩的に）〜に居場所を持つ・〜の中に位置する。"the same item never lives in two buckets"（同じ項目は2つのバケツに同時に属さない）' },
       ],
     },
     // Step 3: Case 1 - sales falling
@@ -111,8 +111,8 @@ const mece: LessonAnnotations = {
       phrases: [
         { en: 'reallocating budget', ja: '予算を再配分する', note: 're- = 再び、allocate = 配分する' },
         { en: 'word-of-mouth', ja: '口コミ', note: '直訳すると「口の言葉」' },
-        { en: 'cold email', ja: '面識のない相手へのメール営業' },
-        { en: 'cold calling', ja: '電話営業（飛び込み）', note: '"cold" = アポなし' },
+        { en: 'cold email', ja: '面識のない相手へのメール営業', note: '"cold" = アポなし／面識なし' },
+        { en: 'cold calling', ja: '電話による新規開拓営業', note: '"cold" = アポなし。訪問の飛び込みは door-to-door。混同しやすいので注意' },
         { en: 'multi-level decomposition', ja: '多階層の分解' },
       ],
     },
@@ -135,11 +135,11 @@ const mece: LessonAnnotations = {
         '■ 状況設定\nあなたは10店舗のコーヒーチェーンの経営者。月間総売上が目標を20%下回っている。漏れを見つけるため、売上をMECEに分解する。\n\n■ 多階層の要素分解\n\n売上 = 顧客数 × 平均客単価\n\n[顧客数]\n├─ 新規顧客\n│  ├─ 通行客（立地）\n│  ├─ 広告経由\n│  ├─ 口コミ\n│  └─ レビューサイト経由\n├─ リピート顧客\n│  ├─ ヘビーユーザー（週3回以上）\n│  ├─ ミドルユーザー（週1-2回）\n│  └─ ライトユーザー（月1-3回）\n└─ 時間帯\n   ├─ 朝（7-10時）\n   ├─ ランチ（11-14時）\n   ├─ 午後（14-17時）\n   └─ 夕方（17-21時）\n\n[平均客単価]\n├─ ドリンク価格 × ドリンク付帯率\n├─ フード価格 × フード付帯率\n├─ デザート価格 × デザート付帯率\n└─ テイクアウト vs イートインの差\n\n■ データが示すもの\n調べると、リピート顧客は変わらず、新規顧客が30%減、特にレビューサイト経由の流入が激減。競合チェーンのレビュー評価上昇で初回客を奪われていた。\n\n■ なぜ機能するか\n「売上 = 顧客数 × 客単価」は古典的な要素分解。さらに1階層下げることで、分析を具体的なアクションに繋げられる。',
       phrases: [
         { en: 'find the leak', ja: '漏れ（穴）を見つける', note: 'leak = 漏れ。問題の原因の比喩' },
-        { en: 'foot traffic', ja: '通行人・来店客数', note: '直訳「足の交通」' },
-        { en: 'attach rate', ja: '付帯率・併売率', note: 'メイン商品に何かが追加される率' },
-        { en: 'dig in', ja: '深掘りする', note: '直訳「掘り進める」' },
-        { en: 'held steady', ja: '横ばいだった、安定していた' },
-        { en: 'connect ... to specific actions', ja: '〜を具体的なアクションに繋げる' },
+        { en: 'foot traffic', ja: '人通り・通行客（→ 来店客数の指標）', note: '直訳「足の交通」。立地に紐づく潜在客数を表す' },
+        { en: 'attach rate', ja: '付帯率・併売率', note: 'メイン商品に何かが追加される率（飲食・小売の指標）' },
+        { en: 'dig in', ja: '深掘りする・突き詰める', note: '直訳「掘り進める」。データ分析で頻出' },
+        { en: 'held steady', ja: '横ばいだった、安定していた', note: 'hold steady = 安定する／横ばいで推移する。held は hold の過去形' },
+        { en: 'connect the analysis to specific actions', ja: '分析を具体的なアクションに繋げる', note: 'connect A to B = A を B に繋げる。分析を施策に落とし込む文脈' },
       ],
     },
     // Step 8: Quiz Customers × Ticket
@@ -169,7 +169,7 @@ const mece: LessonAnnotations = {
       optionsJa: ['カテゴリーの重複', 'カテゴリーの抜け', '重複と抜けの両方', '問題なし'],
       explanationJa: '派遣やフリーランスが含まれていない「抜け」がある。MECEの片割れ「Collectively Exhaustive（網羅）」を満たしていません。',
       phrases: [
-        { en: 'fails the rule', ja: 'ルールを満たさない', note: 'fail = 満たさない・落ちる' },
+        { en: 'fails the', ja: '〜を満たさない・通らない', note: 'fail = 満たさない・落ちる。本文 "fails the \\"Collectively Exhaustive\\" half of MECE" は「網羅性のテストに通らない」' },
       ],
     },
     // Step 11: Quiz best approach
@@ -194,17 +194,22 @@ const mece: LessonAnnotations = {
 const deduction: LessonAnnotations = {
   steps: [
     {
-      titleJa: '演繹法 — 一般から個別へ',
+      titleJa: '演繹法とは？',
       contentJa:
-        '演繹的推論は、一般的な原則から始め、具体的な結論を導きます。古典的な構造は三段論法です：\n\n大前提：すべての人間は死ぬ運命にある\n小前提：ソクラテスは人間である\n結論：ゆえに、ソクラテスは死ぬ運命にある\n\n両方の前提が真であれば、結論は必ず真である。これが演繹の力です — 完全に厳密で、論理的に確実。\n\nビジネスでは、演繹はあなたの推論が確固たる原則の上に立っていることを示すために使われます。',
+        '演繹的推論は、一般的な原則から具体的な結論を導く推論です。\n\n古典的な例（三段論法）：\n① 大前提：すべての人間は死ぬ運命にある\n② 小前提：ソクラテスは人間である\n③ 結論：ゆえに、ソクラテスは死ぬ運命にある\n\n■ 特徴\n・前提が真であれば、結論は必ず真である\n・新しい情報は生まれない — 前提に既に含まれているものを取り出している\n・トップダウンの推論\n\n■ ビジネスでの例\n大前提：マージン5%未満の事業からは撤退する（社内ポリシー）\n小前提：A 事業のマージンは2%\n結論：A 事業は撤退対象\n\n■ 妥当性 vs 健全性 — 重要！\n論理学者は次の2つを区別します：\n\n・妥当性（Validity）：前提が真であると仮定した場合、結論は必然的に導かれるか？（形式の正しさ）\n・健全性（Soundness）：妥当である AND 前提が実際に真であること。\n\n例：\n大前提：「鳥は飛ぶ」/ 小前提：「ペンギンは鳥である」/ 結論：「ペンギンは飛ぶ」\n→ 形式は妥当（A はすべて B、X は A、ゆえに X は B）だが、大前提が偽。論証は妥当だが健全ではない。\n\nビジネスで演繹を使うときは、形式 AND 前提の真偽の両方を必ずチェックすること。',
       phrases: [
-        { en: 'general to specific', ja: '一般から具体へ' },
-        { en: 'syllogism', ja: '三段論法', note: '大前提・小前提・結論からなる演繹推論' },
+        { en: 'general principles to specific conclusions', ja: '一般的な原則から具体的な結論へ', note: '演繹法の方向性。inductive（帰納）はこの逆' },
+        { en: 'syllogism', ja: '三段論法', note: '大前提・小前提・結論からなる演繹推論の古典的形式' },
         { en: 'major premise', ja: '大前提' },
         { en: 'minor premise', ja: '小前提' },
-        { en: 'mortal', ja: '死ぬ運命の・必滅の' },
-        { en: 'rests on', ja: '〜の上に立っている、〜に基づいている', note: 'rest on = 〜に依存・基づく' },
-        { en: 'airtight', ja: '完璧な・隙のない', note: '直訳「空気が漏れない」→ 論理的に隙がない' },
+        { en: 'mortal', ja: '死ぬ運命の・必滅の', note: '哲学標準訳。"All humans are mortal" は三段論法の代表例' },
+        { en: 'No new information is created', ja: '新しい情報は生まれない', note: '演繹の本質。前提に既に含まれていることの取り出しに過ぎない' },
+        { en: 'Top-down reasoning', ja: 'トップダウンの推論', note: '一般 → 具体 の方向。ボトムアップ＝帰納' },
+        { en: 'exit-eligible', ja: '撤退対象（撤退の対象として該当する）', note: '-eligible = 〜の対象として適格な' },
+        { en: 'Validity', ja: '妥当性', note: '形式の正しさ。「前提が真なら結論も必ず真」が成り立つか' },
+        { en: 'Soundness', ja: '健全性', note: '妥当 AND 前提が実際に真。論理学の基本概念' },
+        { en: 'necessarily follow', ja: '必然的に導かれる', note: 'follow = （結論として）導かれる、続く' },
+        { en: 'valid but unsound', ja: '妥当だが健全ではない', note: '形式は正しいが前提が偽の論証' },
       ],
     },
   ],

--- a/src/englishLearningData.ts
+++ b/src/englishLearningData.ts
@@ -127,6 +127,10 @@ const mece: LessonAnnotations = {
       ],
       explanationJa:
         'オンライン／オフラインも、インバウンド／アウトバウンドも、二項対立的な切り口。要素分解は「売上 = 価格 × 数量」のような数式型のことです。',
+      phrases: [
+        { en: 'binary', ja: '二項対立的な・二者択一の', note: '対立概念パターンの典型形。「YES / NO」「A / B」のような2分割' },
+        { en: 'opposing-concept cuts', ja: '対立概念での切り分け', note: 'cut = 分類の切り口。オンライン／オフラインのような分け方' },
+      ],
     },
     // Step 7: Case 3 - coffee chain revenue
     {
@@ -147,6 +151,10 @@ const mece: LessonAnnotations = {
       questionJa: '売上を「顧客数 × 平均客単価」で分けた——どのMECEパターン？',
       optionsJa: ['時系列', '対立概念', '要素分解', '既存フレームワーク'],
       explanationJa: '全体を A × B や A + B のように数式の構成要素に分けるのが要素分解です。',
+      phrases: [
+        { en: 'mathematical components', ja: '数式の構成要素', note: 'A × B や A + B のように分解できる要素' },
+        { en: 'a whole', ja: '全体', note: '"split a whole into ..."（全体を〜に分ける）の文型で頻出' },
+      ],
     },
     // Step 9: Quiz NOT MECE
     {
@@ -161,6 +169,9 @@ const mece: LessonAnnotations = {
         '地域の選択肢は、地理（北部／南部／東部）と人口密度（都市部／郊外）という2つの異なる切り口を混ぜている。北部にも都市部・郊外があるので、カテゴリーが重複してしまいます。',
       phrases: [
         { en: 'mixes two different cuts', ja: '2つの異なる切り口を混ぜている', note: 'cut = 分類の切り口' },
+        { en: 'geographic', ja: '地理的な・地域による', note: 'North/South/East のような場所による分類' },
+        { en: 'population density', ja: '人口密度', note: 'urban（都市部）／rural（郊外）のような人口集中度の指標' },
+        { en: 'overlap', ja: '重複・重なる', note: '名詞・動詞の両方で使う。MECEの "Mutually Exclusive" とは「重複なし」の意味' },
       ],
     },
     // Step 10: Quiz missing categories
@@ -183,8 +194,10 @@ const mece: LessonAnnotations = {
       ],
       explanationJa: '良いMECE分解は、まず最上位の切り口（例：3Cで切る、オンライン／オフラインで切る）を決め、それから1段ずつ細かくしていきます。トップダウン的アプローチです。',
       phrases: [
-        { en: 'top-level cut', ja: '最上位の切り口' },
-        { en: 'progressively subdivide', ja: '段階的に細分化する', note: 'progressively = 段階的に' },
+        { en: 'top-level cut', ja: '最上位の切り口', note: 'MECE分解の最初の段階。3C・オンライン／オフライン などの大きな切り方' },
+        { en: 'progressively subdivide', ja: '段階的に細分化する', note: 'progressively = 段階的に。subdivide = さらに細かく分ける' },
+        { en: 'works top-down', ja: 'トップダウンで機能する', note: '上から下へ＝大きな切り口から細部へ向かう順序。MECEの基本姿勢' },
+        { en: 'easy to spot', ja: '見つけやすい', note: 'spot = （目で）見つける・気づく。"gaps and overlaps easy to spot"（漏れや重複が見つけやすい）' },
       ],
     },
   ],


### PR DESCRIPTION
## Summary
content-reviewer サブエージェントの指摘を反映するコンテンツ修正のみの PR です。`src/englishLearningData.ts` の翻訳精度・ja/en parity を改善します。

PR #125 / #128 とは独立しているため、いつでも単独でマージ可能です。

## 🔴 Critical 修正

### Deduction (lesson 25) step 0 contentJa の大幅欠落を修正
**問題**: 英文には次の3セクションがありますが、`contentJa` には冒頭の三段論法だけしか訳されていませんでした：
- `■ Properties` — "If the premises are true, the conclusion MUST be true / No new information is created / Top-down reasoning"
- `■ In business` — マージン < 5% で撤退の三段論法例
- `■ Validity vs. Soundness — important!` — 妥当性と健全性の区別（Birds/Penguins の例つき）

**影響**: 直後の **quiz step 1** が "BOTH valid in form AND has true premises (a 'sound' argument)" を問うため、和訳しか読まない学習者には**理解不能**でした。

**修正**: 全3セクションを和訳に追加。phrases も拡充（Validity / Soundness / valid but unsound / necessarily follow / exit-eligible 等）。

## 🟡 Should fix 修正

| Phrase | 修正内容 |
|---|---|
| `whichever ... gives` → `whichever pattern gives` | 文法用語を「関係詞」→「複合関係形容詞」に。訳と用例も自然に |
| `never lives in` | 直訳を比喩寄りに調整（「決して存在しない」→「中には決して入っていない・属していない」） |
| `fails the rule` → `fails the` | 本文に存在しない文字列だったので、本文中の `fails the "Collectively Exhaustive" half` にマッチするように修正 |
| `connect ... to specific actions` → `connect the analysis to specific actions` | `...` が本文に存在しないので完全一致に |
| `held steady` | `held` が `hold` の過去形である note を追加 |
| `cold calling` | door-to-door との混同を避けるため「電話による新規開拓営業」と note で明示 |
| `Mutually Exclusive` | 主訳を contentJa の表現と統一（「相互に排他的」→「互いに重ならない」） |
| `team alignment` | ビジネスでは「目標・戦略の方向性が一致」も指す note を追加 |
| `stands for` | note 内 quote を本文に合わせた完全形に |
| `dig in / foot traffic / attach rate` | コンテキスト忠実な訳にニュアンス追加 |

## 変更ファイル
- `src/englishLearningData.ts` のみ（コードロジックには触れていない）

## 関連 PR
- PR #125（merged）— 英語学習モード本体
- PR #128（draft）— インラインフレーズタップ翻訳

## Test plan
- [ ] MECE レッスン（id 20）を英語ロケール × Premium で開いて、本文の `Mutually Exclusive` / `cold calling` / `held steady` / `connect the analysis to specific actions` などをタップ → 修正後の和訳・note が出ることを確認
- [ ] Deduction レッスン（id 25）の step 0 で「日本語訳」を ON → 「特徴」「ビジネスでの例」「妥当性 vs 健全性」の3セクションが表示される
- [ ] Deduction step 1 quiz の正解（"All mammals breathe air with lungs"）が、和訳しか読まない学習者にも納得できるようになっていること

## フォローアップ候補
- 残り 7 つの英語版ロジックレッスン（id 21–24, 26, 27, 68）への注釈拡充
- Deduction (id 25) の step 1〜以降への注釈拡充

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvR3Tk91dhHnxhbQXTVp57)_