### PR TITLE
fix: redirect logged-in users to home screen on app load

### DIFF
--- a/src/AppV3.tsx
+++ b/src/AppV3.tsx
@@ -132,7 +132,7 @@ function getInitialScreen(user: User | null): Screen {
     if (preview === 'roleplay-select') return { type: 'roleplay' }
   }
   // ログイン済みユーザーはオンボーディングをスキップ
-  if (user) return { type: 'daily-fermi' }
+  if (user) return { type: 'home' }
   // 未ログインは必ずオンボーディングまたはログイン画面へ
   if (localStorage.getItem(ONBOARDED_KEY) !== '1') {
     return { type: 'onboarding' }


### PR DESCRIPTION
## Summary
- ログイン済みユーザーがアプリ起動時にフェルミ問題画面 (`daily-fermi`) に遷移していたのを、ホーム画面 (`home`) に遷移するよう修正

## Changes
- `src/AppV3.tsx` の `getInitialScreen()` で、ログイン済みユーザーが返される画面を `daily-fermi` → `home` に変更

## Test plan
- [ ] ログイン済み状態でアプリを起動 → ホーム画面が表示されることを確認
- [ ] 未ログイン → オンボーディングまたはログイン画面の挙動が変わっていないことを確認
- [ ] ログイン直後 (`LoginScreen` の `onLoginSuccess`) もホーム画面に遷移すること（既存挙動）を確認

---
_Generated by [Claude Code](https://claude.ai/code/session_018xv36XHpGGzkvDvkZTBJeB)_