### PR TITLE
fix: プロフィールの言語行タップで選択画面を開く

### DIFF
--- a/src/AppV3.tsx
+++ b/src/AppV3.tsx
@@ -507,6 +507,7 @@ function AppV3() {
           onOpenPricing={() => navigate({ type: 'pricing' })}
           onOpenPlacementTest={() => navigate({ type: 'placement-test' })}
           onOpenLesson={(id) => navigate({ type: 'lesson', lessonId: id })}
+          onOpenLanguage={() => navigate({ type: 'language' })}
         />
       )}
       {screen.type === 'rank' && <RankScreen onBack={handleBack} />}

--- a/src/screens/ProfileScreenV3.tsx
+++ b/src/screens/ProfileScreenV3.tsx
@@ -11,7 +11,7 @@ import { getSubscriptionState, isPremiumPlan, isStandardPlan, daysLeftInTrial } 
 import { getStudyDates as _getStudyDatesArr } from '../stats'
 import LessonIcon from '../LessonIcon'
 import { StarIcon } from '../icons'
-import { t, getLocale, setLocale } from '../i18n'
+import { t, getLocale } from '../i18n'
 
 function getPlanLabel(): string {
   const state = getSubscriptionState()
@@ -35,12 +35,13 @@ interface ProfileScreenV3Props {
   onOpenPricing?: () => void
   onOpenPlacementTest?: () => void
   onOpenLesson?: (lessonId: number) => void
+  onOpenLanguage?: () => void
 }
 
 type Sheet = null | 'streak' | 'lessons' | 'xp'
 
 export function ProfileScreenV3(props: ProfileScreenV3Props) {
-  const { userName, onOpenSettings, onOpenFeedback, onOpenPricing, onOpenPlacementTest, onOpenLesson } = props
+  const { userName, onOpenSettings, onOpenFeedback, onOpenPricing, onOpenPlacementTest, onOpenLesson, onOpenLanguage } = props
   const [sheet, setSheet] = useState<Sheet>(null)
   const streak = getLessonStreak()
   const completed = getCompletedCount()
@@ -164,7 +165,7 @@ export function ProfileScreenV3(props: ProfileScreenV3Props) {
         <div style={{ background: 'var(--bg-card)', borderRadius: 'var(--radius-lg)', overflow: 'hidden', boxShadow: 'var(--shadow-v3-card-inset)' }}>
           <SettingRow icon="user" name={t('profile.account')} sub={userName || t('home.guestName')} onClick={() => onOpenSettings('account')} />
           <SettingRow icon="bell" name={t('profile.notifications')} sub="" onClick={() => onOpenSettings('notifications')} />
-          <SettingRow icon="globe" name={t('profile.languageTitle')} sub={getLocale() === 'ja' ? t('profile.languageJa') : t('profile.languageEn')} onClick={() => setLocale(getLocale() === 'ja' ? 'en' : 'ja')} />
+          <SettingRow icon="globe" name={t('profile.languageTitle')} sub={getLocale() === 'ja' ? t('profile.languageJa') : t('profile.languageEn')} onClick={onOpenLanguage} />
           <SettingRow icon="card" name={t('profile.plan')} sub={getPlanLabel()} onClick={onOpenPricing} />
           <SettingRow icon="message" name={t('profile.feedbackName')} sub={t('profile.feedbackSub')} onClick={onOpenFeedback} />
           <SettingRow icon="doc" name={t('profile.terms')} sub="" onClick={() => window.open('/terms.html', '_blank')} />


### PR DESCRIPTION
## 概要

プロフィール画面の「言語」行をタップすると、ja ↔ en を即時トグルしていたため、誤タップで意図せず英語に切り替わってしまう問題を修正。

## 変更点

- `ProfileScreenV3.tsx`: 言語行の `onClick` を `setLocale` の即時トグルから `onOpenLanguage` 経由の `LanguageScreen` 遷移に変更
- `AppV3.tsx`: `ProfileScreenV3` に `onOpenLanguage` を渡して `language` 画面へナビゲートするよう接続

これにより、タップ後に `LanguageScreen` で日本語 / English を明示的に選択する UX になる。

## テスト

- [x] `npx tsc --noEmit` パス
- [ ] プロフィール → 言語をタップ → LanguageScreen が開くことを確認
- [ ] LanguageScreen で言語を選択すると切り替わることを確認

https://claude.ai/code/session_01UCcjB3ZbhJZ6oRuTWwgvvb

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCcjB3ZbhJZ6oRuTWwgvvb)_