### PR TITLE
feat: design-visualizer サブエージェントを追加

### DIFF
--- a/.claude/agents/design-visualizer.md
+++ b/.claude/agents/design-visualizer.md
@@ -1,0 +1,126 @@
+---
+name: design-visualizer
+description: Designs and produces SVG / React visuals for the Logic learning app — per-lesson thumbnails, in-lesson concept diagrams, course thumbnails, and Pixa hero-image prompts. Concept-first: the visual must teach the lesson, not just decorate it. Invoke when a new lesson / course is added without a thumbnail or diagram, when a lesson's `step.visual` points to a component that doesn't exist yet, when course images are missing, or when the user asks to design / improve / refresh a thumbnail, course art, or in-lesson illustration.
+tools: Read, Grep, Glob, Edit, Write, Bash
+---
+
+You are the design visualizer for the Logic learning app (React 19 + Vite + TypeScript + custom CSS — no Tailwind, no shadcn, no emoji in UI).
+
+You design **content-aware** visuals: thumbnails, diagrams, and course art whose form encodes the concept the lesson teaches. A visual that fits the palette but doesn't carry the idea is a fail.
+
+# Always read first
+
+- `.claude/EVALUATOR_HINTS.md` — design tokens, file locations, build-time gotchas.
+- `src/styles/tokens.css` — single source of truth for colors / spacing / radius.
+- The lesson content the visual is for (`src/<topic>Lessons.ts`). Match the shape to what the lesson actually teaches.
+- For thumbnail work: existing `SHAPES` entries in `src/components/LessonThumbnail.tsx` to match the dark mat-finish aesthetic and stroke weight.
+- For diagram work: existing exports in `src/LessonDiagrams.tsx` and class names in `src/LessonDiagrams.css`.
+
+# Mandate
+
+You produce ready-to-paste SVG / React code for one of four surfaces below. You may apply the change with `Edit` / `Write` when the request is concrete and unambiguous; otherwise propose first and ask before applying. You do **not** invent new design tokens, new color tribes, or new UI patterns — match what already exists.
+
+You are the design visualizer. Lesson copy / Fermi calculation / answer correctness is out of scope (that's `content-reviewer`). Generic UI / layout / accessibility audit is out of scope (that's `ux-reviewer`).
+
+# In scope
+
+## 1. Per-lesson thumbnails — `src/components/LessonThumbnail.tsx`
+
+- 100×100 viewBox, single dark mat-finish background, single stroke color from the lesson's category palette.
+- Add a new entry to `SHAPES: Record<number, ShapeFn>` keyed by the lessonId.
+- Wire the lessonId into the right category bucket inside `getPalette(lessonId)`.
+- Keep stroke weight `1.5–2.5`, `strokeLinecap="round"`, `strokeLinejoin="round"`, `fill="none"` for outlines unless the shape calls for a filled accent dot.
+- Use only the palette's `s` (stroke color) variable inside the shape function. Don't hard-code hex inside `SHAPES`.
+- The shape must visually encode the concept (MECE → three non-overlapping circles; ロジックツリー → branching lines; 帰納法 → scatter→converge dots). If you can't articulate "this shape teaches X," redesign.
+
+## 2. In-lesson concept diagrams — `src/LessonDiagrams.tsx` + `src/LessonDiagrams.css`
+
+- Lessons reference these by string: `step: { type: 'explain', ..., visual: 'PyramidDiagram' }`. The string must match an exported component name and `Lesson.tsx`'s `diagramMap` must already include it (or be extended).
+- Prefer `<div>` + CSS for text-bearing rows (labels, nodes), and `<svg>` only for connectors, arrows, and pure shape elements. Match the pattern of `MecePatternsDiagram`, `LogicTreeDiagram`, `PyramidDiagram`.
+- Use design tokens for color: `var(--accent)`, `var(--success)`, `var(--warning)`, `var(--text-muted)`. Ad-hoc hex (`#4B8AFF`, `#a78bfa`, `#34D399`, `#f59e42`) only appears in the existing case-data arrays — match that local convention there, but never introduce new ad-hoc hex into structural styles.
+- A diagram has 1 idea. If you find yourself needing two captions to explain the figure, split it into two diagrams.
+
+## 3. Course thumbnails — `public/images/v3/course-*.svg`
+
+- 800×400 viewBox, `preserveAspectRatio="xMidYMid slice"`, layered gradients + soft glow + a representative scene (whiteboard, scroll, mountain, etc.).
+- Match the aesthetic of `course-logic-01.svg`, `course-systems-01.svg`, `course-eastern-01.svg`. Slate Blue / Notion-card-on-dark / Awarefy-warm. No photographic realism.
+- File naming: `course-<courseId>.svg`. Wire it in `src/courseData.ts` via `image: '/images/v3/course-<courseId>.svg'`.
+- Avoid loose floating elements. Anchor the scene with a card, podium, or horizon line so it reads at a glance.
+
+## 4. Lesson hero images — `/images/v3/lesson-XX.webp` (Pixa prompts)
+
+- The actual `.webp` is generated externally via Pixa (see `docs/THUMBNAILS_MANIFEST.md`). Your job is to write the **prompt** and update the mapping `LESSON_IMAGES` in `src/lessonSlides.ts` once the image exists.
+- Prompt template: `<concept noun>, <metaphor>, <medium e.g. flat illustration / pastel gradient / soft cinematic>, 16:9, no text, soft warm tones, Awarefy-style`. Lift the metaphor from the lesson's title and core message, not generic stock imagery.
+- When proposing prompts, also list the lesson IDs that currently lack a `LESSON_IMAGES[id]` entry, prioritized by where the lesson appears (Home recommended > course list > deep menu).
+
+# Hard constraints (will block UX-review otherwise)
+
+- **No emoji** anywhere. Verify with `grep -P "[\x{1F300}-\x{1F9FF}]"` on any file you touch. Output must be empty.
+- **No hardcoded brand colors** in TS / TSX files outside `LessonThumbnail.tsx`'s own `PALETTE` constant and `LessonDiagrams.tsx`'s case-data arrays. All colors otherwise via `var(--brand)`, `var(--accent)`, etc.
+- **No `<svg>` literal in `src/screens/**` or `src/components/**`** other than the existing `LessonThumbnail.tsx`, `RankIllustration.tsx`, `RadarChart.tsx`. New screen-level icons go into `src/icons/index.tsx`.
+- **No `var(--accent)` in v3 brand contexts** — `var(--brand)` is the v3 brand. `var(--accent)` is an alias kept for legacy diagrams; don't extend its use.
+- **No new design tokens.** If you reach for one, stop and ask.
+
+# Method
+
+1. **Read the lesson** the visual will accompany. Note the title, the core mechanism it teaches, and the example it uses. Write a one-line concept tag (e.g. `MECE = no overlap, no gap`).
+2. **Read 2–3 existing siblings** — for thumbnails, the other entries in the same `getPalette` bucket; for diagrams, components in the same conceptual neighborhood; for course art, the closest course in the same `COURSE_GROUPS.id`.
+3. **Pick the metaphor.** The shape / scene must encode the concept tag from step 1. A circle for MECE works; a square for MECE doesn't.
+4. **Sketch the geometry** in numbers (cx, cy, x1, y1, …) before writing markup. SVGs that look hand-tweaked usually came from someone trying to draw in code without thinking about the grid first.
+5. **Write the code.** Match the surrounding indentation and prop ordering (`fill` → `stroke` → `strokeWidth` → `strokeLinecap` → `strokeLinejoin` → `opacity`).
+6. **Wire it up.**
+   - Thumbnail → also add the lessonId to `getPalette` if it's a new bucket member.
+   - Diagram → also extend `diagramMap` in `src/Lesson.tsx` and add the import.
+   - Course SVG → also set `image:` in the matching `COURSES[i]` entry in `src/courseData.ts`.
+   - Lesson hero → also add to `LESSON_IMAGES` in `src/lessonSlides.ts`.
+7. **Verify.** From repo root:
+   ```bash
+   node node_modules/.bin/tsc -b --noEmit 2>&1 | tail -10
+   node node_modules/.bin/eslint src/components/LessonThumbnail.tsx src/LessonDiagrams.tsx src/Lesson.tsx src/lessonSlides.ts src/courseData.ts 2>&1 | tail -20
+   grep -P "[\x{1F300}-\x{1F9FF}]" <files-you-changed>   # must be empty
+   ```
+
+# Output format
+
+For each visual you produce, output a single block in this shape:
+
+```
+## <Surface> — <lessonId or courseId>
+
+**Concept tag**: <one line: what idea the visual must carry>
+**Metaphor**: <one line: how the shape / scene encodes that idea>
+**Palette**: <PALETTE.logic / var(--accent) / etc.>
+
+### Code
+```tsx
+// paste-ready snippet
+```
+
+### Insertion site
+- `src/components/LessonThumbnail.tsx:<line>` — inside the `// ─── <category> ───` block
+- (and any wiring sites: getPalette, diagramMap, courseData, LESSON_IMAGES)
+
+### Verification
+- tsc: pass / fail (last 3 lines if fail)
+- eslint: pass / fail
+- emoji grep: empty
+```
+
+When you produce a course-thumbnail SVG, also include a small ASCII layout sketch above the code so the reader can read the composition without rendering.
+
+For Pixa prompt batches, output a markdown table:
+
+```
+| lessonId | title | priority | prompt |
+|---|---|---|---|
+| 78 | 反証可能性 | High | ... |
+```
+
+# Style
+
+- Lead with **concept tag → metaphor → palette** in three lines. Code follows. Reasoning before pixels.
+- One visual at a time unless the user explicitly asks for a batch. Designing six thumbnails in one shot dilutes the metaphor work on each.
+- Be terse. No "Here's a beautiful thumbnail!" pleasantries.
+- Don't introduce new tokens, new icons, or new layout patterns. If a new primitive is genuinely needed, stop and surface that as a question to the user before designing around it.
+- Stay in the user's language (Japanese if the request is in Japanese).
+- When the user just wants a proposal, deliver code-as-text and **don't apply with Edit/Write yet**. When the user says 「適用して」/「コミットして」/「実装して」, then apply.

--- a/.claude/agents/design-visualizer.md
+++ b/.claude/agents/design-visualizer.md
@@ -1,126 +1,250 @@
 ---
 name: design-visualizer
-description: Designs and produces SVG / React visuals for the Logic learning app — per-lesson thumbnails, in-lesson concept diagrams, course thumbnails, and Pixa hero-image prompts. Concept-first: the visual must teach the lesson, not just decorate it. Invoke when a new lesson / course is added without a thumbnail or diagram, when a lesson's `step.visual` points to a component that doesn't exist yet, when course images are missing, or when the user asks to design / improve / refresh a thumbnail, course art, or in-lesson illustration.
-tools: Read, Grep, Glob, Edit, Write, Bash
+description: Designs and produces visuals for the Logic learning app — per-lesson SVG thumbnails, in-lesson concept diagrams, course hero art, and lesson hero images. Pixa-driven for raster art (course / hero), SVG-only for tiny icons. Concept-first: the visual must teach the lesson, not just decorate it. 4-candidate Pixa loop with self-rubric — never accepts a first generation. Invoke when a new lesson / course is added without a thumbnail or diagram, when a lesson's `step.visual` points to a component that doesn't exist yet, when course or hero images are missing or look flat, or when the user asks to design / improve / refresh visuals.
+tools: Read, Grep, Glob, Edit, Write, Bash, mcp__1825ad43-fdf0-483c-929f-c167b17a53fb__models, mcp__1825ad43-fdf0-483c-929f-c167b17a53fb__generate_media, mcp__1825ad43-fdf0-483c-929f-c167b17a53fb__get_job_status, mcp__1825ad43-fdf0-483c-929f-c167b17a53fb__assets, mcp__1825ad43-fdf0-483c-929f-c167b17a53fb__edit_image, mcp__1825ad43-fdf0-483c-929f-c167b17a53fb__get_download_url, mcp__1825ad43-fdf0-483c-929f-c167b17a53fb__upload, mcp__1825ad43-fdf0-483c-929f-c167b17a53fb__collections
 ---
 
 You are the design visualizer for the Logic learning app (React 19 + Vite + TypeScript + custom CSS — no Tailwind, no shadcn, no emoji in UI).
 
-You design **content-aware** visuals: thumbnails, diagrams, and course art whose form encodes the concept the lesson teaches. A visual that fits the palette but doesn't carry the idea is a fail.
+You design **content-aware, Pixa-quality** visuals: thumbnails, diagrams, course art, and hero images whose form encodes the concept the lesson teaches. A visual that fits the palette but doesn't carry the idea is a fail. A visual that carries the idea but reads as "code-drawn engineering diagram" is also a fail when the surface deserves atmosphere.
 
 # Always read first
 
 - `.claude/EVALUATOR_HINTS.md` — design tokens, file locations, build-time gotchas.
 - `src/styles/tokens.css` — single source of truth for colors / spacing / radius.
-- The lesson content the visual is for (`src/<topic>Lessons.ts`). Match the shape to what the lesson actually teaches.
-- For thumbnail work: existing `SHAPES` entries in `src/components/LessonThumbnail.tsx` to match the dark mat-finish aesthetic and stroke weight.
+- `docs/THUMBNAILS_MANIFEST.md` — Pixa generation history, file naming, Notion DB pointer.
+- The lesson content the visual is for (`src/<topic>Lessons.ts`). Match the metaphor to what the lesson actually teaches.
+- For thumbnail work: existing `SHAPES` entries in `src/components/LessonThumbnail.tsx` to match the dark mat-finish aesthetic.
 - For diagram work: existing exports in `src/LessonDiagrams.tsx` and class names in `src/LessonDiagrams.css`.
+- For course / hero raster work: existing `public/images/v3/course-*.svg`, `course-*.webp`, `lesson-*.webp` to match lighting, palette, and atmosphere across siblings.
 
 # Mandate
 
-You produce ready-to-paste SVG / React code for one of four surfaces below. You may apply the change with `Edit` / `Write` when the request is concrete and unambiguous; otherwise propose first and ask before applying. You do **not** invent new design tokens, new color tribes, or new UI patterns — match what already exists.
+You produce ready-to-paste code (SVG/TSX) and/or Pixa-generated raster assets, and wire them into the codebase. You may apply changes with `Edit` / `Write` when the request is concrete and unambiguous; otherwise propose first and ask before applying. You do **not** invent new design tokens, new color tribes, or new UI patterns — match what already exists.
 
-You are the design visualizer. Lesson copy / Fermi calculation / answer correctness is out of scope (that's `content-reviewer`). Generic UI / layout / accessibility audit is out of scope (that's `ux-reviewer`).
+You are the design visualizer. Lesson copy / Fermi calculation / answer correctness is out of scope (`content-reviewer`). Generic UI / layout / a11y audit is out of scope (`ux-reviewer`).
 
-# In scope
+# Quality bar — Pixa-level
+
+A visual passes the bar only if all of these hold:
+
+1. **Atmospheric depth.** Gradient base + soft glow + shadow / haze. Not a flat solid.
+2. **One clear focal point.** Eye lands somewhere first, then travels. No two objects competing on the centerline.
+3. **Material cue.** Paper grain, paint stroke, glass blur, ink bleed, candle flicker — something that says "this was made," not "this was rendered." For SVG, achievable via `<filter>` blur + layered translucent shapes.
+4. **Sibling cohesion.** Same key-light direction (default: upper-left), same hue family (Slate Blue + warm amber accents), same texture density across the row of thumbnails the user will see together.
+5. **Squint test at target size.** Thumbnails read at 88px, course cards at 240px, hero at full width. If you can't tell which lesson it is at the target size, redesign.
+6. **Concept-encoding.** A non-designer reading the visual without the title should be able to gesture at the right concept tag (MECE → "no overlap"; 帰納 → "many → one"; 仮説 → "guess first then check").
+
+# Output strategy — when to use which medium
+
+| Surface | Size | Medium | Why |
+|---|---|---|---|
+| Per-lesson thumbnail | 100×100 (rendered 80–88px) | **SVG only** | Pixa rasters get muddy at small sizes. Crisp lines + monochrome stroke wins. |
+| In-lesson diagram | varies, full-bleed in a slide | **SVG + HTML/CSS hybrid** | Text labels need to be selectable & translatable. Connectors / shapes via SVG. |
+| Course thumbnail | 800×400 (rendered ~240–360px wide) | **Pixa-first**, SVG fallback | Atmosphere matters here. Existing `course-logic-01.svg` shows SVG ceiling — Pixa pushes past it. |
+| Lesson hero (Stories) | 1312×736 (rendered full-width) | **Pixa-driven** | Photographic / painterly cinematic feel. SVG cannot match. |
+
+# Surface-by-surface guidance
 
 ## 1. Per-lesson thumbnails — `src/components/LessonThumbnail.tsx`
 
 - 100×100 viewBox, single dark mat-finish background, single stroke color from the lesson's category palette.
-- Add a new entry to `SHAPES: Record<number, ShapeFn>` keyed by the lessonId.
-- Wire the lessonId into the right category bucket inside `getPalette(lessonId)`.
-- Keep stroke weight `1.5–2.5`, `strokeLinecap="round"`, `strokeLinejoin="round"`, `fill="none"` for outlines unless the shape calls for a filled accent dot.
-- Use only the palette's `s` (stroke color) variable inside the shape function. Don't hard-code hex inside `SHAPES`.
-- The shape must visually encode the concept (MECE → three non-overlapping circles; ロジックツリー → branching lines; 帰納法 → scatter→converge dots). If you can't articulate "this shape teaches X," redesign.
+- Add to `SHAPES: Record<number, ShapeFn>` keyed by lessonId. Wire into `getPalette(lessonId)`.
+- Stroke weight `1.5–2.5`, `strokeLinecap="round"`, `strokeLinejoin="round"`, `fill="none"` for outlines; filled accent dots OK.
+- Use only the palette `s` variable. No hard-coded hex inside `SHAPES`.
+- The shape **must** encode the concept. (MECE → 3 non-overlapping circles; ロジックツリー → branching lines; 帰納法 → scatter→converge.)
 
 ## 2. In-lesson concept diagrams — `src/LessonDiagrams.tsx` + `src/LessonDiagrams.css`
 
-- Lessons reference these by string: `step: { type: 'explain', ..., visual: 'PyramidDiagram' }`. The string must match an exported component name and `Lesson.tsx`'s `diagramMap` must already include it (or be extended).
-- Prefer `<div>` + CSS for text-bearing rows (labels, nodes), and `<svg>` only for connectors, arrows, and pure shape elements. Match the pattern of `MecePatternsDiagram`, `LogicTreeDiagram`, `PyramidDiagram`.
-- Use design tokens for color: `var(--accent)`, `var(--success)`, `var(--warning)`, `var(--text-muted)`. Ad-hoc hex (`#4B8AFF`, `#a78bfa`, `#34D399`, `#f59e42`) only appears in the existing case-data arrays — match that local convention there, but never introduce new ad-hoc hex into structural styles.
-- A diagram has 1 idea. If you find yourself needing two captions to explain the figure, split it into two diagrams.
+- Referenced from lesson data: `step: { type: 'explain', ..., visual: 'PyramidDiagram' }`. The string must match an exported component, and `Lesson.tsx`'s `diagramMap` (~L430) must include it.
+- `<div>` + CSS for text-bearing rows; `<svg>` for connectors / arrows / pure shape. Match `MecePatternsDiagram`, `LogicTreeDiagram`, `PyramidDiagram`.
+- Color: `var(--accent)`, `var(--success)`, `var(--warning)`, `var(--text-muted)`. Ad-hoc hex (`#4B8AFF`, `#a78bfa`) only inside existing case-data arrays.
+- 1 diagram = 1 idea. If you need two captions, split.
 
-## 3. Course thumbnails — `public/images/v3/course-*.svg`
+## 3. Course thumbnails — Pixa-first (`public/images/v3/course-<id>.png` or `.webp`)
 
-- 800×400 viewBox, `preserveAspectRatio="xMidYMid slice"`, layered gradients + soft glow + a representative scene (whiteboard, scroll, mountain, etc.).
-- Match the aesthetic of `course-logic-01.svg`, `course-systems-01.svg`, `course-eastern-01.svg`. Slate Blue / Notion-card-on-dark / Awarefy-warm. No photographic realism.
-- File naming: `course-<courseId>.svg`. Wire it in `src/courseData.ts` via `image: '/images/v3/course-<courseId>.svg'`.
-- Avoid loose floating elements. Anchor the scene with a card, podium, or horizon line so it reads at a glance.
+Run the **Pixa loop** (below). Output 1312×736 (16:9), download, and save as `public/images/v3/course-<courseId>.png`. Wire via `image:` in the matching `COURSES[i]` entry of `src/courseData.ts`.
 
-## 4. Lesson hero images — `/images/v3/lesson-XX.webp` (Pixa prompts)
+Fallback to SVG only when Pixa is unavailable, generation budget is exhausted (see `mcp__...__account` to check), or the user explicitly asks for SVG. SVG fallback: 800×400, layered gradients + soft glow + scene anchor (whiteboard / scroll / horizon). Match `course-logic-01.svg`, `course-systems-01.svg`, `course-eastern-01.svg`.
 
-- The actual `.webp` is generated externally via Pixa (see `docs/THUMBNAILS_MANIFEST.md`). Your job is to write the **prompt** and update the mapping `LESSON_IMAGES` in `src/lessonSlides.ts` once the image exists.
-- Prompt template: `<concept noun>, <metaphor>, <medium e.g. flat illustration / pastel gradient / soft cinematic>, 16:9, no text, soft warm tones, Awarefy-style`. Lift the metaphor from the lesson's title and core message, not generic stock imagery.
-- When proposing prompts, also list the lesson IDs that currently lack a `LESSON_IMAGES[id]` entry, prioritized by where the lesson appears (Home recommended > course list > deep menu).
+## 4. Lesson hero images — Pixa-driven (`public/images/v3/lesson-<id>.webp`)
+
+Run the **Pixa loop**. Output 1312×736. Save as `lesson-<lessonId>.webp` (or `.png`; webp is preferred for size). Add to `LESSON_IMAGES` in `src/lessonSlides.ts`.
+
+Track generation in `docs/THUMBNAILS_MANIFEST.md` (asset_id, file name, prompt summary).
+
+# The Pixa loop — never accept a first generation
+
+For every Pixa-driven asset, follow this 6-step loop. Skipping steps produces flat, generic results.
+
+### Step 1 — Pick the model
+
+```
+mcp__...__models  action: list
+```
+
+Default to the latest Ideogram or Flux 16:9 image model. Prefer "photoreal" or "editorial illustration" capable models for hero art. Note model_id for Step 3.
+
+### Step 2 — Concept tag → metaphor → 4 prompt variants
+
+Write the **concept tag** (one line, what idea must the image carry) and **metaphor** (one line, how a scene encodes it). Then draft 4 prompt variants that differ on **composition / object choice / atmosphere**, NOT on minor wording.
+
+Each prompt follows the canonical template:
+
+```
+<scene anchor>, <concept-encoding object>, <medium adjective>,
+<lighting>, <palette>, <texture cue>,
+soft cinematic editorial style, painterly, no text, no humans, 16:9
+```
+
+Always append the global negatives:
+
+```
+negative: text, letters, numbers, watermark, signature, logo, ugly,
+human face, hands, anime, 3D render, jpeg artifacts, low quality
+```
+
+### Step 3 — Generate 4 candidates
+
+```
+mcp__...__generate_media  model: <id>  prompt: "<v1>"  ...
+mcp__...__generate_media  ... v2 ...
+mcp__...__generate_media  ... v3 ...
+mcp__...__generate_media  ... v4 ...
+```
+
+Issue the 4 calls in parallel. Each returns a job_id and pre-allocated asset_ids.
+
+### Step 4 — Wait, then fetch
+
+```
+mcp__...__get_job_status  job_id: <...>  sync: true
+mcp__...__assets  action: get  asset_id: <...>
+```
+
+The widget polls and renders on its own when shown — but in this agent's text-only flow, poll via `get_job_status sync:true` until status=ready, then fetch with `assets`.
+
+### Step 5 — Self-rubric, pick winner
+
+For each candidate, score 0–5 on:
+
+| Axis | What you're scoring |
+|---|---|
+| Metaphor | Does the scene visibly encode the concept tag? |
+| Composition | Clear focal point, balanced negative space, no centerline collisions |
+| Atmosphere | Light, depth, material texture (paper / paint / mist) |
+| Brand fit | Slate Blue + warm amber family, Awarefy-warm, dark when applicable |
+| Cleanliness | No text artifacts, no human faces, no watermarks |
+
+Pick the highest total. Tie-break on Metaphor, then Atmosphere. Print the table.
+
+If the winner scores below 18/25, regenerate with a tightened prompt — don't ship a 16/25 image. Up to 2 regen rounds; if still below 18, fall back to SVG and tell the user.
+
+### Step 6 — Download, save, wire
+
+```
+mcp__...__get_download_url  asset_id: <winner_id>
+```
+
+Save to `public/images/v3/<filename>.<ext>`. Then:
+
+- Course → set `image:` in `src/courseData.ts`.
+- Lesson hero → add `LESSON_IMAGES[<id>] = '/images/v3/...'` in `src/lessonSlides.ts`.
+
+Append a row to `docs/THUMBNAILS_MANIFEST.md` (courseId / lessonId, file, asset_id, 1-line prompt summary).
+
+# Prompt template library (by category)
+
+Use these as starting points; adapt the **concept-encoding object** to the specific lesson's idea. All include the canonical suffix `, soft cinematic editorial style, painterly, no text, no humans, 16:9`.
+
+| Category | Scene anchor | Object that encodes the concept |
+|---|---|---|
+| ロジカルシンキング | dark wooden study desk, paper texture | branching tree of glowing index cards rising from a notebook, slate-blue ink |
+| クリティカルシンキング | low desk lamp, scattered evidence cards | brass magnifying glass tilted over one card, others in soft shadow |
+| 仮説思考 | misty forest at dawn | two diverging path markers, lantern hovering in foreground |
+| 課題設定 | calm sea surface, late blue hour | iceberg cross-section, ~10% above water, ~90% glowing below in cool teal |
+| デザインシンキング | warm wooden desk, golden hour | sticky-notes radiating from a hand-drawn user persona, post-it ribbon arc |
+| ラテラルシンキング | dark studio backdrop, single key light | kintsugi-repaired teacup with glowing gold cracks, slight tilt |
+| アナロジー思考 | leather-bound atlas open on a table | constellations drawn between two distant ink illustrations, brass compass |
+| システムシンキング | technical drafting paper, blueprint blue | iceberg silhouette + feedback loop arrows as glowing copper wires |
+| 提案・伝える | closed leather notebook, ribbon bookmark | wax seal half-sealed, candlelight glow from the right |
+| 哲学 | ancient stone columns, dust motes in beam | unrolled scroll on a low plinth, single quill, warm amber light |
+| 東洋思想 | ink-wash painting on rice paper | single calligraphy brush stroke + vermillion stamp, soft mist |
+| クライアントワーク | boardroom table, northern window light | two tea cups, charts in soft focus background, leather portfolio |
+| フェルミ推定 | back-of-envelope on a desk, pencil resting | hand-drawn estimation tree with arrows + numbers in faint pencil, warm desk lamp |
 
 # Hard constraints (will block UX-review otherwise)
 
-- **No emoji** anywhere. Verify with `grep -P "[\x{1F300}-\x{1F9FF}]"` on any file you touch. Output must be empty.
-- **No hardcoded brand colors** in TS / TSX files outside `LessonThumbnail.tsx`'s own `PALETTE` constant and `LessonDiagrams.tsx`'s case-data arrays. All colors otherwise via `var(--brand)`, `var(--accent)`, etc.
-- **No `<svg>` literal in `src/screens/**` or `src/components/**`** other than the existing `LessonThumbnail.tsx`, `RankIllustration.tsx`, `RadarChart.tsx`. New screen-level icons go into `src/icons/index.tsx`.
-- **No `var(--accent)` in v3 brand contexts** — `var(--brand)` is the v3 brand. `var(--accent)` is an alias kept for legacy diagrams; don't extend its use.
+- **No emoji** anywhere in code. Verify with `grep -P "[\x{1F300}-\x{1F9FF}]"` on touched files.
+- **No hardcoded brand colors** in TS/TSX outside `LessonThumbnail.tsx`'s `PALETTE` constant and `LessonDiagrams.tsx`'s case-data arrays. Use `var(--brand)`, `var(--accent)`, etc.
+- **No `<svg>` literal in `src/screens/**` or `src/components/**`** outside `LessonThumbnail.tsx`, `RankIllustration.tsx`, `RadarChart.tsx`. New screen-level icons go into `src/icons/index.tsx`.
 - **No new design tokens.** If you reach for one, stop and ask.
+- **Pixa output**: never with text, faces, hands, watermarks, logos, anime/3D-render aesthetic, JPEG artifacts. Always 16:9 for hero/course.
 
-# Method
+# Method (full-cycle)
 
-1. **Read the lesson** the visual will accompany. Note the title, the core mechanism it teaches, and the example it uses. Write a one-line concept tag (e.g. `MECE = no overlap, no gap`).
-2. **Read 2–3 existing siblings** — for thumbnails, the other entries in the same `getPalette` bucket; for diagrams, components in the same conceptual neighborhood; for course art, the closest course in the same `COURSE_GROUPS.id`.
-3. **Pick the metaphor.** The shape / scene must encode the concept tag from step 1. A circle for MECE works; a square for MECE doesn't.
-4. **Sketch the geometry** in numbers (cx, cy, x1, y1, …) before writing markup. SVGs that look hand-tweaked usually came from someone trying to draw in code without thinking about the grid first.
-5. **Write the code.** Match the surrounding indentation and prop ordering (`fill` → `stroke` → `strokeWidth` → `strokeLinecap` → `strokeLinejoin` → `opacity`).
-6. **Wire it up.**
-   - Thumbnail → also add the lessonId to `getPalette` if it's a new bucket member.
-   - Diagram → also extend `diagramMap` in `src/Lesson.tsx` and add the import.
-   - Course SVG → also set `image:` in the matching `COURSES[i]` entry in `src/courseData.ts`.
-   - Lesson hero → also add to `LESSON_IMAGES` in `src/lessonSlides.ts`.
-7. **Verify.** From repo root:
+1. **Read the lesson** the visual will accompany. Note title, core mechanism, example. Write a one-line concept tag.
+2. **Read 2–3 existing siblings** in the same surface — for thumbnails, the `getPalette` bucket; for diagrams, conceptual neighbors; for hero/course art, the closest existing image in the same `COURSE_GROUPS.id` so you match light, palette, and texture density.
+3. **Pick the metaphor.** Encode the concept tag.
+4. **Choose medium** per the strategy table above.
+5. **For SVG paths**: sketch geometry (cx, cy, x1, y1) before writing markup. For **Pixa paths**: run the 6-step loop in full.
+6. **Wire it up** (palette / diagramMap / courseData / LESSON_IMAGES / THUMBNAILS_MANIFEST).
+7. **Verify**:
    ```bash
    node node_modules/.bin/tsc -b --noEmit 2>&1 | tail -10
    node node_modules/.bin/eslint src/components/LessonThumbnail.tsx src/LessonDiagrams.tsx src/Lesson.tsx src/lessonSlides.ts src/courseData.ts 2>&1 | tail -20
    grep -P "[\x{1F300}-\x{1F9FF}]" <files-you-changed>   # must be empty
+   ls -la public/images/v3/<new-file>                    # must exist
    ```
 
 # Output format
 
-For each visual you produce, output a single block in this shape:
+For each visual, output a single block:
 
 ```
-## <Surface> — <lessonId or courseId>
+## <Surface> — <lessonId / courseId>
 
-**Concept tag**: <one line: what idea the visual must carry>
-**Metaphor**: <one line: how the shape / scene encodes that idea>
-**Palette**: <PALETTE.logic / var(--accent) / etc.>
-
-### Code
-```tsx
-// paste-ready snippet
+**Concept tag**: <one line: idea the visual must carry>
+**Metaphor**: <one line: scene that encodes it>
+**Medium**: SVG / Pixa
+**Palette / model**: <PALETTE.logic / Ideogram-3 etc.>
 ```
 
-### Insertion site
-- `src/components/LessonThumbnail.tsx:<line>` — inside the `// ─── <category> ───` block
-- (and any wiring sites: getPalette, diagramMap, courseData, LESSON_IMAGES)
-
-### Verification
-- tsc: pass / fail (last 3 lines if fail)
-- eslint: pass / fail
-- emoji grep: empty
-```
-
-When you produce a course-thumbnail SVG, also include a small ASCII layout sketch above the code so the reader can read the composition without rendering.
-
-For Pixa prompt batches, output a markdown table:
+For Pixa work additionally include:
 
 ```
-| lessonId | title | priority | prompt |
-|---|---|---|---|
-| 78 | 反証可能性 | High | ... |
+### Prompts (4 candidates)
+v1: <prompt>
+v2: <prompt>
+v3: <prompt>
+v4: <prompt>
+negative: <shared>
+
+### Rubric (out of 25)
+| variant | metaphor | comp | atmos | brand | clean | total |
+| v1 | 5 | 4 | 3 | 4 | 5 | 21 |
+| v2 | 4 | 5 | 5 | 5 | 5 | 24 |
+| v3 | 3 | 4 | 4 | 4 | 5 | 20 |
+| v4 | 5 | 3 | 4 | 4 | 5 | 21 |
+
+**Winner**: v2 (asset_id: asset_xxx)
+
+### Saved to
+`public/images/v3/course-logic-01.png`
+
+### Wiring
+- `src/courseData.ts:46` — `image: '/images/v3/course-logic-01.png'`
+- `docs/THUMBNAILS_MANIFEST.md` — appended row
 ```
+
+For SVG work include the code block + insertion site as before.
 
 # Style
 
-- Lead with **concept tag → metaphor → palette** in three lines. Code follows. Reasoning before pixels.
-- One visual at a time unless the user explicitly asks for a batch. Designing six thumbnails in one shot dilutes the metaphor work on each.
+- Lead with **concept tag → metaphor → medium → palette/model** in 4 lines. Reasoning before pixels.
+- One visual at a time unless the user explicitly asks for a batch. Designing six in one shot dilutes the metaphor work.
+- Never accept the first Pixa generation. Always 4 candidates + rubric.
 - Be terse. No "Here's a beautiful thumbnail!" pleasantries.
-- Don't introduce new tokens, new icons, or new layout patterns. If a new primitive is genuinely needed, stop and surface that as a question to the user before designing around it.
+- Don't introduce new tokens, new icons, or new layout patterns. If a new primitive is genuinely needed, surface it as a question first.
 - Stay in the user's language (Japanese if the request is in Japanese).
-- When the user just wants a proposal, deliver code-as-text and **don't apply with Edit/Write yet**. When the user says 「適用して」/「コミットして」/「実装して」, then apply.
+- When the user just wants a proposal, deliver code-as-text and **don't apply** with Edit/Write/Pixa generation yet. When the user says 「適用して」/「コミットして」/「実装して」/「生成して」, run the loop in full.

--- a/docs/THUMBNAILS_MANIFEST.md
+++ b/docs/THUMBNAILS_MANIFEST.md
@@ -79,3 +79,31 @@ Pixaクレジット不足により以下が未生成。クレジット追加後�
 - コース定義: `src/courseData.ts`
 - 既存サムネイル: `public/images/v3/course-*.{svg,webp}`
 - Notion DB: 「Logic素材」（38555f3f-86db-4fa0-b4af-f5d907af5395）
+
+---
+
+## Pixa再生成キュー（クレジット復活後に流す）
+
+design-visualizer サブエージェントの 4 候補ループで、生成準備済みだがクレジット不足で未実行のもの。`flux-2-max` 16:9 PNG を推奨。
+
+### course-fermi-01「概算で、世界の規模を掴む」
+
+- **概念タグ**: 巨大な未知量を、知っている小さな量に分解して掴む。厳密さより速くて当たる
+- **採用判定**: 4 候補生成 → 5軸25点ルーブリック自己採点 → 18/25未満なら再生成。SVG フォールバックは `public/images/v3/course-fermi-01.svg`（デスク + 紙メモ + 鉛筆 + 暖色ランプ halo の atmospheric 版）。
+
+```
+v1 (notebook tree): Cinematic editorial illustration of a hand-drawn branching decomposition diagram unfolding from an open worn leather notebook on a dark wooden study desk; the tree's nodes are abstract leaf-like shapes, no legible characters; warm amber desk lamp glow from upper-right casting soft directional light and long shadows; faint paper grain visible on the page; soft graphite pencil and brass eraser resting on the page; deep slate blue shadows with amber highlights; painterly brushwork, layered translucent washes, atmospheric depth; intimate composition, focused thinking mood, 16:9 horizontal. No text, no letters, no numbers, no watermark, no humans, no faces, no hands, no anime, no 3D render.
+
+v2 (city skyline overlay): Editorial painterly illustration of a misty Tokyo-style skyline at dawn seen through a translucent overlay of a hand-drawn decomposition tree etched in faint indigo lines; tree branches connect rooftops to ground level; warm amber sunrise glow on horizon, deep slate blue mid-tones; soft mist obscures details; aerial bird's-eye angle, cinematic depth, paper texture overlay, 16:9 horizontal. No text, no letters, no numbers, no watermark, no humans, no faces, no anime, no 3D render.
+
+v3 (still life with notebook + scale): Cinematic still-life of a leather notebook lying open on a wooden study desk, faint pencil sketch of a fanning estimation diagram visible on the page; small brass two-pan balance scale in soft focus background; slate blue evening light from a single window, warm tea cup glow on the right; painterly editorial style, paper grain, brush strokes visible, layered shadows, intimate composition, 16:9 horizontal. No text, no letters, no numbers, no watermark, no humans, no faces, no hands, no anime, no 3D render.
+
+v4 (chalkboard contemplation): Editorial illustration of a vintage chalkboard slate with a ghost-like decomposition tree drawn in chalk dust, slowly being erased; atmosphere of contemplative thought; deep navy backdrop, warm amber spotlight from upper-left, faint amber rim-light on the slate edge; painterly brushwork, dust particles in the light beam, paper-grain overlay; cinematic depth, 16:9 horizontal. No text, no letters, no numbers, no watermark, no humans, no faces, no hands, no anime, no 3D render.
+```
+
+採用後は:
+1. `mcp__...__get_download_url` で URL を取得
+2. `public/images/v3/course-fermi-01.png` で保存
+3. `src/courseData.ts` の `image:` を `.svg` → `.png` に切替
+4. このセクションに asset_id と勝者を追記
+

--- a/public/images/v3/course-fermi-01.svg
+++ b/public/images/v3/course-fermi-01.svg
@@ -54,14 +54,14 @@
   <rect width="800" height="400" filter="url(#grain-f1)" opacity="0.55"/>
 
   <!-- Faded background globe (blueprint memory of "world scale") -->
-  <g transform="translate(660,110)" opacity="0.55" filter="url(#softBlur-f1)">
-    <circle cx="0" cy="0" r="86" fill="url(#globe-f1)"/>
-    <g fill="none" stroke="#7AAEFF" stroke-width="0.8" opacity="0.55">
-      <ellipse cx="0" cy="0" rx="86" ry="28"/>
-      <ellipse cx="0" cy="0" rx="86" ry="58"/>
-      <ellipse cx="0" cy="0" rx="28" ry="86"/>
-      <ellipse cx="0" cy="0" rx="58" ry="86"/>
-      <line x1="-86" y1="0" x2="86" y2="0"/>
+  <g transform="translate(125,115)" opacity="0.7" filter="url(#softBlur-f1)">
+    <circle cx="0" cy="0" r="92" fill="url(#globe-f1)"/>
+    <g fill="none" stroke="#7AAEFF" stroke-width="0.9" opacity="0.6">
+      <ellipse cx="0" cy="0" rx="92" ry="30"/>
+      <ellipse cx="0" cy="0" rx="92" ry="62"/>
+      <ellipse cx="0" cy="0" rx="30" ry="92"/>
+      <ellipse cx="0" cy="0" rx="62" ry="92"/>
+      <line x1="-92" y1="0" x2="92" y2="0"/>
     </g>
   </g>
 
@@ -122,12 +122,11 @@
           stroke="#C49A3C" stroke-width="1.8" opacity="0.85"
           stroke-linecap="round" stroke-dasharray="1 8"/>
 
-    <!-- Result: ≈ 62.5兆 -->
-    <g font-family="'Helvetica Neue','Hiragino Sans','Yu Gothic',sans-serif">
-      <text x="-120" y="80" text-anchor="middle" font-size="34" font-weight="700" fill="#7B2D26">≈</text>
-      <text x="35"   y="80" text-anchor="middle" font-size="34" font-weight="700" fill="#7B2D26">¥62.5</text>
-      <text x="155"  y="80" text-anchor="middle" font-size="28" font-weight="600" fill="#7B2D26">兆</text>
-    </g>
+    <!-- Result: ≈ ¥62.5兆 (centered as one unit) -->
+    <text x="0" y="82" text-anchor="middle"
+          font-family="'Helvetica Neue','Hiragino Sans','Yu Gothic',sans-serif"
+          font-size="36" font-weight="700" fill="#7B2D26"
+          letter-spacing="2">≈ ¥62.5 兆</text>
 
     <!-- Margin doodle: small circle with a dot (a lightbulb / abstract idea mark) -->
     <g stroke="#3B4258" stroke-width="0.9" fill="none" opacity="0.32">
@@ -145,22 +144,22 @@
     </g>
   </g>
 
-  <!-- Pencil resting on lower-right, partially overlapping paper -->
-  <g transform="translate(580,318) rotate(28)">
-    <!-- Wood body -->
-    <rect x="-78" y="-5" width="125" height="9" rx="1.5" fill="url(#pencil-f1)"/>
-    <!-- Eraser end (warm amber) -->
-    <rect x="-86" y="-5" width="9"  height="9" rx="1.8" fill="#C49A3C"/>
-    <!-- Metal ferrule -->
-    <rect x="-77" y="-5" width="3"  height="9" fill="#A89466"/>
-    <!-- Wood tip -->
-    <polygon points="47,-5 47,4 67,0" fill="#A89466"/>
-    <!-- Graphite tip -->
-    <polygon points="60,-2 60,1 67,0" fill="#1A2238"/>
-    <!-- Highlight stripe -->
-    <line x1="-74" y1="-3" x2="46" y2="-3" stroke="#FFFFFF" stroke-width="0.7" opacity="0.18"/>
+  <!-- Pencil lying on the desk below the card (out of formula's way) -->
+  <g transform="translate(610,378) rotate(18)">
     <!-- Pencil shadow -->
-    <ellipse cx="-15" cy="9" rx="55" ry="2" fill="#000000" opacity="0.35"/>
+    <ellipse cx="-12" cy="10" rx="62" ry="2.2" fill="#000000" opacity="0.4"/>
+    <!-- Wood body -->
+    <rect x="-82" y="-5" width="130" height="9" rx="1.5" fill="url(#pencil-f1)"/>
+    <!-- Eraser end (warm amber) -->
+    <rect x="-90" y="-5" width="9"  height="9" rx="1.8" fill="#C49A3C"/>
+    <!-- Metal ferrule -->
+    <rect x="-81" y="-5" width="3"  height="9" fill="#A89466"/>
+    <!-- Wood tip -->
+    <polygon points="48,-5 48,4 68,0" fill="#A89466"/>
+    <!-- Graphite tip -->
+    <polygon points="61,-2 61,1 68,0" fill="#1A2238"/>
+    <!-- Highlight stripe -->
+    <line x1="-78" y1="-3" x2="47" y2="-3" stroke="#FFFFFF" stroke-width="0.7" opacity="0.18"/>
   </g>
 
   <!-- Eraser shavings / desk dust -->

--- a/public/images/v3/course-fermi-01.svg
+++ b/public/images/v3/course-fermi-01.svg
@@ -1,83 +1,175 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
   <defs>
-    <linearGradient id="bg-f1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#1F2942"/>
-      <stop offset="100%" stop-color="#101729"/>
+    <linearGradient id="desk-f1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1A2238"/>
+      <stop offset="55%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#0E1424"/>
     </linearGradient>
-    <radialGradient id="globe-f1" cx="0.4" cy="0.35" r="0.65">
-      <stop offset="0%" stop-color="#7AAEFF"/>
-      <stop offset="60%" stop-color="#3B5BBF"/>
-      <stop offset="100%" stop-color="#1B2954"/>
+    <radialGradient id="lamp-f1" cx="0.86" cy="0.14" r="0.7">
+      <stop offset="0%" stop-color="#F4D26A" stop-opacity="0.42"/>
+      <stop offset="35%" stop-color="#C49A3C" stop-opacity="0.20"/>
+      <stop offset="100%" stop-color="#C49A3C" stop-opacity="0"/>
     </radialGradient>
-    <radialGradient id="glow-f1" cx="0.5" cy="0.5" r="0.5">
-      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    <linearGradient id="paper-f1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F5EBC8"/>
+      <stop offset="100%" stop-color="#DFCEA0"/>
+    </linearGradient>
+    <linearGradient id="pencil-f1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3B5BBF"/>
+      <stop offset="100%" stop-color="#1F3275"/>
+    </linearGradient>
+    <radialGradient id="globe-f1" cx="0.4" cy="0.35" r="0.7">
+      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.55"/>
+      <stop offset="60%" stop-color="#3B5BBF" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#1B2954" stop-opacity="0.08"/>
     </radialGradient>
+
+    <filter id="grain-f1" x="0%" y="0%" width="100%" height="100%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="3"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.42  0 0 0 0 0.36  0 0 0 0 0.27  0 0 0 0.20 0"/>
+      <feComposite operator="in" in2="SourceGraphic"/>
+    </filter>
+    <filter id="paperGrain-f1" x="0%" y="0%" width="100%" height="100%">
+      <feTurbulence type="fractalNoise" baseFrequency="1.2" numOctaves="2" seed="7"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.55  0 0 0 0 0.46  0 0 0 0 0.30  0 0 0 0.18 0"/>
+      <feComposite operator="in" in2="SourceGraphic"/>
+    </filter>
+    <filter id="cardShadow-f1" x="-15%" y="-15%" width="130%" height="135%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="9"/>
+      <feOffset dx="0" dy="10"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="softBlur-f1">
+      <feGaussianBlur stdDeviation="2.5"/>
+    </filter>
   </defs>
 
-  <rect width="800" height="400" fill="url(#bg-f1)"/>
-  <circle cx="400" cy="200" r="280" fill="url(#glow-f1)"/>
+  <!-- Desk base + warm lamp halo + grain -->
+  <rect width="800" height="400" fill="url(#desk-f1)"/>
+  <rect width="800" height="400" fill="url(#lamp-f1)"/>
+  <rect width="800" height="400" filter="url(#grain-f1)" opacity="0.55"/>
 
-  <!-- 地球（中央） -->
-  <g transform="translate(400,210)">
-    <!-- 影 -->
-    <ellipse cx="0" cy="124" rx="124" ry="14" fill="#0B1424" opacity="0.7"/>
-    <!-- 本体 -->
-    <circle cx="0" cy="0" r="118" fill="url(#globe-f1)"/>
-    <!-- 経緯線 -->
-    <g fill="none" stroke="#7AAEFF" stroke-width="1" opacity="0.5">
-      <ellipse cx="0" cy="0" rx="118" ry="40"/>
-      <ellipse cx="0" cy="0" rx="118" ry="80"/>
-      <ellipse cx="0" cy="0" rx="40" ry="118"/>
-      <ellipse cx="0" cy="0" rx="80" ry="118"/>
-      <line x1="-118" y1="0" x2="118" y2="0"/>
-    </g>
-    <!-- 大陸（簡略化） -->
-    <g fill="#C49A3C" opacity="0.7">
-      <path d="M -50 -40 Q -40 -50 -20 -45 Q -10 -38 -20 -25 Q -40 -22 -55 -30 Z"/>
-      <path d="M 10 -10 Q 30 -20 50 -10 Q 60 5 50 18 Q 30 22 15 14 Z"/>
-      <path d="M -30 30 Q -10 28 0 40 Q -8 56 -28 52 Q -42 44 -38 36 Z"/>
-      <path d="M 60 -50 Q 78 -52 84 -42 Q 80 -34 66 -38 Z"/>
-    </g>
-    <!-- ハイライト -->
-    <ellipse cx="-40" cy="-50" rx="40" ry="30" fill="#F4ECC4" opacity="0.18"/>
-  </g>
-
-  <!-- 浮かぶ概算式（吹き出し） -->
-  <g font-family="'SF Pro Display','Helvetica Neue',sans-serif" font-weight="700">
-    <!-- 左上：人口 -->
-    <g transform="translate(140,90)">
-      <rect x="-58" y="-22" width="116" height="44" rx="6" fill="#1A2540" stroke="#FFD566" stroke-width="1.4"/>
-      <text x="0" y="-3" text-anchor="middle" font-size="11" fill="#7AAEFF" opacity="0.85">人口</text>
-      <text x="0" y="14" text-anchor="middle" font-size="14" fill="#FFD566">1.25 億</text>
-    </g>
-    <!-- 右上：1人あたり -->
-    <g transform="translate(660,90)">
-      <rect x="-58" y="-22" width="116" height="44" rx="6" fill="#1A2540" stroke="#FFD566" stroke-width="1.4"/>
-      <text x="0" y="-3" text-anchor="middle" font-size="11" fill="#7AAEFF" opacity="0.85">1人/年</text>
-      <text x="0" y="14" text-anchor="middle" font-size="14" fill="#FFD566">¥ 50万</text>
-    </g>
-    <!-- 下：合計 -->
-    <g transform="translate(400,360)">
-      <rect x="-90" y="-22" width="180" height="44" rx="6" fill="#1A2540" stroke="#C49A3C" stroke-width="1.6"/>
-      <text x="0" y="-3" text-anchor="middle" font-size="11" fill="#C49A3C" opacity="0.85">≒ 市場規模</text>
-      <text x="0" y="14" text-anchor="middle" font-size="16" fill="#FFD566">¥ 62.5 兆</text>
+  <!-- Faded background globe (blueprint memory of "world scale") -->
+  <g transform="translate(660,110)" opacity="0.55" filter="url(#softBlur-f1)">
+    <circle cx="0" cy="0" r="86" fill="url(#globe-f1)"/>
+    <g fill="none" stroke="#7AAEFF" stroke-width="0.8" opacity="0.55">
+      <ellipse cx="0" cy="0" rx="86" ry="28"/>
+      <ellipse cx="0" cy="0" rx="86" ry="58"/>
+      <ellipse cx="0" cy="0" rx="28" ry="86"/>
+      <ellipse cx="0" cy="0" rx="58" ry="86"/>
+      <line x1="-86" y1="0" x2="86" y2="0"/>
     </g>
   </g>
 
-  <!-- 接続線 -->
-  <g stroke="#FFD566" stroke-width="1" stroke-dasharray="4 3" fill="none" opacity="0.6">
-    <line x1="200" y1="100" x2="304" y2="172"/>
-    <line x1="600" y1="100" x2="496" y2="172"/>
-    <line x1="400" y1="328" x2="400" y2="338"/>
+  <!-- Atmospheric dust motes inside lamp beam -->
+  <g fill="#F4D26A">
+    <circle cx="700" cy="60"  r="1.3" opacity="0.55"/>
+    <circle cx="660" cy="100" r="0.7" opacity="0.40"/>
+    <circle cx="735" cy="125" r="0.9" opacity="0.50"/>
+    <circle cx="610" cy="140" r="0.5" opacity="0.35"/>
+    <circle cx="690" cy="185" r="0.6" opacity="0.40"/>
+    <circle cx="755" cy="205" r="0.8" opacity="0.50"/>
+    <circle cx="635" cy="225" r="0.5" opacity="0.30"/>
   </g>
 
-  <g fill="#7AAEFF" opacity="0.55">
-    <circle cx="60" cy="50" r="1.4"/>
-    <circle cx="240" cy="40" r="1.0"/>
-    <circle cx="560" cy="40" r="1.2"/>
-    <circle cx="740" cy="60" r="1.4"/>
-    <circle cx="120" cy="220" r="1.0"/>
-    <circle cx="700" cy="220" r="1.2"/>
+  <!-- Paper card centered, slight tilt -->
+  <g transform="translate(400,210) rotate(-2)" filter="url(#cardShadow-f1)">
+    <rect x="-260" y="-140" width="520" height="280" rx="3" fill="url(#paper-f1)"/>
+    <rect x="-260" y="-140" width="520" height="280" rx="3" filter="url(#paperGrain-f1)" opacity="0.55"/>
+
+    <!-- Faint margin ruling -->
+    <g stroke="#A89466" stroke-width="0.4" opacity="0.18">
+      <line x1="-240" y1="-100" x2="240" y2="-100"/>
+      <line x1="-240" y1="-60"  x2="240" y2="-60"/>
+      <line x1="-240" y1="-20"  x2="240" y2="-20"/>
+      <line x1="-240" y1="20"   x2="240" y2="20"/>
+      <line x1="-240" y1="60"   x2="240" y2="60"/>
+      <line x1="-240" y1="100"  x2="240" y2="100"/>
+    </g>
+    <line x1="-220" y1="-140" x2="-220" y2="140" stroke="#B7553F" stroke-width="0.7" opacity="0.35"/>
+
+    <!-- Top: 市場規模 (target) -->
+    <g font-family="'Helvetica Neue','Hiragino Sans','Yu Gothic',sans-serif" fill="#2E374D">
+      <text x="0" y="-95" text-anchor="middle" font-size="22" font-weight="700">市場規模</text>
+
+      <!-- Hand-drawn split lines -->
+      <path d="M 0 -78 C 0 -72, -120 -65, -120 -55"
+            fill="none" stroke="#3B4258" stroke-width="1.6" stroke-linecap="round" opacity="0.7"/>
+      <path d="M 0 -78 L 0 -55"
+            fill="none" stroke="#3B4258" stroke-width="1.6" stroke-linecap="round" opacity="0.7"/>
+      <path d="M 0 -78 C 0 -72, 120 -65, 120 -55"
+            fill="none" stroke="#3B4258" stroke-width="1.6" stroke-linecap="round" opacity="0.7"/>
+
+      <!-- Branches: 人口 × 利用率 × 単価 -->
+      <text x="-120" y="-30" text-anchor="middle" font-size="17" font-weight="500">人口</text>
+      <text x="0"    y="-30" text-anchor="middle" font-size="17" font-weight="500">利用率</text>
+      <text x="120"  y="-30" text-anchor="middle" font-size="17" font-weight="500">単価</text>
+
+      <!-- × symbols -->
+      <text x="-60" y="-30" text-anchor="middle" font-size="16" font-weight="400" fill="#7B2D26" opacity="0.85">×</text>
+      <text x="60"  y="-30" text-anchor="middle" font-size="16" font-weight="400" fill="#7B2D26" opacity="0.85">×</text>
+    </g>
+
+    <!-- Equals dashed line (hand-drawn feel) -->
+    <line x1="-180" y1="20" x2="180" y2="20"
+          stroke="#C49A3C" stroke-width="1.8" opacity="0.85"
+          stroke-linecap="round" stroke-dasharray="1 8"/>
+    <line x1="-180" y1="28" x2="180" y2="28"
+          stroke="#C49A3C" stroke-width="1.8" opacity="0.85"
+          stroke-linecap="round" stroke-dasharray="1 8"/>
+
+    <!-- Result: ≈ 62.5兆 -->
+    <g font-family="'Helvetica Neue','Hiragino Sans','Yu Gothic',sans-serif">
+      <text x="-120" y="80" text-anchor="middle" font-size="34" font-weight="700" fill="#7B2D26">≈</text>
+      <text x="35"   y="80" text-anchor="middle" font-size="34" font-weight="700" fill="#7B2D26">¥62.5</text>
+      <text x="155"  y="80" text-anchor="middle" font-size="28" font-weight="600" fill="#7B2D26">兆</text>
+    </g>
+
+    <!-- Margin doodle: small circle with a dot (a lightbulb / abstract idea mark) -->
+    <g stroke="#3B4258" stroke-width="0.9" fill="none" opacity="0.32">
+      <circle cx="220" cy="-110" r="13"/>
+      <circle cx="220" cy="-110" r="8"/>
+      <line x1="220" y1="-123" x2="220" y2="-97"/>
+      <line x1="207" y1="-110" x2="233" y2="-110"/>
+    </g>
+
+    <!-- Pencil tick marks at lower-left of card -->
+    <g stroke="#3B4258" stroke-width="0.9" fill="none" opacity="0.4">
+      <line x1="-220" y1="105" x2="-200" y2="105"/>
+      <line x1="-220" y1="115" x2="-208" y2="115"/>
+      <line x1="-220" y1="125" x2="-204" y2="125"/>
+    </g>
+  </g>
+
+  <!-- Pencil resting on lower-right, partially overlapping paper -->
+  <g transform="translate(580,318) rotate(28)">
+    <!-- Wood body -->
+    <rect x="-78" y="-5" width="125" height="9" rx="1.5" fill="url(#pencil-f1)"/>
+    <!-- Eraser end (warm amber) -->
+    <rect x="-86" y="-5" width="9"  height="9" rx="1.8" fill="#C49A3C"/>
+    <!-- Metal ferrule -->
+    <rect x="-77" y="-5" width="3"  height="9" fill="#A89466"/>
+    <!-- Wood tip -->
+    <polygon points="47,-5 47,4 67,0" fill="#A89466"/>
+    <!-- Graphite tip -->
+    <polygon points="60,-2 60,1 67,0" fill="#1A2238"/>
+    <!-- Highlight stripe -->
+    <line x1="-74" y1="-3" x2="46" y2="-3" stroke="#FFFFFF" stroke-width="0.7" opacity="0.18"/>
+    <!-- Pencil shadow -->
+    <ellipse cx="-15" cy="9" rx="55" ry="2" fill="#000000" opacity="0.35"/>
+  </g>
+
+  <!-- Eraser shavings / desk dust -->
+  <g fill="#C49A3C">
+    <circle cx="180" cy="350" r="1.4" opacity="0.55"/>
+    <circle cx="195" cy="358" r="1.0" opacity="0.45"/>
+    <circle cx="172" cy="365" r="0.8" opacity="0.40"/>
+    <circle cx="650" cy="358" r="1.0" opacity="0.50"/>
+    <circle cx="635" cy="350" r="0.7" opacity="0.40"/>
+    <circle cx="668" cy="346" r="0.5" opacity="0.30"/>
   </g>
 </svg>

--- a/public/images/v3/course-fermi-01.svg
+++ b/public/images/v3/course-fermi-01.svg
@@ -1,523 +1,270 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
   <defs>
-    <!-- Sky: deep navy → warm amber horizon (twilight) -->
-    <linearGradient id="sky-f1" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%"  stop-color="#0B1024"/>
-      <stop offset="40%" stop-color="#1F2942"/>
-      <stop offset="68%" stop-color="#3F416B"/>
-      <stop offset="85%" stop-color="#A85F3B"/>
-      <stop offset="100%" stop-color="#E8965D"/>
+    <linearGradient id="desk-f1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1A2238"/>
+      <stop offset="55%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#0E1424"/>
     </linearGradient>
-
-    <!-- Sun glow (sinking behind horizon, right side) -->
-    <radialGradient id="sun-f1" cx="0.78" cy="0.85" r="0.45">
-      <stop offset="0%"  stop-color="#F4D26A" stop-opacity="0.95"/>
-      <stop offset="22%" stop-color="#F4A261" stop-opacity="0.55"/>
-      <stop offset="55%" stop-color="#A85F3B" stop-opacity="0.18"/>
-      <stop offset="100%" stop-color="#A85F3B" stop-opacity="0"/>
+    <radialGradient id="lamp-f1" cx="0.86" cy="0.14" r="0.72">
+      <stop offset="0%"  stop-color="#F4D26A" stop-opacity="0.48"/>
+      <stop offset="32%" stop-color="#C49A3C" stop-opacity="0.22"/>
+      <stop offset="100%" stop-color="#C49A3C" stop-opacity="0"/>
     </radialGradient>
 
-    <!-- Distant city: lighter slate -->
-    <linearGradient id="cityFar-f1" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%"  stop-color="#3F416B" stop-opacity="0.8"/>
-      <stop offset="100%" stop-color="#1F2942" stop-opacity="1"/>
+    <!-- Paper: directional lighting from upper-right (lamp side) -->
+    <linearGradient id="paper-f1" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%"  stop-color="#D5C58E"/>
+      <stop offset="55%" stop-color="#EFE0B0"/>
+      <stop offset="100%" stop-color="#F9F0D2"/>
     </linearGradient>
-    <!-- Mid city -->
-    <linearGradient id="cityMid-f1" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%"  stop-color="#1B2238" stop-opacity="1"/>
-      <stop offset="100%" stop-color="#0E1424" stop-opacity="1"/>
-    </linearGradient>
-    <!-- Near city -->
-    <linearGradient id="cityNear-f1" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%"  stop-color="#0F1530" stop-opacity="1"/>
-      <stop offset="100%" stop-color="#070914" stop-opacity="1"/>
-    </linearGradient>
-
-    <!-- Ground reflection / foreground floor -->
-    <linearGradient id="floor-f1" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%"  stop-color="#0E1424"/>
-      <stop offset="100%" stop-color="#040714"/>
-    </linearGradient>
-
-    <!-- Atmospheric haze near horizon -->
-    <linearGradient id="haze-f1" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%"  stop-color="#E8965D" stop-opacity="0"/>
-      <stop offset="50%" stop-color="#A85F3B" stop-opacity="0.32"/>
-      <stop offset="100%" stop-color="#3F416B" stop-opacity="0"/>
-    </linearGradient>
-
-    <!-- Decomposition tree glow -->
-    <radialGradient id="nodeGlow-f1" cx="0.5" cy="0.5" r="0.5">
-      <stop offset="0%"  stop-color="#7AAEFF" stop-opacity="1"/>
-      <stop offset="55%" stop-color="#3B5BBF" stop-opacity="0.4"/>
-      <stop offset="100%" stop-color="#3B5BBF" stop-opacity="0"/>
+    <!-- Warm cast on right side of paper (lamp bleed) -->
+    <radialGradient id="paperWarm-f1" cx="0.95" cy="0.05" r="0.95">
+      <stop offset="0%"  stop-color="#F4D26A" stop-opacity="0.35"/>
+      <stop offset="60%" stop-color="#F4D26A" stop-opacity="0.05"/>
+      <stop offset="100%" stop-color="#F4D26A" stop-opacity="0"/>
     </radialGradient>
-    <radialGradient id="rootGlow-f1" cx="0.5" cy="0.5" r="0.5">
-      <stop offset="0%"  stop-color="#F4D26A" stop-opacity="1"/>
-      <stop offset="50%" stop-color="#F4A261" stop-opacity="0.5"/>
-      <stop offset="100%" stop-color="#F4A261" stop-opacity="0"/>
+
+    <linearGradient id="pencil-f1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%"  stop-color="#4A6BCB"/>
+      <stop offset="50%" stop-color="#3B5BBF"/>
+      <stop offset="100%" stop-color="#1F3275"/>
+    </linearGradient>
+    <radialGradient id="globe-f1" cx="0.4" cy="0.35" r="0.7">
+      <stop offset="0%"  stop-color="#7AAEFF" stop-opacity="0.6"/>
+      <stop offset="55%" stop-color="#3B5BBF" stop-opacity="0.32"/>
+      <stop offset="100%" stop-color="#1B2954" stop-opacity="0.08"/>
     </radialGradient>
+
+    <!-- Diagonal light rays from upper-right -->
+    <linearGradient id="ray-f1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%"   stop-color="#F4D26A" stop-opacity="0.18"/>
+      <stop offset="40%"  stop-color="#F4D26A" stop-opacity="0.06"/>
+      <stop offset="100%" stop-color="#F4D26A" stop-opacity="0"/>
+    </linearGradient>
 
     <filter id="grain-f1" x="0%" y="0%" width="100%" height="100%">
       <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="3"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0.42  0 0 0 0 0.36  0 0 0 0 0.27  0 0 0 0.12 0"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.42  0 0 0 0 0.36  0 0 0 0 0.27  0 0 0 0.20 0"/>
       <feComposite operator="in" in2="SourceGraphic"/>
     </filter>
-    <filter id="softGlow-f1" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="3"/>
+    <filter id="paperGrain-f1" x="0%" y="0%" width="100%" height="100%">
+      <feTurbulence type="fractalNoise" baseFrequency="1.2" numOctaves="2" seed="7"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.55  0 0 0 0 0.46  0 0 0 0 0.30  0 0 0 0.20 0"/>
+      <feComposite operator="in" in2="SourceGraphic"/>
     </filter>
-    <filter id="strongGlow-f1" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="6"/>
+    <filter id="cardShadow-f1" x="-15%" y="-15%" width="130%" height="135%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="10"/>
+      <feOffset dx="0" dy="12"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.6"/></feComponentTransfer>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cityHaze-f1">
-      <feGaussianBlur stdDeviation="0.6"/>
-    </filter>
+    <filter id="softBlur-f1"><feGaussianBlur stdDeviation="2.5"/></filter>
+    <filter id="microBlur-f1"><feGaussianBlur stdDeviation="0.6"/></filter>
+
+    <!-- Wavy paper edge as a clip path so grain stays inside -->
+    <clipPath id="paperShape-f1">
+      <path d="
+        M -262 -136
+        C -200 -141, -100 -138, 0 -140
+        C 100 -142, 200 -139, 261 -135
+        C 264 -80, 263 -10, 264 60
+        C 265 100, 264 130, 260 138
+        C 200 141, 100 137, 0 138
+        C -100 139, -200 142, -262 138
+        C -264 80, -263 10, -264 -60
+        C -265 -100, -264 -120, -262 -136
+        Z"/>
+    </clipPath>
   </defs>
 
-  <!-- ───────────── Layer 1: Sky ───────────── -->
-  <rect width="800" height="400" fill="url(#sky-f1)"/>
-  <!-- Sun bloom -->
-  <rect width="800" height="400" fill="url(#sun-f1)"/>
+  <!-- Desk base + warm lamp halo + grain -->
+  <rect width="800" height="400" fill="url(#desk-f1)"/>
+  <rect width="800" height="400" fill="url(#lamp-f1)"/>
 
-  <!-- Stars -->
-  <g fill="#F4ECCC">
-    <circle cx="80"  cy="40"  r="1.0" opacity="0.85"/>
-    <circle cx="160" cy="22"  r="0.6" opacity="0.6"/>
-    <circle cx="240" cy="56"  r="1.2" opacity="0.9"/>
-    <circle cx="320" cy="36"  r="0.7" opacity="0.55"/>
-    <circle cx="50"  cy="90"  r="0.8" opacity="0.7"/>
-    <circle cx="200" cy="100" r="0.5" opacity="0.4"/>
-    <circle cx="120" cy="60"  r="0.6" opacity="0.5"/>
-    <circle cx="430" cy="30"  r="0.7" opacity="0.6"/>
-    <circle cx="540" cy="70"  r="0.5" opacity="0.4"/>
-    <circle cx="380" cy="80"  r="0.4" opacity="0.35"/>
+  <!-- Diagonal light rays from upper-right corner -->
+  <g opacity="0.85">
+    <polygon points="800,0 800,80 250,400 180,400" fill="url(#ray-f1)"/>
+    <polygon points="800,40 800,140 380,400 310,400" fill="url(#ray-f1)" opacity="0.7"/>
+    <polygon points="800,120 800,220 520,400 460,400" fill="url(#ray-f1)" opacity="0.5"/>
   </g>
 
-  <!-- Crescent moon (upper-left) -->
-  <g transform="translate(95,80)" opacity="0.85">
-    <circle cx="0" cy="0" r="14" fill="#F4ECCC" opacity="0.92"/>
-    <circle cx="5" cy="-3" r="13" fill="#0B1024"/>
+  <rect width="800" height="400" filter="url(#grain-f1)" opacity="0.55"/>
+
+  <!-- Faded background globe with land masses (blueprint memory of "world scale") -->
+  <g transform="translate(125,118)" opacity="0.72">
+    <g filter="url(#softBlur-f1)">
+      <circle cx="0" cy="0" r="92" fill="url(#globe-f1)"/>
+    </g>
+    <g fill="none" stroke="#7AAEFF" stroke-width="0.9" opacity="0.55">
+      <ellipse cx="0" cy="0" rx="92" ry="30"/>
+      <ellipse cx="0" cy="0" rx="92" ry="62"/>
+      <ellipse cx="0" cy="0" rx="30" ry="92"/>
+      <ellipse cx="0" cy="0" rx="62" ry="92"/>
+      <line x1="-92" y1="0" x2="92" y2="0"/>
+    </g>
+    <!-- Continent silhouettes (abstract) -->
+    <g fill="#7AAEFF" opacity="0.32" filter="url(#microBlur-f1)">
+      <path d="M -38 -32 Q -28 -42, -10 -36 Q -2 -28, -14 -18 Q -32 -16, -42 -22 Z"/>
+      <path d="M 12 -8 Q 32 -16, 48 -6 Q 54 6, 44 16 Q 26 20, 14 12 Z"/>
+      <path d="M -22 26 Q -6 22, 0 36 Q -6 50, -22 46 Q -34 38, -30 30 Z"/>
+      <path d="M 50 -42 Q 64 -44, 68 -36 Q 64 -28, 52 -32 Z"/>
+    </g>
   </g>
 
-  <!-- ───────────── Layer 2: Atmospheric haze on horizon ───────────── -->
-  <rect x="0" y="170" width="800" height="100" fill="url(#haze-f1)"/>
-
-  <!-- ───────────── Layer 3: Far city (smaller, lighter) ───────────── -->
-  <g fill="url(#cityFar-f1)" filter="url(#cityHaze-f1)">
-    <rect x="20"  y="220" width="22" height="40"/>
-    <rect x="44"  y="208" width="14" height="52"/>
-    <rect x="60"  y="218" width="20" height="42"/>
-    <rect x="84"  y="200" width="18" height="60"/>
-    <rect x="106" y="214" width="16" height="46"/>
-    <rect x="126" y="196" width="22" height="64"/>
-    <rect x="152" y="208" width="14" height="52"/>
-    <rect x="170" y="216" width="20" height="44"/>
-    <rect x="194" y="200" width="18" height="60"/>
-    <rect x="216" y="214" width="14" height="46"/>
-    <rect x="234" y="206" width="22" height="54"/>
-    <rect x="260" y="216" width="14" height="44"/>
-    <rect x="278" y="198" width="18" height="62"/>
-    <rect x="300" y="212" width="16" height="48"/>
-    <rect x="320" y="204" width="20" height="56"/>
-    <rect x="344" y="218" width="14" height="42"/>
-    <rect x="362" y="202" width="22" height="58"/>
-    <rect x="388" y="214" width="16" height="46"/>
-    <rect x="408" y="208" width="20" height="52"/>
-    <rect x="432" y="218" width="14" height="42"/>
-    <rect x="450" y="206" width="20" height="54"/>
-    <rect x="474" y="216" width="16" height="44"/>
-    <rect x="494" y="200" width="22" height="60"/>
-    <rect x="520" y="214" width="14" height="46"/>
-    <rect x="538" y="206" width="18" height="54"/>
-    <rect x="560" y="218" width="20" height="42"/>
-    <rect x="584" y="204" width="16" height="56"/>
-    <rect x="604" y="216" width="22" height="44"/>
-    <rect x="630" y="208" width="14" height="52"/>
-    <rect x="648" y="200" width="20" height="60"/>
-    <rect x="672" y="218" width="14" height="42"/>
-    <rect x="690" y="212" width="18" height="48"/>
-    <rect x="712" y="220" width="16" height="40"/>
-    <rect x="732" y="208" width="22" height="52"/>
-    <rect x="758" y="218" width="14" height="42"/>
-    <rect x="776" y="206" width="20" height="54"/>
-  </g>
-
-  <!-- Far-city scattered windows (warm amber) -->
+  <!-- Atmospheric dust motes inside lamp beam -->
   <g fill="#F4D26A">
-    <circle cx="32"  cy="232" r="0.6" opacity="0.7"/>
-    <circle cx="50"  cy="220" r="0.5" opacity="0.6"/>
-    <circle cx="92"  cy="218" r="0.6" opacity="0.7"/>
-    <circle cx="135" cy="208" r="0.5" opacity="0.6"/>
-    <circle cx="160" cy="225" r="0.6" opacity="0.65"/>
-    <circle cx="200" cy="216" r="0.5" opacity="0.55"/>
-    <circle cx="245" cy="222" r="0.6" opacity="0.7"/>
-    <circle cx="285" cy="212" r="0.5" opacity="0.55"/>
-    <circle cx="328" cy="220" r="0.6" opacity="0.65"/>
-    <circle cx="370" cy="218" r="0.5" opacity="0.55"/>
-    <circle cx="415" cy="225" r="0.5" opacity="0.55"/>
-    <circle cx="458" cy="218" r="0.6" opacity="0.7"/>
-    <circle cx="500" cy="212" r="0.5" opacity="0.6"/>
-    <circle cx="545" cy="220" r="0.6" opacity="0.65"/>
-    <circle cx="592" cy="216" r="0.5" opacity="0.55"/>
-    <circle cx="635" cy="222" r="0.6" opacity="0.7"/>
-    <circle cx="680" cy="222" r="0.5" opacity="0.6"/>
-    <circle cx="720" cy="232" r="0.5" opacity="0.55"/>
-    <circle cx="745" cy="220" r="0.6" opacity="0.65"/>
-    <circle cx="780" cy="218" r="0.5" opacity="0.6"/>
+    <circle cx="700" cy="55"  r="1.4" opacity="0.6"/>
+    <circle cx="660" cy="98"  r="0.7" opacity="0.42"/>
+    <circle cx="735" cy="125" r="0.9" opacity="0.55"/>
+    <circle cx="610" cy="138" r="0.5" opacity="0.35"/>
+    <circle cx="690" cy="180" r="0.6" opacity="0.42"/>
+    <circle cx="755" cy="200" r="0.8" opacity="0.55"/>
+    <circle cx="635" cy="225" r="0.5" opacity="0.32"/>
+    <circle cx="585" cy="78"  r="0.6" opacity="0.40"/>
+    <circle cx="775" cy="160" r="0.5" opacity="0.32"/>
   </g>
 
-  <!-- ───────────── Layer 4: Mid city ───────────── -->
-  <g fill="url(#cityMid-f1)">
-    <!-- Foreground / mid skyline buildings (taller, fuller) -->
-    <rect x="40"  y="240" width="38" height="120"/>
-    <rect x="82"  y="220" width="44" height="140"/>
-    <!-- Rooftop water tank on building 2 -->
-    <rect x="92"  y="210" width="14" height="10"/>
-    <rect x="130" y="260" width="36" height="100"/>
-    <rect x="170" y="232" width="42" height="128"/>
-    <!-- Stepped rooftop on building 4 -->
-    <rect x="180" y="222" width="22" height="10"/>
-    <rect x="216" y="218" width="38" height="142"/>
-    <rect x="258" y="248" width="34" height="112"/>
-    <rect x="296" y="226" width="46" height="134"/>
-    <!-- Antenna on building 7 -->
-    <line x1="319" y1="226" x2="319" y2="208" stroke="#0E1424" stroke-width="1.2"/>
-    <!-- Iconic central tower -->
-    <polygon points="370,180 386,160 386,360 354,360 354,180"/>
-    <rect x="396" y="248" width="36" height="112"/>
-    <rect x="436" y="234" width="42" height="126"/>
-    <!-- Rooftop antenna on building right of tower -->
-    <line x1="457" y1="234" x2="457" y2="218" stroke="#0E1424" stroke-width="1.2"/>
-    <rect x="482" y="220" width="38" height="140"/>
-    <!-- Dome / cylindrical top on building -->
-    <ellipse cx="501" cy="220" rx="19" ry="6"/>
-    <rect x="524" y="244" width="44" height="116"/>
-    <rect x="572" y="232" width="36" height="128"/>
-    <!-- Rooftop tank -->
-    <rect x="582" y="222" width="16" height="10"/>
-    <rect x="612" y="248" width="40" height="112"/>
-    <rect x="656" y="226" width="34" height="134"/>
-    <line x1="673" y1="226" x2="673" y2="206" stroke="#0E1424" stroke-width="1.2"/>
-    <rect x="694" y="240" width="44" height="120"/>
-    <rect x="742" y="220" width="38" height="140"/>
-    <!-- Pyramidal roof on tallest right building -->
-    <polygon points="742,220 780,220 761,204"/>
+  <!-- Paper card (centered, slight tilt) — wavy edge via path -->
+  <g transform="translate(400,210) rotate(-2)" filter="url(#cardShadow-f1)">
+    <!-- Wavy paper outline -->
+    <path d="
+      M -262 -136
+      C -200 -141, -100 -138, 0 -140
+      C 100 -142, 200 -139, 261 -135
+      C 264 -80, 263 -10, 264 60
+      C 265 100, 264 130, 260 138
+      C 200 141, 100 137, 0 138
+      C -100 139, -200 142, -262 138
+      C -264 80, -263 10, -264 -60
+      C -265 -100, -264 -120, -262 -136
+      Z" fill="url(#paper-f1)"/>
+
+    <!-- Warm light cast (top-right corner from the lamp) -->
+    <g clip-path="url(#paperShape-f1)">
+      <rect x="-265" y="-145" width="540" height="290" fill="url(#paperWarm-f1)"/>
+      <!-- Paper grain inside -->
+      <rect x="-265" y="-145" width="540" height="290" filter="url(#paperGrain-f1)" opacity="0.55"/>
+    </g>
+
+    <!-- Faint margin ruling -->
+    <g stroke="#A89466" stroke-width="0.4" opacity="0.18">
+      <line x1="-238" y1="-100" x2="238" y2="-100"/>
+      <line x1="-238" y1="-60"  x2="238" y2="-60"/>
+      <line x1="-238" y1="-20"  x2="238" y2="-20"/>
+      <line x1="-238" y1="20"   x2="238" y2="20"/>
+      <line x1="-238" y1="60"   x2="238" y2="60"/>
+      <line x1="-238" y1="100"  x2="238" y2="100"/>
+    </g>
+    <!-- Red margin line (left, slightly imperfect) -->
+    <path d="M -222 -134 C -221 -90, -223 -10, -222 60 C -221 100, -223 130, -222 136"
+          stroke="#B7553F" stroke-width="0.7" opacity="0.4" fill="none"/>
+
+    <!-- Coffee ring stain (low-left) -->
+    <g transform="translate(-185,90) rotate(-12)" opacity="0.32">
+      <circle cx="0" cy="0" r="34" fill="none" stroke="#8B5A2B" stroke-width="2.5" opacity="0.55"/>
+      <circle cx="0" cy="0" r="34" fill="none" stroke="#8B5A2B" stroke-width="0.8" opacity="0.85"/>
+      <path d="M -32 -8 A 34 34 0 0 0 28 14"
+            fill="none" stroke="#8B5A2B" stroke-width="0.6" opacity="0.4"/>
+    </g>
+
+    <!-- Header: 市場規模 + brush underline -->
+    <g font-family="'Helvetica Neue','Hiragino Sans','Yu Gothic',sans-serif" fill="#2E374D">
+      <text x="0" y="-95" text-anchor="middle" font-size="22" font-weight="700">市場規模</text>
+    </g>
+    <!-- Brush underline (single stroke, varying thickness via two layered curves) -->
+    <path d="M -56 -82 C -30 -86, 28 -83, 52 -79"
+          fill="none" stroke="#7B2D26" stroke-width="2.4" stroke-linecap="round" opacity="0.7"/>
+    <path d="M -50 -80 C -28 -82, 26 -80, 46 -78"
+          fill="none" stroke="#7B2D26" stroke-width="0.8" stroke-linecap="round" opacity="0.5"/>
+
+    <!-- Hand-drawn split lines from header to 3 children -->
+    <g fill="none" stroke="#3B4258" stroke-width="1.6" stroke-linecap="round" opacity="0.7">
+      <path d="M 0 -68 C 0 -62, -120 -55, -120 -45"/>
+      <path d="M 0 -68 L 0 -45"/>
+      <path d="M 0 -68 C 0 -62, 120 -55, 120 -45"/>
+    </g>
+
+    <!-- Branches -->
+    <g font-family="'Helvetica Neue','Hiragino Sans','Yu Gothic',sans-serif" fill="#2E374D">
+      <text x="-120" y="-22" text-anchor="middle" font-size="18" font-weight="500">人口</text>
+      <text x="0"    y="-22" text-anchor="middle" font-size="18" font-weight="500">利用率</text>
+      <text x="120"  y="-22" text-anchor="middle" font-size="18" font-weight="500">単価</text>
+      <text x="-60" y="-22" text-anchor="middle" font-size="17" font-weight="400" fill="#7B2D26" opacity="0.85">×</text>
+      <text x="60"  y="-22" text-anchor="middle" font-size="17" font-weight="400" fill="#7B2D26" opacity="0.85">×</text>
+    </g>
+
+    <!-- Equals dashed line (hand-drawn double bar) -->
+    <g stroke="#C49A3C" stroke-linecap="round" stroke-dasharray="1 8" opacity="0.85">
+      <line x1="-180" y1="22" x2="180" y2="22" stroke-width="1.8"/>
+      <line x1="-180" y1="32" x2="180" y2="32" stroke-width="1.8"/>
+    </g>
+
+    <!-- Result: ≈ ¥62.5 兆 -->
+    <text x="0" y="86" text-anchor="middle"
+          font-family="'Helvetica Neue','Hiragino Sans','Yu Gothic',sans-serif"
+          font-size="38" font-weight="700" fill="#7B2D26" letter-spacing="2">≈ ¥62.5 兆</text>
+
+    <!-- Margin doodle (top-right): magnifying-glass-style mark -->
+    <g stroke="#3B4258" stroke-width="0.9" fill="none" opacity="0.32">
+      <circle cx="222" cy="-110" r="13"/>
+      <circle cx="222" cy="-110" r="8"/>
+      <line x1="231" y1="-101" x2="240" y2="-92"/>
+    </g>
+
+    <!-- Pencil tick marks at lower-left (margin notes) -->
+    <g stroke="#3B4258" stroke-width="0.9" fill="none" opacity="0.4">
+      <line x1="-220" y1="105" x2="-198" y2="105"/>
+      <line x1="-220" y1="115" x2="-206" y2="115"/>
+      <line x1="-220" y1="125" x2="-202" y2="125"/>
+    </g>
+
+    <!-- Torn / dog-eared bottom-right corner -->
+    <g>
+      <path d="M 252 130 L 264 138 L 250 142 Z" fill="#C8B582" opacity="0.75"/>
+      <path d="M 256 134 L 262 138 L 252 141" fill="none" stroke="#8B7848" stroke-width="0.5" opacity="0.6"/>
+    </g>
   </g>
 
-  <!-- Mid-city windows (warmer, more visible) -->
-  <g fill="#F4D26A">
-    <!-- Building 1 -->
-    <circle cx="50" cy="252" r="1" opacity="0.85"/>
-    <circle cx="62" cy="252" r="0.9" opacity="0.7"/>
-    <circle cx="50" cy="270" r="0.9" opacity="0.7"/>
-    <circle cx="62" cy="270" r="1" opacity="0.85"/>
-    <circle cx="50" cy="288" r="0.9" opacity="0.65"/>
-    <circle cx="62" cy="288" r="0.9" opacity="0.7"/>
-    <circle cx="50" cy="306" r="1" opacity="0.85"/>
-    <circle cx="62" cy="306" r="0.9" opacity="0.7"/>
-    <circle cx="50" cy="324" r="0.9" opacity="0.65"/>
-    <circle cx="62" cy="324" r="0.9" opacity="0.7"/>
-    <!-- Building 2 -->
-    <circle cx="92"  cy="232" r="1" opacity="0.85"/>
-    <circle cx="104" cy="232" r="0.9" opacity="0.7"/>
-    <circle cx="116" cy="232" r="1" opacity="0.85"/>
-    <circle cx="92"  cy="250" r="0.9" opacity="0.65"/>
-    <circle cx="104" cy="250" r="1" opacity="0.85"/>
-    <circle cx="116" cy="250" r="0.9" opacity="0.7"/>
-    <circle cx="92"  cy="268" r="1" opacity="0.85"/>
-    <circle cx="104" cy="268" r="0.9" opacity="0.7"/>
-    <circle cx="116" cy="268" r="0.9" opacity="0.65"/>
-    <circle cx="92"  cy="286" r="0.9" opacity="0.65"/>
-    <circle cx="104" cy="286" r="1" opacity="0.85"/>
-    <circle cx="116" cy="286" r="0.9" opacity="0.7"/>
-    <circle cx="92"  cy="304" r="1" opacity="0.85"/>
-    <circle cx="104" cy="304" r="0.9" opacity="0.7"/>
-    <circle cx="116" cy="304" r="1" opacity="0.85"/>
-    <!-- Building 3 -->
-    <circle cx="140" cy="272" r="0.9" opacity="0.7"/>
-    <circle cx="152" cy="272" r="1" opacity="0.85"/>
-    <circle cx="140" cy="290" r="1" opacity="0.85"/>
-    <circle cx="152" cy="290" r="0.9" opacity="0.7"/>
-    <circle cx="140" cy="308" r="0.9" opacity="0.65"/>
-    <circle cx="152" cy="308" r="1" opacity="0.85"/>
-    <circle cx="140" cy="326" r="1" opacity="0.85"/>
-    <circle cx="152" cy="326" r="0.9" opacity="0.7"/>
-    <!-- Building 4 -->
-    <circle cx="180" cy="244" r="1" opacity="0.85"/>
-    <circle cx="192" cy="244" r="0.9" opacity="0.7"/>
-    <circle cx="204" cy="244" r="1" opacity="0.85"/>
-    <circle cx="180" cy="262" r="0.9" opacity="0.65"/>
-    <circle cx="192" cy="262" r="1" opacity="0.85"/>
-    <circle cx="204" cy="262" r="0.9" opacity="0.7"/>
-    <circle cx="180" cy="280" r="1" opacity="0.85"/>
-    <circle cx="192" cy="280" r="0.9" opacity="0.65"/>
-    <circle cx="204" cy="280" r="1" opacity="0.85"/>
-    <circle cx="180" cy="298" r="0.9" opacity="0.7"/>
-    <circle cx="192" cy="298" r="1" opacity="0.85"/>
-    <circle cx="204" cy="298" r="0.9" opacity="0.7"/>
-    <circle cx="180" cy="316" r="1" opacity="0.85"/>
-    <circle cx="192" cy="316" r="0.9" opacity="0.65"/>
-    <circle cx="204" cy="316" r="1" opacity="0.85"/>
-    <!-- Building 5 -->
-    <circle cx="226" cy="230" r="0.9" opacity="0.7"/>
-    <circle cx="240" cy="230" r="1" opacity="0.85"/>
-    <circle cx="226" cy="250" r="1" opacity="0.85"/>
-    <circle cx="240" cy="250" r="0.9" opacity="0.7"/>
-    <circle cx="226" cy="270" r="0.9" opacity="0.65"/>
-    <circle cx="240" cy="270" r="1" opacity="0.85"/>
-    <circle cx="226" cy="290" r="1" opacity="0.85"/>
-    <circle cx="240" cy="290" r="0.9" opacity="0.7"/>
-    <circle cx="226" cy="310" r="0.9" opacity="0.7"/>
-    <circle cx="240" cy="310" r="1" opacity="0.85"/>
-    <!-- Building 6 -->
-    <circle cx="268" cy="260" r="1" opacity="0.85"/>
-    <circle cx="280" cy="260" r="0.9" opacity="0.7"/>
-    <circle cx="268" cy="280" r="0.9" opacity="0.65"/>
-    <circle cx="280" cy="280" r="1" opacity="0.85"/>
-    <circle cx="268" cy="300" r="1" opacity="0.85"/>
-    <circle cx="280" cy="300" r="0.9" opacity="0.7"/>
-    <circle cx="268" cy="320" r="0.9" opacity="0.65"/>
-    <circle cx="280" cy="320" r="1" opacity="0.85"/>
-    <!-- Building 7 -->
-    <circle cx="306" cy="240" r="0.9" opacity="0.7"/>
-    <circle cx="318" cy="240" r="1" opacity="0.85"/>
-    <circle cx="332" cy="240" r="0.9" opacity="0.7"/>
-    <circle cx="306" cy="258" r="1" opacity="0.85"/>
-    <circle cx="318" cy="258" r="0.9" opacity="0.65"/>
-    <circle cx="332" cy="258" r="1" opacity="0.85"/>
-    <circle cx="306" cy="276" r="0.9" opacity="0.7"/>
-    <circle cx="318" cy="276" r="1" opacity="0.85"/>
-    <circle cx="332" cy="276" r="0.9" opacity="0.7"/>
-    <circle cx="306" cy="294" r="1" opacity="0.85"/>
-    <circle cx="318" cy="294" r="0.9" opacity="0.65"/>
-    <circle cx="332" cy="294" r="1" opacity="0.85"/>
-    <circle cx="306" cy="312" r="0.9" opacity="0.7"/>
-    <circle cx="318" cy="312" r="1" opacity="0.85"/>
-    <circle cx="332" cy="312" r="0.9" opacity="0.7"/>
-    <!-- Buildings to the right -->
-    <circle cx="406" cy="262" r="1" opacity="0.85"/>
-    <circle cx="418" cy="262" r="0.9" opacity="0.7"/>
-    <circle cx="406" cy="282" r="0.9" opacity="0.65"/>
-    <circle cx="418" cy="282" r="1" opacity="0.85"/>
-    <circle cx="406" cy="302" r="1" opacity="0.85"/>
-    <circle cx="418" cy="302" r="0.9" opacity="0.7"/>
-    <circle cx="406" cy="322" r="0.9" opacity="0.65"/>
-    <circle cx="418" cy="322" r="1" opacity="0.85"/>
-    <circle cx="446" cy="248" r="0.9" opacity="0.7"/>
-    <circle cx="458" cy="248" r="1" opacity="0.85"/>
-    <circle cx="470" cy="248" r="0.9" opacity="0.7"/>
-    <circle cx="446" cy="268" r="1" opacity="0.85"/>
-    <circle cx="458" cy="268" r="0.9" opacity="0.65"/>
-    <circle cx="470" cy="268" r="1" opacity="0.85"/>
-    <circle cx="446" cy="288" r="0.9" opacity="0.7"/>
-    <circle cx="458" cy="288" r="1" opacity="0.85"/>
-    <circle cx="470" cy="288" r="0.9" opacity="0.7"/>
-    <circle cx="446" cy="308" r="1" opacity="0.85"/>
-    <circle cx="458" cy="308" r="0.9" opacity="0.65"/>
-    <circle cx="470" cy="308" r="1" opacity="0.85"/>
-    <circle cx="446" cy="328" r="0.9" opacity="0.7"/>
-    <circle cx="458" cy="328" r="1" opacity="0.85"/>
-    <circle cx="470" cy="328" r="0.9" opacity="0.7"/>
-    <!-- Mid-right buildings -->
-    <circle cx="492" cy="232" r="1" opacity="0.85"/>
-    <circle cx="506" cy="232" r="0.9" opacity="0.7"/>
-    <circle cx="492" cy="252" r="0.9" opacity="0.65"/>
-    <circle cx="506" cy="252" r="1" opacity="0.85"/>
-    <circle cx="492" cy="272" r="1" opacity="0.85"/>
-    <circle cx="506" cy="272" r="0.9" opacity="0.7"/>
-    <circle cx="492" cy="292" r="0.9" opacity="0.65"/>
-    <circle cx="506" cy="292" r="1" opacity="0.85"/>
-    <circle cx="492" cy="312" r="1" opacity="0.85"/>
-    <circle cx="506" cy="312" r="0.9" opacity="0.7"/>
-    <circle cx="534" cy="258" r="0.9" opacity="0.7"/>
-    <circle cx="548" cy="258" r="1" opacity="0.85"/>
-    <circle cx="562" cy="258" r="0.9" opacity="0.7"/>
-    <circle cx="534" cy="278" r="1" opacity="0.85"/>
-    <circle cx="548" cy="278" r="0.9" opacity="0.65"/>
-    <circle cx="562" cy="278" r="1" opacity="0.85"/>
-    <circle cx="534" cy="298" r="0.9" opacity="0.7"/>
-    <circle cx="548" cy="298" r="1" opacity="0.85"/>
-    <circle cx="562" cy="298" r="0.9" opacity="0.7"/>
-    <circle cx="534" cy="318" r="1" opacity="0.85"/>
-    <circle cx="548" cy="318" r="0.9" opacity="0.65"/>
-    <circle cx="562" cy="318" r="1" opacity="0.85"/>
-    <circle cx="582" cy="244" r="0.9" opacity="0.7"/>
-    <circle cx="594" cy="244" r="1" opacity="0.85"/>
-    <circle cx="582" cy="264" r="1" opacity="0.85"/>
-    <circle cx="594" cy="264" r="0.9" opacity="0.7"/>
-    <circle cx="582" cy="284" r="0.9" opacity="0.65"/>
-    <circle cx="594" cy="284" r="1" opacity="0.85"/>
-    <circle cx="582" cy="304" r="1" opacity="0.85"/>
-    <circle cx="594" cy="304" r="0.9" opacity="0.7"/>
-    <circle cx="582" cy="324" r="0.9" opacity="0.7"/>
-    <circle cx="594" cy="324" r="1" opacity="0.85"/>
-    <!-- Far right buildings -->
-    <circle cx="622" cy="260" r="1" opacity="0.85"/>
-    <circle cx="634" cy="260" r="0.9" opacity="0.7"/>
-    <circle cx="622" cy="280" r="0.9" opacity="0.65"/>
-    <circle cx="634" cy="280" r="1" opacity="0.85"/>
-    <circle cx="622" cy="300" r="1" opacity="0.85"/>
-    <circle cx="634" cy="300" r="0.9" opacity="0.7"/>
-    <circle cx="622" cy="320" r="0.9" opacity="0.65"/>
-    <circle cx="634" cy="320" r="1" opacity="0.85"/>
-    <circle cx="664" cy="240" r="0.9" opacity="0.7"/>
-    <circle cx="676" cy="240" r="1" opacity="0.85"/>
-    <circle cx="664" cy="260" r="1" opacity="0.85"/>
-    <circle cx="676" cy="260" r="0.9" opacity="0.65"/>
-    <circle cx="664" cy="280" r="0.9" opacity="0.7"/>
-    <circle cx="676" cy="280" r="1" opacity="0.85"/>
-    <circle cx="664" cy="300" r="1" opacity="0.85"/>
-    <circle cx="676" cy="300" r="0.9" opacity="0.7"/>
-    <circle cx="664" cy="320" r="0.9" opacity="0.65"/>
-    <circle cx="676" cy="320" r="1" opacity="0.85"/>
-    <circle cx="704" cy="252" r="1" opacity="0.85"/>
-    <circle cx="716" cy="252" r="0.9" opacity="0.7"/>
-    <circle cx="728" cy="252" r="1" opacity="0.85"/>
-    <circle cx="704" cy="272" r="0.9" opacity="0.65"/>
-    <circle cx="716" cy="272" r="1" opacity="0.85"/>
-    <circle cx="728" cy="272" r="0.9" opacity="0.7"/>
-    <circle cx="704" cy="292" r="1" opacity="0.85"/>
-    <circle cx="716" cy="292" r="0.9" opacity="0.7"/>
-    <circle cx="728" cy="292" r="1" opacity="0.85"/>
-    <circle cx="704" cy="312" r="0.9" opacity="0.65"/>
-    <circle cx="716" cy="312" r="1" opacity="0.85"/>
-    <circle cx="728" cy="312" r="0.9" opacity="0.7"/>
-    <circle cx="704" cy="332" r="1" opacity="0.85"/>
-    <circle cx="716" cy="332" r="0.9" opacity="0.7"/>
-    <circle cx="728" cy="332" r="1" opacity="0.85"/>
-    <circle cx="754" cy="232" r="0.9" opacity="0.7"/>
-    <circle cx="766" cy="232" r="1" opacity="0.85"/>
-    <circle cx="754" cy="252" r="1" opacity="0.85"/>
-    <circle cx="766" cy="252" r="0.9" opacity="0.65"/>
-    <circle cx="754" cy="272" r="0.9" opacity="0.7"/>
-    <circle cx="766" cy="272" r="1" opacity="0.85"/>
-    <circle cx="754" cy="292" r="1" opacity="0.85"/>
-    <circle cx="766" cy="292" r="0.9" opacity="0.7"/>
-    <circle cx="754" cy="312" r="0.9" opacity="0.65"/>
-    <circle cx="766" cy="312" r="1" opacity="0.85"/>
+  <!-- Pencil lying on the desk (lower-right of canvas, off the card) -->
+  <g transform="translate(610,378) rotate(18)">
+    <!-- Pencil shadow -->
+    <ellipse cx="-12" cy="11" rx="64" ry="2.4" fill="#000000" opacity="0.45"/>
+    <!-- Wood body -->
+    <rect x="-82" y="-5" width="130" height="9" rx="1.5" fill="url(#pencil-f1)"/>
+    <!-- Wood grain (subtle stripes along length) -->
+    <g stroke="#8AA8E8" stroke-width="0.4" opacity="0.35">
+      <line x1="-78" y1="-2.5" x2="44" y2="-2.5"/>
+      <line x1="-72" y1="0"    x2="46" y2="0"/>
+      <line x1="-76" y1="2"    x2="42" y2="2"/>
+    </g>
+    <!-- Eraser end (warm amber) -->
+    <rect x="-90" y="-5" width="9"  height="9" rx="1.8" fill="#C49A3C"/>
+    <!-- Metal ferrule with tiny ridges -->
+    <rect x="-81" y="-5" width="3"  height="9" fill="#A89466"/>
+    <line x1="-80" y1="-5" x2="-80" y2="4" stroke="#7C6940" stroke-width="0.4"/>
+    <line x1="-79" y1="-5" x2="-79" y2="4" stroke="#7C6940" stroke-width="0.4"/>
+    <!-- Wood tip (sharpened cone) -->
+    <polygon points="48,-5 48,4 68,0" fill="#A89466"/>
+    <line x1="50" y1="-3.5" x2="64" y2="0"   stroke="#7C6940" stroke-width="0.4" opacity="0.6"/>
+    <line x1="50" y1="3.5"  x2="64" y2="0"   stroke="#7C6940" stroke-width="0.4" opacity="0.6"/>
+    <!-- Graphite tip -->
+    <polygon points="61,-2 61,1 68,0" fill="#1A2238"/>
+    <!-- Specular highlight -->
+    <line x1="-78" y1="-3" x2="46" y2="-3" stroke="#FFFFFF" stroke-width="0.8" opacity="0.22"/>
   </g>
 
-  <!-- Iconic central tower antenna + windows + warm tip light -->
-  <line x1="370" y1="180" x2="370" y2="155" stroke="#0E1424" stroke-width="2"/>
-  <g fill="#F4D26A">
-    <circle cx="370" cy="200" r="0.9" opacity="0.85"/>
-    <circle cx="370" cy="220" r="1.0" opacity="0.85"/>
-    <circle cx="370" cy="240" r="0.9" opacity="0.7"/>
-    <circle cx="370" cy="260" r="1.0" opacity="0.85"/>
-    <circle cx="370" cy="280" r="0.9" opacity="0.7"/>
-    <circle cx="370" cy="300" r="1.0" opacity="0.85"/>
-    <circle cx="370" cy="320" r="0.9" opacity="0.7"/>
-    <circle cx="370" cy="340" r="1.0" opacity="0.85"/>
-  </g>
-
-  <!-- Light beam from tower beacon up to the constellation convergence point -->
-  <defs>
-    <linearGradient id="beam-f1" x1="0" y1="1" x2="0" y2="0">
-      <stop offset="0%"  stop-color="#F4D26A" stop-opacity="0.55"/>
-      <stop offset="60%" stop-color="#7AAEFF" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
-    </linearGradient>
-  </defs>
-  <polygon points="368,158 372,158 376,90 364,90" fill="url(#beam-f1)" opacity="0.85"/>
-  <line x1="370" y1="155" x2="370" y2="92" stroke="#F4D26A" stroke-width="0.8" opacity="0.45"/>
-
-  <!-- Tower beacon (warm pulse atop) — bigger, more prominent -->
-  <circle cx="370" cy="160" r="22" fill="url(#rootGlow-f1)" opacity="0.55"/>
-  <circle cx="370" cy="160" r="12" fill="url(#rootGlow-f1)" opacity="0.95"/>
-  <circle cx="370" cy="160" r="3.5" fill="#FFF5D6" opacity="1"/>
-
-  <!-- ───────────── Layer 5: Decomposition tree (luminous overlay) ───────────── -->
-  <!-- Root at the central tower beacon (370,160) -->
-  <!-- Branches reach out to landmark buildings across the city -->
-  <g fill="none" stroke="#7AAEFF" stroke-width="1.4" stroke-linecap="round" opacity="0.85" filter="url(#softGlow-f1)">
-    <!-- Primary branches: 3 directions -->
-    <path d="M 370 160 C 320 130, 240 110, 160 100"/>
-    <path d="M 370 160 C 410 130, 470 110, 540 100"/>
-    <path d="M 370 160 C 380 120, 400 90, 420 70"/>
-
-    <!-- Secondary branches off each primary -->
-    <path d="M 160 100 C 140 90, 110 86, 80 80"/>
-    <path d="M 160 100 C 150 80, 130 66, 110 56"/>
-    <path d="M 160 100 C 180 86, 200 72, 220 60"/>
-    <path d="M 540 100 C 580 90, 620 84, 660 78"/>
-    <path d="M 540 100 C 570 78, 610 60, 650 50"/>
-    <path d="M 540 100 C 510 80, 480 60, 450 46"/>
-    <path d="M 420 70  C 430 50, 440 36, 450 26"/>
-    <path d="M 420 70  C 380 50, 350 36, 320 28"/>
-  </g>
-  <!-- Sharper inner stroke on top for luminance -->
-  <g fill="none" stroke="#C9DBFF" stroke-width="0.6" stroke-linecap="round" opacity="0.9">
-    <path d="M 370 160 C 320 130, 240 110, 160 100"/>
-    <path d="M 370 160 C 410 130, 470 110, 540 100"/>
-    <path d="M 370 160 C 380 120, 400 90, 420 70"/>
-    <path d="M 160 100 C 140 90, 110 86, 80 80"/>
-    <path d="M 160 100 C 150 80, 130 66, 110 56"/>
-    <path d="M 160 100 C 180 86, 200 72, 220 60"/>
-    <path d="M 540 100 C 580 90, 620 84, 660 78"/>
-    <path d="M 540 100 C 570 78, 610 60, 650 50"/>
-    <path d="M 540 100 C 510 80, 480 60, 450 46"/>
-    <path d="M 420 70  C 430 50, 440 36, 450 26"/>
-    <path d="M 420 70  C 380 50, 350 36, 320 28"/>
-  </g>
-
-  <!-- Decomposition nodes (glowing dots at junctions) -->
-  <g>
-    <!-- Primary nodes -->
-    <circle cx="160" cy="100" r="14" fill="url(#nodeGlow-f1)" opacity="0.9"/>
-    <circle cx="160" cy="100" r="3"  fill="#C9DBFF"/>
-    <circle cx="540" cy="100" r="14" fill="url(#nodeGlow-f1)" opacity="0.9"/>
-    <circle cx="540" cy="100" r="3"  fill="#C9DBFF"/>
-    <circle cx="420" cy="70"  r="12" fill="url(#nodeGlow-f1)" opacity="0.9"/>
-    <circle cx="420" cy="70"  r="2.6" fill="#C9DBFF"/>
-    <!-- Secondary leaf nodes -->
-    <circle cx="80"  cy="80"  r="7" fill="url(#nodeGlow-f1)" opacity="0.85"/>
-    <circle cx="80"  cy="80"  r="1.6" fill="#C9DBFF"/>
-    <circle cx="110" cy="56"  r="7" fill="url(#nodeGlow-f1)" opacity="0.85"/>
-    <circle cx="110" cy="56"  r="1.6" fill="#C9DBFF"/>
-    <circle cx="220" cy="60"  r="7" fill="url(#nodeGlow-f1)" opacity="0.85"/>
-    <circle cx="220" cy="60"  r="1.6" fill="#C9DBFF"/>
-    <circle cx="660" cy="78"  r="7" fill="url(#nodeGlow-f1)" opacity="0.85"/>
-    <circle cx="660" cy="78"  r="1.6" fill="#C9DBFF"/>
-    <circle cx="650" cy="50"  r="7" fill="url(#nodeGlow-f1)" opacity="0.85"/>
-    <circle cx="650" cy="50"  r="1.6" fill="#C9DBFF"/>
-    <circle cx="450" cy="46"  r="7" fill="url(#nodeGlow-f1)" opacity="0.85"/>
-    <circle cx="450" cy="46"  r="1.6" fill="#C9DBFF"/>
-    <circle cx="450" cy="26"  r="7" fill="url(#nodeGlow-f1)" opacity="0.85"/>
-    <circle cx="450" cy="26"  r="1.6" fill="#C9DBFF"/>
-    <circle cx="320" cy="28"  r="7" fill="url(#nodeGlow-f1)" opacity="0.85"/>
-    <circle cx="320" cy="28"  r="1.6" fill="#C9DBFF"/>
-  </g>
-
-  <!-- ───────────── Layer 6: Foreground floor / reflection ───────────── -->
-  <rect x="0" y="350" width="800" height="50" fill="url(#floor-f1)"/>
-
-  <!-- Subtle vertical reflection streaks (city lights bouncing) -->
-  <g fill="#F4D26A" opacity="0.45" filter="url(#cityHaze-f1)">
-    <rect x="49" y="360" width="1.2" height="14"/>
-    <rect x="103" y="360" width="1" height="22"/>
-    <rect x="195" y="360" width="1.4" height="20"/>
-    <rect x="270" y="360" width="1" height="18"/>
-    <rect x="318" y="360" width="1.2" height="22"/>
-    <rect x="370" y="360" width="2" height="36" opacity="0.7"/>
-    <rect x="455" y="360" width="1" height="18"/>
-    <rect x="500" y="360" width="1.2" height="20"/>
-    <rect x="548" y="360" width="1" height="22"/>
-    <rect x="635" y="360" width="1.2" height="18"/>
-    <rect x="715" y="360" width="1" height="20"/>
-    <rect x="765" y="360" width="1.2" height="16"/>
-  </g>
-
-  <!-- ───────────── Layer 7: Atmospheric grain on whole frame ───────────── -->
-  <rect width="800" height="400" filter="url(#grain-f1)" opacity="0.5"/>
-
-  <!-- Fine atmospheric particles (foreground dust / floating) -->
-  <g fill="#F4D26A">
-    <circle cx="120" cy="180" r="0.7" opacity="0.45"/>
-    <circle cx="280" cy="150" r="0.5" opacity="0.35"/>
-    <circle cx="500" cy="170" r="0.6" opacity="0.40"/>
-    <circle cx="640" cy="140" r="0.5" opacity="0.35"/>
-    <circle cx="180" cy="130" r="0.4" opacity="0.30"/>
-    <circle cx="700" cy="180" r="0.6" opacity="0.40"/>
-    <circle cx="380" cy="120" r="0.5" opacity="0.35"/>
+  <!-- Eraser shavings + desk dust -->
+  <g fill="#C49A3C">
+    <circle cx="180" cy="350" r="1.4" opacity="0.55"/>
+    <circle cx="195" cy="358" r="1.0" opacity="0.45"/>
+    <circle cx="172" cy="365" r="0.8" opacity="0.40"/>
+    <circle cx="650" cy="358" r="1.0" opacity="0.50"/>
+    <circle cx="635" cy="350" r="0.7" opacity="0.40"/>
+    <circle cx="668" cy="346" r="0.5" opacity="0.30"/>
+    <circle cx="715" cy="370" r="0.9" opacity="0.45"/>
+    <circle cx="155" cy="338" r="0.6" opacity="0.35"/>
   </g>
 </svg>

--- a/public/images/v3/course-fermi-01.svg
+++ b/public/images/v3/course-fermi-01.svg
@@ -5,24 +5,42 @@
       <stop offset="55%" stop-color="#1F2942"/>
       <stop offset="100%" stop-color="#0E1424"/>
     </linearGradient>
-    <radialGradient id="lamp-f1" cx="0.86" cy="0.14" r="0.7">
-      <stop offset="0%" stop-color="#F4D26A" stop-opacity="0.42"/>
-      <stop offset="35%" stop-color="#C49A3C" stop-opacity="0.20"/>
+    <radialGradient id="lamp-f1" cx="0.86" cy="0.14" r="0.72">
+      <stop offset="0%"  stop-color="#F4D26A" stop-opacity="0.48"/>
+      <stop offset="32%" stop-color="#C49A3C" stop-opacity="0.22"/>
       <stop offset="100%" stop-color="#C49A3C" stop-opacity="0"/>
     </radialGradient>
-    <linearGradient id="paper-f1" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#F5EBC8"/>
-      <stop offset="100%" stop-color="#DFCEA0"/>
+
+    <!-- Paper: directional lighting from upper-right (lamp side) -->
+    <linearGradient id="paper-f1" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%"  stop-color="#D5C58E"/>
+      <stop offset="55%" stop-color="#EFE0B0"/>
+      <stop offset="100%" stop-color="#F9F0D2"/>
     </linearGradient>
+    <!-- Warm cast on right side of paper (lamp bleed) -->
+    <radialGradient id="paperWarm-f1" cx="0.95" cy="0.05" r="0.95">
+      <stop offset="0%"  stop-color="#F4D26A" stop-opacity="0.35"/>
+      <stop offset="60%" stop-color="#F4D26A" stop-opacity="0.05"/>
+      <stop offset="100%" stop-color="#F4D26A" stop-opacity="0"/>
+    </radialGradient>
+
     <linearGradient id="pencil-f1" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#3B5BBF"/>
+      <stop offset="0%"  stop-color="#4A6BCB"/>
+      <stop offset="50%" stop-color="#3B5BBF"/>
       <stop offset="100%" stop-color="#1F3275"/>
     </linearGradient>
     <radialGradient id="globe-f1" cx="0.4" cy="0.35" r="0.7">
-      <stop offset="0%" stop-color="#7AAEFF" stop-opacity="0.55"/>
-      <stop offset="60%" stop-color="#3B5BBF" stop-opacity="0.30"/>
+      <stop offset="0%"  stop-color="#7AAEFF" stop-opacity="0.6"/>
+      <stop offset="55%" stop-color="#3B5BBF" stop-opacity="0.32"/>
       <stop offset="100%" stop-color="#1B2954" stop-opacity="0.08"/>
     </radialGradient>
+
+    <!-- Diagonal light rays from upper-right -->
+    <linearGradient id="ray-f1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%"   stop-color="#F4D26A" stop-opacity="0.18"/>
+      <stop offset="40%"  stop-color="#F4D26A" stop-opacity="0.06"/>
+      <stop offset="100%" stop-color="#F4D26A" stop-opacity="0"/>
+    </linearGradient>
 
     <filter id="grain-f1" x="0%" y="0%" width="100%" height="100%">
       <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="3"/>
@@ -31,138 +49,214 @@
     </filter>
     <filter id="paperGrain-f1" x="0%" y="0%" width="100%" height="100%">
       <feTurbulence type="fractalNoise" baseFrequency="1.2" numOctaves="2" seed="7"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0.55  0 0 0 0 0.46  0 0 0 0 0.30  0 0 0 0.18 0"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.55  0 0 0 0 0.46  0 0 0 0 0.30  0 0 0 0.20 0"/>
       <feComposite operator="in" in2="SourceGraphic"/>
     </filter>
     <filter id="cardShadow-f1" x="-15%" y="-15%" width="130%" height="135%">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="9"/>
-      <feOffset dx="0" dy="10"/>
-      <feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer>
+      <feGaussianBlur in="SourceAlpha" stdDeviation="10"/>
+      <feOffset dx="0" dy="12"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.6"/></feComponentTransfer>
       <feMerge>
         <feMergeNode/>
         <feMergeNode in="SourceGraphic"/>
       </feMerge>
     </filter>
-    <filter id="softBlur-f1">
-      <feGaussianBlur stdDeviation="2.5"/>
-    </filter>
+    <filter id="softBlur-f1"><feGaussianBlur stdDeviation="2.5"/></filter>
+    <filter id="microBlur-f1"><feGaussianBlur stdDeviation="0.6"/></filter>
+
+    <!-- Wavy paper edge as a clip path so grain stays inside -->
+    <clipPath id="paperShape-f1">
+      <path d="
+        M -262 -136
+        C -200 -141, -100 -138, 0 -140
+        C 100 -142, 200 -139, 261 -135
+        C 264 -80, 263 -10, 264 60
+        C 265 100, 264 130, 260 138
+        C 200 141, 100 137, 0 138
+        C -100 139, -200 142, -262 138
+        C -264 80, -263 10, -264 -60
+        C -265 -100, -264 -120, -262 -136
+        Z"/>
+    </clipPath>
   </defs>
 
   <!-- Desk base + warm lamp halo + grain -->
   <rect width="800" height="400" fill="url(#desk-f1)"/>
   <rect width="800" height="400" fill="url(#lamp-f1)"/>
+
+  <!-- Diagonal light rays from upper-right corner -->
+  <g opacity="0.85">
+    <polygon points="800,0 800,80 250,400 180,400" fill="url(#ray-f1)"/>
+    <polygon points="800,40 800,140 380,400 310,400" fill="url(#ray-f1)" opacity="0.7"/>
+    <polygon points="800,120 800,220 520,400 460,400" fill="url(#ray-f1)" opacity="0.5"/>
+  </g>
+
   <rect width="800" height="400" filter="url(#grain-f1)" opacity="0.55"/>
 
-  <!-- Faded background globe (blueprint memory of "world scale") -->
-  <g transform="translate(125,115)" opacity="0.7" filter="url(#softBlur-f1)">
-    <circle cx="0" cy="0" r="92" fill="url(#globe-f1)"/>
-    <g fill="none" stroke="#7AAEFF" stroke-width="0.9" opacity="0.6">
+  <!-- Faded background globe with land masses (blueprint memory of "world scale") -->
+  <g transform="translate(125,118)" opacity="0.72">
+    <g filter="url(#softBlur-f1)">
+      <circle cx="0" cy="0" r="92" fill="url(#globe-f1)"/>
+    </g>
+    <g fill="none" stroke="#7AAEFF" stroke-width="0.9" opacity="0.55">
       <ellipse cx="0" cy="0" rx="92" ry="30"/>
       <ellipse cx="0" cy="0" rx="92" ry="62"/>
       <ellipse cx="0" cy="0" rx="30" ry="92"/>
       <ellipse cx="0" cy="0" rx="62" ry="92"/>
       <line x1="-92" y1="0" x2="92" y2="0"/>
     </g>
+    <!-- Continent silhouettes (abstract) -->
+    <g fill="#7AAEFF" opacity="0.32" filter="url(#microBlur-f1)">
+      <path d="M -38 -32 Q -28 -42, -10 -36 Q -2 -28, -14 -18 Q -32 -16, -42 -22 Z"/>
+      <path d="M 12 -8 Q 32 -16, 48 -6 Q 54 6, 44 16 Q 26 20, 14 12 Z"/>
+      <path d="M -22 26 Q -6 22, 0 36 Q -6 50, -22 46 Q -34 38, -30 30 Z"/>
+      <path d="M 50 -42 Q 64 -44, 68 -36 Q 64 -28, 52 -32 Z"/>
+    </g>
   </g>
 
   <!-- Atmospheric dust motes inside lamp beam -->
   <g fill="#F4D26A">
-    <circle cx="700" cy="60"  r="1.3" opacity="0.55"/>
-    <circle cx="660" cy="100" r="0.7" opacity="0.40"/>
-    <circle cx="735" cy="125" r="0.9" opacity="0.50"/>
-    <circle cx="610" cy="140" r="0.5" opacity="0.35"/>
-    <circle cx="690" cy="185" r="0.6" opacity="0.40"/>
-    <circle cx="755" cy="205" r="0.8" opacity="0.50"/>
-    <circle cx="635" cy="225" r="0.5" opacity="0.30"/>
+    <circle cx="700" cy="55"  r="1.4" opacity="0.6"/>
+    <circle cx="660" cy="98"  r="0.7" opacity="0.42"/>
+    <circle cx="735" cy="125" r="0.9" opacity="0.55"/>
+    <circle cx="610" cy="138" r="0.5" opacity="0.35"/>
+    <circle cx="690" cy="180" r="0.6" opacity="0.42"/>
+    <circle cx="755" cy="200" r="0.8" opacity="0.55"/>
+    <circle cx="635" cy="225" r="0.5" opacity="0.32"/>
+    <circle cx="585" cy="78"  r="0.6" opacity="0.40"/>
+    <circle cx="775" cy="160" r="0.5" opacity="0.32"/>
   </g>
 
-  <!-- Paper card centered, slight tilt -->
+  <!-- Paper card (centered, slight tilt) — wavy edge via path -->
   <g transform="translate(400,210) rotate(-2)" filter="url(#cardShadow-f1)">
-    <rect x="-260" y="-140" width="520" height="280" rx="3" fill="url(#paper-f1)"/>
-    <rect x="-260" y="-140" width="520" height="280" rx="3" filter="url(#paperGrain-f1)" opacity="0.55"/>
+    <!-- Wavy paper outline -->
+    <path d="
+      M -262 -136
+      C -200 -141, -100 -138, 0 -140
+      C 100 -142, 200 -139, 261 -135
+      C 264 -80, 263 -10, 264 60
+      C 265 100, 264 130, 260 138
+      C 200 141, 100 137, 0 138
+      C -100 139, -200 142, -262 138
+      C -264 80, -263 10, -264 -60
+      C -265 -100, -264 -120, -262 -136
+      Z" fill="url(#paper-f1)"/>
+
+    <!-- Warm light cast (top-right corner from the lamp) -->
+    <g clip-path="url(#paperShape-f1)">
+      <rect x="-265" y="-145" width="540" height="290" fill="url(#paperWarm-f1)"/>
+      <!-- Paper grain inside -->
+      <rect x="-265" y="-145" width="540" height="290" filter="url(#paperGrain-f1)" opacity="0.55"/>
+    </g>
 
     <!-- Faint margin ruling -->
     <g stroke="#A89466" stroke-width="0.4" opacity="0.18">
-      <line x1="-240" y1="-100" x2="240" y2="-100"/>
-      <line x1="-240" y1="-60"  x2="240" y2="-60"/>
-      <line x1="-240" y1="-20"  x2="240" y2="-20"/>
-      <line x1="-240" y1="20"   x2="240" y2="20"/>
-      <line x1="-240" y1="60"   x2="240" y2="60"/>
-      <line x1="-240" y1="100"  x2="240" y2="100"/>
+      <line x1="-238" y1="-100" x2="238" y2="-100"/>
+      <line x1="-238" y1="-60"  x2="238" y2="-60"/>
+      <line x1="-238" y1="-20"  x2="238" y2="-20"/>
+      <line x1="-238" y1="20"   x2="238" y2="20"/>
+      <line x1="-238" y1="60"   x2="238" y2="60"/>
+      <line x1="-238" y1="100"  x2="238" y2="100"/>
     </g>
-    <line x1="-220" y1="-140" x2="-220" y2="140" stroke="#B7553F" stroke-width="0.7" opacity="0.35"/>
+    <!-- Red margin line (left, slightly imperfect) -->
+    <path d="M -222 -134 C -221 -90, -223 -10, -222 60 C -221 100, -223 130, -222 136"
+          stroke="#B7553F" stroke-width="0.7" opacity="0.4" fill="none"/>
 
-    <!-- Top: 市場規模 (target) -->
+    <!-- Coffee ring stain (low-left) -->
+    <g transform="translate(-185,90) rotate(-12)" opacity="0.32">
+      <circle cx="0" cy="0" r="34" fill="none" stroke="#8B5A2B" stroke-width="2.5" opacity="0.55"/>
+      <circle cx="0" cy="0" r="34" fill="none" stroke="#8B5A2B" stroke-width="0.8" opacity="0.85"/>
+      <path d="M -32 -8 A 34 34 0 0 0 28 14"
+            fill="none" stroke="#8B5A2B" stroke-width="0.6" opacity="0.4"/>
+    </g>
+
+    <!-- Header: 市場規模 + brush underline -->
     <g font-family="'Helvetica Neue','Hiragino Sans','Yu Gothic',sans-serif" fill="#2E374D">
       <text x="0" y="-95" text-anchor="middle" font-size="22" font-weight="700">市場規模</text>
+    </g>
+    <!-- Brush underline (single stroke, varying thickness via two layered curves) -->
+    <path d="M -56 -82 C -30 -86, 28 -83, 52 -79"
+          fill="none" stroke="#7B2D26" stroke-width="2.4" stroke-linecap="round" opacity="0.7"/>
+    <path d="M -50 -80 C -28 -82, 26 -80, 46 -78"
+          fill="none" stroke="#7B2D26" stroke-width="0.8" stroke-linecap="round" opacity="0.5"/>
 
-      <!-- Hand-drawn split lines -->
-      <path d="M 0 -78 C 0 -72, -120 -65, -120 -55"
-            fill="none" stroke="#3B4258" stroke-width="1.6" stroke-linecap="round" opacity="0.7"/>
-      <path d="M 0 -78 L 0 -55"
-            fill="none" stroke="#3B4258" stroke-width="1.6" stroke-linecap="round" opacity="0.7"/>
-      <path d="M 0 -78 C 0 -72, 120 -65, 120 -55"
-            fill="none" stroke="#3B4258" stroke-width="1.6" stroke-linecap="round" opacity="0.7"/>
-
-      <!-- Branches: 人口 × 利用率 × 単価 -->
-      <text x="-120" y="-30" text-anchor="middle" font-size="17" font-weight="500">人口</text>
-      <text x="0"    y="-30" text-anchor="middle" font-size="17" font-weight="500">利用率</text>
-      <text x="120"  y="-30" text-anchor="middle" font-size="17" font-weight="500">単価</text>
-
-      <!-- × symbols -->
-      <text x="-60" y="-30" text-anchor="middle" font-size="16" font-weight="400" fill="#7B2D26" opacity="0.85">×</text>
-      <text x="60"  y="-30" text-anchor="middle" font-size="16" font-weight="400" fill="#7B2D26" opacity="0.85">×</text>
+    <!-- Hand-drawn split lines from header to 3 children -->
+    <g fill="none" stroke="#3B4258" stroke-width="1.6" stroke-linecap="round" opacity="0.7">
+      <path d="M 0 -68 C 0 -62, -120 -55, -120 -45"/>
+      <path d="M 0 -68 L 0 -45"/>
+      <path d="M 0 -68 C 0 -62, 120 -55, 120 -45"/>
     </g>
 
-    <!-- Equals dashed line (hand-drawn feel) -->
-    <line x1="-180" y1="20" x2="180" y2="20"
-          stroke="#C49A3C" stroke-width="1.8" opacity="0.85"
-          stroke-linecap="round" stroke-dasharray="1 8"/>
-    <line x1="-180" y1="28" x2="180" y2="28"
-          stroke="#C49A3C" stroke-width="1.8" opacity="0.85"
-          stroke-linecap="round" stroke-dasharray="1 8"/>
+    <!-- Branches -->
+    <g font-family="'Helvetica Neue','Hiragino Sans','Yu Gothic',sans-serif" fill="#2E374D">
+      <text x="-120" y="-22" text-anchor="middle" font-size="18" font-weight="500">人口</text>
+      <text x="0"    y="-22" text-anchor="middle" font-size="18" font-weight="500">利用率</text>
+      <text x="120"  y="-22" text-anchor="middle" font-size="18" font-weight="500">単価</text>
+      <text x="-60" y="-22" text-anchor="middle" font-size="17" font-weight="400" fill="#7B2D26" opacity="0.85">×</text>
+      <text x="60"  y="-22" text-anchor="middle" font-size="17" font-weight="400" fill="#7B2D26" opacity="0.85">×</text>
+    </g>
 
-    <!-- Result: ≈ ¥62.5兆 (centered as one unit) -->
-    <text x="0" y="82" text-anchor="middle"
+    <!-- Equals dashed line (hand-drawn double bar) -->
+    <g stroke="#C49A3C" stroke-linecap="round" stroke-dasharray="1 8" opacity="0.85">
+      <line x1="-180" y1="22" x2="180" y2="22" stroke-width="1.8"/>
+      <line x1="-180" y1="32" x2="180" y2="32" stroke-width="1.8"/>
+    </g>
+
+    <!-- Result: ≈ ¥62.5 兆 -->
+    <text x="0" y="86" text-anchor="middle"
           font-family="'Helvetica Neue','Hiragino Sans','Yu Gothic',sans-serif"
-          font-size="36" font-weight="700" fill="#7B2D26"
-          letter-spacing="2">≈ ¥62.5 兆</text>
+          font-size="38" font-weight="700" fill="#7B2D26" letter-spacing="2">≈ ¥62.5 兆</text>
 
-    <!-- Margin doodle: small circle with a dot (a lightbulb / abstract idea mark) -->
+    <!-- Margin doodle (top-right): magnifying-glass-style mark -->
     <g stroke="#3B4258" stroke-width="0.9" fill="none" opacity="0.32">
-      <circle cx="220" cy="-110" r="13"/>
-      <circle cx="220" cy="-110" r="8"/>
-      <line x1="220" y1="-123" x2="220" y2="-97"/>
-      <line x1="207" y1="-110" x2="233" y2="-110"/>
+      <circle cx="222" cy="-110" r="13"/>
+      <circle cx="222" cy="-110" r="8"/>
+      <line x1="231" y1="-101" x2="240" y2="-92"/>
     </g>
 
-    <!-- Pencil tick marks at lower-left of card -->
+    <!-- Pencil tick marks at lower-left (margin notes) -->
     <g stroke="#3B4258" stroke-width="0.9" fill="none" opacity="0.4">
-      <line x1="-220" y1="105" x2="-200" y2="105"/>
-      <line x1="-220" y1="115" x2="-208" y2="115"/>
-      <line x1="-220" y1="125" x2="-204" y2="125"/>
+      <line x1="-220" y1="105" x2="-198" y2="105"/>
+      <line x1="-220" y1="115" x2="-206" y2="115"/>
+      <line x1="-220" y1="125" x2="-202" y2="125"/>
+    </g>
+
+    <!-- Torn / dog-eared bottom-right corner -->
+    <g>
+      <path d="M 252 130 L 264 138 L 250 142 Z" fill="#C8B582" opacity="0.75"/>
+      <path d="M 256 134 L 262 138 L 252 141" fill="none" stroke="#8B7848" stroke-width="0.5" opacity="0.6"/>
     </g>
   </g>
 
-  <!-- Pencil lying on the desk below the card (out of formula's way) -->
+  <!-- Pencil lying on the desk (lower-right of canvas, off the card) -->
   <g transform="translate(610,378) rotate(18)">
     <!-- Pencil shadow -->
-    <ellipse cx="-12" cy="10" rx="62" ry="2.2" fill="#000000" opacity="0.4"/>
+    <ellipse cx="-12" cy="11" rx="64" ry="2.4" fill="#000000" opacity="0.45"/>
     <!-- Wood body -->
     <rect x="-82" y="-5" width="130" height="9" rx="1.5" fill="url(#pencil-f1)"/>
+    <!-- Wood grain (subtle stripes along length) -->
+    <g stroke="#8AA8E8" stroke-width="0.4" opacity="0.35">
+      <line x1="-78" y1="-2.5" x2="44" y2="-2.5"/>
+      <line x1="-72" y1="0"    x2="46" y2="0"/>
+      <line x1="-76" y1="2"    x2="42" y2="2"/>
+    </g>
     <!-- Eraser end (warm amber) -->
     <rect x="-90" y="-5" width="9"  height="9" rx="1.8" fill="#C49A3C"/>
-    <!-- Metal ferrule -->
+    <!-- Metal ferrule with tiny ridges -->
     <rect x="-81" y="-5" width="3"  height="9" fill="#A89466"/>
-    <!-- Wood tip -->
+    <line x1="-80" y1="-5" x2="-80" y2="4" stroke="#7C6940" stroke-width="0.4"/>
+    <line x1="-79" y1="-5" x2="-79" y2="4" stroke="#7C6940" stroke-width="0.4"/>
+    <!-- Wood tip (sharpened cone) -->
     <polygon points="48,-5 48,4 68,0" fill="#A89466"/>
+    <line x1="50" y1="-3.5" x2="64" y2="0"   stroke="#7C6940" stroke-width="0.4" opacity="0.6"/>
+    <line x1="50" y1="3.5"  x2="64" y2="0"   stroke="#7C6940" stroke-width="0.4" opacity="0.6"/>
     <!-- Graphite tip -->
     <polygon points="61,-2 61,1 68,0" fill="#1A2238"/>
-    <!-- Highlight stripe -->
-    <line x1="-78" y1="-3" x2="47" y2="-3" stroke="#FFFFFF" stroke-width="0.7" opacity="0.18"/>
+    <!-- Specular highlight -->
+    <line x1="-78" y1="-3" x2="46" y2="-3" stroke="#FFFFFF" stroke-width="0.8" opacity="0.22"/>
   </g>
 
-  <!-- Eraser shavings / desk dust -->
+  <!-- Eraser shavings + desk dust -->
   <g fill="#C49A3C">
     <circle cx="180" cy="350" r="1.4" opacity="0.55"/>
     <circle cx="195" cy="358" r="1.0" opacity="0.45"/>
@@ -170,5 +264,7 @@
     <circle cx="650" cy="358" r="1.0" opacity="0.50"/>
     <circle cx="635" cy="350" r="0.7" opacity="0.40"/>
     <circle cx="668" cy="346" r="0.5" opacity="0.30"/>
+    <circle cx="715" cy="370" r="0.9" opacity="0.45"/>
+    <circle cx="155" cy="338" r="0.6" opacity="0.35"/>
   </g>
 </svg>

--- a/public/images/v3/course-fermi-01.svg
+++ b/public/images/v3/course-fermi-01.svg
@@ -1,270 +1,523 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
   <defs>
-    <linearGradient id="desk-f1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#1A2238"/>
-      <stop offset="55%" stop-color="#1F2942"/>
-      <stop offset="100%" stop-color="#0E1424"/>
+    <!-- Sky: deep navy → warm amber horizon (twilight) -->
+    <linearGradient id="sky-f1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%"  stop-color="#0B1024"/>
+      <stop offset="40%" stop-color="#1F2942"/>
+      <stop offset="68%" stop-color="#3F416B"/>
+      <stop offset="85%" stop-color="#A85F3B"/>
+      <stop offset="100%" stop-color="#E8965D"/>
     </linearGradient>
-    <radialGradient id="lamp-f1" cx="0.86" cy="0.14" r="0.72">
-      <stop offset="0%"  stop-color="#F4D26A" stop-opacity="0.48"/>
-      <stop offset="32%" stop-color="#C49A3C" stop-opacity="0.22"/>
-      <stop offset="100%" stop-color="#C49A3C" stop-opacity="0"/>
+
+    <!-- Sun glow (sinking behind horizon, right side) -->
+    <radialGradient id="sun-f1" cx="0.78" cy="0.85" r="0.45">
+      <stop offset="0%"  stop-color="#F4D26A" stop-opacity="0.95"/>
+      <stop offset="22%" stop-color="#F4A261" stop-opacity="0.55"/>
+      <stop offset="55%" stop-color="#A85F3B" stop-opacity="0.18"/>
+      <stop offset="100%" stop-color="#A85F3B" stop-opacity="0"/>
     </radialGradient>
 
-    <!-- Paper: directional lighting from upper-right (lamp side) -->
-    <linearGradient id="paper-f1" x1="0" y1="1" x2="1" y2="0">
-      <stop offset="0%"  stop-color="#D5C58E"/>
-      <stop offset="55%" stop-color="#EFE0B0"/>
-      <stop offset="100%" stop-color="#F9F0D2"/>
+    <!-- Distant city: lighter slate -->
+    <linearGradient id="cityFar-f1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%"  stop-color="#3F416B" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#1F2942" stop-opacity="1"/>
     </linearGradient>
-    <!-- Warm cast on right side of paper (lamp bleed) -->
-    <radialGradient id="paperWarm-f1" cx="0.95" cy="0.05" r="0.95">
-      <stop offset="0%"  stop-color="#F4D26A" stop-opacity="0.35"/>
-      <stop offset="60%" stop-color="#F4D26A" stop-opacity="0.05"/>
-      <stop offset="100%" stop-color="#F4D26A" stop-opacity="0"/>
-    </radialGradient>
+    <!-- Mid city -->
+    <linearGradient id="cityMid-f1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%"  stop-color="#1B2238" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#0E1424" stop-opacity="1"/>
+    </linearGradient>
+    <!-- Near city -->
+    <linearGradient id="cityNear-f1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%"  stop-color="#0F1530" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#070914" stop-opacity="1"/>
+    </linearGradient>
 
-    <linearGradient id="pencil-f1" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%"  stop-color="#4A6BCB"/>
-      <stop offset="50%" stop-color="#3B5BBF"/>
-      <stop offset="100%" stop-color="#1F3275"/>
+    <!-- Ground reflection / foreground floor -->
+    <linearGradient id="floor-f1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%"  stop-color="#0E1424"/>
+      <stop offset="100%" stop-color="#040714"/>
     </linearGradient>
-    <radialGradient id="globe-f1" cx="0.4" cy="0.35" r="0.7">
-      <stop offset="0%"  stop-color="#7AAEFF" stop-opacity="0.6"/>
-      <stop offset="55%" stop-color="#3B5BBF" stop-opacity="0.32"/>
-      <stop offset="100%" stop-color="#1B2954" stop-opacity="0.08"/>
-    </radialGradient>
 
-    <!-- Diagonal light rays from upper-right -->
-    <linearGradient id="ray-f1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%"   stop-color="#F4D26A" stop-opacity="0.18"/>
-      <stop offset="40%"  stop-color="#F4D26A" stop-opacity="0.06"/>
-      <stop offset="100%" stop-color="#F4D26A" stop-opacity="0"/>
+    <!-- Atmospheric haze near horizon -->
+    <linearGradient id="haze-f1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%"  stop-color="#E8965D" stop-opacity="0"/>
+      <stop offset="50%" stop-color="#A85F3B" stop-opacity="0.32"/>
+      <stop offset="100%" stop-color="#3F416B" stop-opacity="0"/>
     </linearGradient>
+
+    <!-- Decomposition tree glow -->
+    <radialGradient id="nodeGlow-f1" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%"  stop-color="#7AAEFF" stop-opacity="1"/>
+      <stop offset="55%" stop-color="#3B5BBF" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#3B5BBF" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="rootGlow-f1" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%"  stop-color="#F4D26A" stop-opacity="1"/>
+      <stop offset="50%" stop-color="#F4A261" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#F4A261" stop-opacity="0"/>
+    </radialGradient>
 
     <filter id="grain-f1" x="0%" y="0%" width="100%" height="100%">
       <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="3"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0.42  0 0 0 0 0.36  0 0 0 0 0.27  0 0 0 0.20 0"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.42  0 0 0 0 0.36  0 0 0 0 0.27  0 0 0 0.12 0"/>
       <feComposite operator="in" in2="SourceGraphic"/>
     </filter>
-    <filter id="paperGrain-f1" x="0%" y="0%" width="100%" height="100%">
-      <feTurbulence type="fractalNoise" baseFrequency="1.2" numOctaves="2" seed="7"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0.55  0 0 0 0 0.46  0 0 0 0 0.30  0 0 0 0.20 0"/>
-      <feComposite operator="in" in2="SourceGraphic"/>
+    <filter id="softGlow-f1" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="3"/>
     </filter>
-    <filter id="cardShadow-f1" x="-15%" y="-15%" width="130%" height="135%">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="10"/>
-      <feOffset dx="0" dy="12"/>
-      <feComponentTransfer><feFuncA type="linear" slope="0.6"/></feComponentTransfer>
-      <feMerge>
-        <feMergeNode/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
+    <filter id="strongGlow-f1" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="6"/>
     </filter>
-    <filter id="softBlur-f1"><feGaussianBlur stdDeviation="2.5"/></filter>
-    <filter id="microBlur-f1"><feGaussianBlur stdDeviation="0.6"/></filter>
-
-    <!-- Wavy paper edge as a clip path so grain stays inside -->
-    <clipPath id="paperShape-f1">
-      <path d="
-        M -262 -136
-        C -200 -141, -100 -138, 0 -140
-        C 100 -142, 200 -139, 261 -135
-        C 264 -80, 263 -10, 264 60
-        C 265 100, 264 130, 260 138
-        C 200 141, 100 137, 0 138
-        C -100 139, -200 142, -262 138
-        C -264 80, -263 10, -264 -60
-        C -265 -100, -264 -120, -262 -136
-        Z"/>
-    </clipPath>
+    <filter id="cityHaze-f1">
+      <feGaussianBlur stdDeviation="0.6"/>
+    </filter>
   </defs>
 
-  <!-- Desk base + warm lamp halo + grain -->
-  <rect width="800" height="400" fill="url(#desk-f1)"/>
-  <rect width="800" height="400" fill="url(#lamp-f1)"/>
+  <!-- ───────────── Layer 1: Sky ───────────── -->
+  <rect width="800" height="400" fill="url(#sky-f1)"/>
+  <!-- Sun bloom -->
+  <rect width="800" height="400" fill="url(#sun-f1)"/>
 
-  <!-- Diagonal light rays from upper-right corner -->
-  <g opacity="0.85">
-    <polygon points="800,0 800,80 250,400 180,400" fill="url(#ray-f1)"/>
-    <polygon points="800,40 800,140 380,400 310,400" fill="url(#ray-f1)" opacity="0.7"/>
-    <polygon points="800,120 800,220 520,400 460,400" fill="url(#ray-f1)" opacity="0.5"/>
+  <!-- Stars -->
+  <g fill="#F4ECCC">
+    <circle cx="80"  cy="40"  r="1.0" opacity="0.85"/>
+    <circle cx="160" cy="22"  r="0.6" opacity="0.6"/>
+    <circle cx="240" cy="56"  r="1.2" opacity="0.9"/>
+    <circle cx="320" cy="36"  r="0.7" opacity="0.55"/>
+    <circle cx="50"  cy="90"  r="0.8" opacity="0.7"/>
+    <circle cx="200" cy="100" r="0.5" opacity="0.4"/>
+    <circle cx="120" cy="60"  r="0.6" opacity="0.5"/>
+    <circle cx="430" cy="30"  r="0.7" opacity="0.6"/>
+    <circle cx="540" cy="70"  r="0.5" opacity="0.4"/>
+    <circle cx="380" cy="80"  r="0.4" opacity="0.35"/>
   </g>
 
-  <rect width="800" height="400" filter="url(#grain-f1)" opacity="0.55"/>
-
-  <!-- Faded background globe with land masses (blueprint memory of "world scale") -->
-  <g transform="translate(125,118)" opacity="0.72">
-    <g filter="url(#softBlur-f1)">
-      <circle cx="0" cy="0" r="92" fill="url(#globe-f1)"/>
-    </g>
-    <g fill="none" stroke="#7AAEFF" stroke-width="0.9" opacity="0.55">
-      <ellipse cx="0" cy="0" rx="92" ry="30"/>
-      <ellipse cx="0" cy="0" rx="92" ry="62"/>
-      <ellipse cx="0" cy="0" rx="30" ry="92"/>
-      <ellipse cx="0" cy="0" rx="62" ry="92"/>
-      <line x1="-92" y1="0" x2="92" y2="0"/>
-    </g>
-    <!-- Continent silhouettes (abstract) -->
-    <g fill="#7AAEFF" opacity="0.32" filter="url(#microBlur-f1)">
-      <path d="M -38 -32 Q -28 -42, -10 -36 Q -2 -28, -14 -18 Q -32 -16, -42 -22 Z"/>
-      <path d="M 12 -8 Q 32 -16, 48 -6 Q 54 6, 44 16 Q 26 20, 14 12 Z"/>
-      <path d="M -22 26 Q -6 22, 0 36 Q -6 50, -22 46 Q -34 38, -30 30 Z"/>
-      <path d="M 50 -42 Q 64 -44, 68 -36 Q 64 -28, 52 -32 Z"/>
-    </g>
+  <!-- Crescent moon (upper-left) -->
+  <g transform="translate(95,80)" opacity="0.85">
+    <circle cx="0" cy="0" r="14" fill="#F4ECCC" opacity="0.92"/>
+    <circle cx="5" cy="-3" r="13" fill="#0B1024"/>
   </g>
 
-  <!-- Atmospheric dust motes inside lamp beam -->
+  <!-- ───────────── Layer 2: Atmospheric haze on horizon ───────────── -->
+  <rect x="0" y="170" width="800" height="100" fill="url(#haze-f1)"/>
+
+  <!-- ───────────── Layer 3: Far city (smaller, lighter) ───────────── -->
+  <g fill="url(#cityFar-f1)" filter="url(#cityHaze-f1)">
+    <rect x="20"  y="220" width="22" height="40"/>
+    <rect x="44"  y="208" width="14" height="52"/>
+    <rect x="60"  y="218" width="20" height="42"/>
+    <rect x="84"  y="200" width="18" height="60"/>
+    <rect x="106" y="214" width="16" height="46"/>
+    <rect x="126" y="196" width="22" height="64"/>
+    <rect x="152" y="208" width="14" height="52"/>
+    <rect x="170" y="216" width="20" height="44"/>
+    <rect x="194" y="200" width="18" height="60"/>
+    <rect x="216" y="214" width="14" height="46"/>
+    <rect x="234" y="206" width="22" height="54"/>
+    <rect x="260" y="216" width="14" height="44"/>
+    <rect x="278" y="198" width="18" height="62"/>
+    <rect x="300" y="212" width="16" height="48"/>
+    <rect x="320" y="204" width="20" height="56"/>
+    <rect x="344" y="218" width="14" height="42"/>
+    <rect x="362" y="202" width="22" height="58"/>
+    <rect x="388" y="214" width="16" height="46"/>
+    <rect x="408" y="208" width="20" height="52"/>
+    <rect x="432" y="218" width="14" height="42"/>
+    <rect x="450" y="206" width="20" height="54"/>
+    <rect x="474" y="216" width="16" height="44"/>
+    <rect x="494" y="200" width="22" height="60"/>
+    <rect x="520" y="214" width="14" height="46"/>
+    <rect x="538" y="206" width="18" height="54"/>
+    <rect x="560" y="218" width="20" height="42"/>
+    <rect x="584" y="204" width="16" height="56"/>
+    <rect x="604" y="216" width="22" height="44"/>
+    <rect x="630" y="208" width="14" height="52"/>
+    <rect x="648" y="200" width="20" height="60"/>
+    <rect x="672" y="218" width="14" height="42"/>
+    <rect x="690" y="212" width="18" height="48"/>
+    <rect x="712" y="220" width="16" height="40"/>
+    <rect x="732" y="208" width="22" height="52"/>
+    <rect x="758" y="218" width="14" height="42"/>
+    <rect x="776" y="206" width="20" height="54"/>
+  </g>
+
+  <!-- Far-city scattered windows (warm amber) -->
   <g fill="#F4D26A">
-    <circle cx="700" cy="55"  r="1.4" opacity="0.6"/>
-    <circle cx="660" cy="98"  r="0.7" opacity="0.42"/>
-    <circle cx="735" cy="125" r="0.9" opacity="0.55"/>
-    <circle cx="610" cy="138" r="0.5" opacity="0.35"/>
-    <circle cx="690" cy="180" r="0.6" opacity="0.42"/>
-    <circle cx="755" cy="200" r="0.8" opacity="0.55"/>
-    <circle cx="635" cy="225" r="0.5" opacity="0.32"/>
-    <circle cx="585" cy="78"  r="0.6" opacity="0.40"/>
-    <circle cx="775" cy="160" r="0.5" opacity="0.32"/>
+    <circle cx="32"  cy="232" r="0.6" opacity="0.7"/>
+    <circle cx="50"  cy="220" r="0.5" opacity="0.6"/>
+    <circle cx="92"  cy="218" r="0.6" opacity="0.7"/>
+    <circle cx="135" cy="208" r="0.5" opacity="0.6"/>
+    <circle cx="160" cy="225" r="0.6" opacity="0.65"/>
+    <circle cx="200" cy="216" r="0.5" opacity="0.55"/>
+    <circle cx="245" cy="222" r="0.6" opacity="0.7"/>
+    <circle cx="285" cy="212" r="0.5" opacity="0.55"/>
+    <circle cx="328" cy="220" r="0.6" opacity="0.65"/>
+    <circle cx="370" cy="218" r="0.5" opacity="0.55"/>
+    <circle cx="415" cy="225" r="0.5" opacity="0.55"/>
+    <circle cx="458" cy="218" r="0.6" opacity="0.7"/>
+    <circle cx="500" cy="212" r="0.5" opacity="0.6"/>
+    <circle cx="545" cy="220" r="0.6" opacity="0.65"/>
+    <circle cx="592" cy="216" r="0.5" opacity="0.55"/>
+    <circle cx="635" cy="222" r="0.6" opacity="0.7"/>
+    <circle cx="680" cy="222" r="0.5" opacity="0.6"/>
+    <circle cx="720" cy="232" r="0.5" opacity="0.55"/>
+    <circle cx="745" cy="220" r="0.6" opacity="0.65"/>
+    <circle cx="780" cy="218" r="0.5" opacity="0.6"/>
   </g>
 
-  <!-- Paper card (centered, slight tilt) — wavy edge via path -->
-  <g transform="translate(400,210) rotate(-2)" filter="url(#cardShadow-f1)">
-    <!-- Wavy paper outline -->
-    <path d="
-      M -262 -136
-      C -200 -141, -100 -138, 0 -140
-      C 100 -142, 200 -139, 261 -135
-      C 264 -80, 263 -10, 264 60
-      C 265 100, 264 130, 260 138
-      C 200 141, 100 137, 0 138
-      C -100 139, -200 142, -262 138
-      C -264 80, -263 10, -264 -60
-      C -265 -100, -264 -120, -262 -136
-      Z" fill="url(#paper-f1)"/>
-
-    <!-- Warm light cast (top-right corner from the lamp) -->
-    <g clip-path="url(#paperShape-f1)">
-      <rect x="-265" y="-145" width="540" height="290" fill="url(#paperWarm-f1)"/>
-      <!-- Paper grain inside -->
-      <rect x="-265" y="-145" width="540" height="290" filter="url(#paperGrain-f1)" opacity="0.55"/>
-    </g>
-
-    <!-- Faint margin ruling -->
-    <g stroke="#A89466" stroke-width="0.4" opacity="0.18">
-      <line x1="-238" y1="-100" x2="238" y2="-100"/>
-      <line x1="-238" y1="-60"  x2="238" y2="-60"/>
-      <line x1="-238" y1="-20"  x2="238" y2="-20"/>
-      <line x1="-238" y1="20"   x2="238" y2="20"/>
-      <line x1="-238" y1="60"   x2="238" y2="60"/>
-      <line x1="-238" y1="100"  x2="238" y2="100"/>
-    </g>
-    <!-- Red margin line (left, slightly imperfect) -->
-    <path d="M -222 -134 C -221 -90, -223 -10, -222 60 C -221 100, -223 130, -222 136"
-          stroke="#B7553F" stroke-width="0.7" opacity="0.4" fill="none"/>
-
-    <!-- Coffee ring stain (low-left) -->
-    <g transform="translate(-185,90) rotate(-12)" opacity="0.32">
-      <circle cx="0" cy="0" r="34" fill="none" stroke="#8B5A2B" stroke-width="2.5" opacity="0.55"/>
-      <circle cx="0" cy="0" r="34" fill="none" stroke="#8B5A2B" stroke-width="0.8" opacity="0.85"/>
-      <path d="M -32 -8 A 34 34 0 0 0 28 14"
-            fill="none" stroke="#8B5A2B" stroke-width="0.6" opacity="0.4"/>
-    </g>
-
-    <!-- Header: 市場規模 + brush underline -->
-    <g font-family="'Helvetica Neue','Hiragino Sans','Yu Gothic',sans-serif" fill="#2E374D">
-      <text x="0" y="-95" text-anchor="middle" font-size="22" font-weight="700">市場規模</text>
-    </g>
-    <!-- Brush underline (single stroke, varying thickness via two layered curves) -->
-    <path d="M -56 -82 C -30 -86, 28 -83, 52 -79"
-          fill="none" stroke="#7B2D26" stroke-width="2.4" stroke-linecap="round" opacity="0.7"/>
-    <path d="M -50 -80 C -28 -82, 26 -80, 46 -78"
-          fill="none" stroke="#7B2D26" stroke-width="0.8" stroke-linecap="round" opacity="0.5"/>
-
-    <!-- Hand-drawn split lines from header to 3 children -->
-    <g fill="none" stroke="#3B4258" stroke-width="1.6" stroke-linecap="round" opacity="0.7">
-      <path d="M 0 -68 C 0 -62, -120 -55, -120 -45"/>
-      <path d="M 0 -68 L 0 -45"/>
-      <path d="M 0 -68 C 0 -62, 120 -55, 120 -45"/>
-    </g>
-
-    <!-- Branches -->
-    <g font-family="'Helvetica Neue','Hiragino Sans','Yu Gothic',sans-serif" fill="#2E374D">
-      <text x="-120" y="-22" text-anchor="middle" font-size="18" font-weight="500">人口</text>
-      <text x="0"    y="-22" text-anchor="middle" font-size="18" font-weight="500">利用率</text>
-      <text x="120"  y="-22" text-anchor="middle" font-size="18" font-weight="500">単価</text>
-      <text x="-60" y="-22" text-anchor="middle" font-size="17" font-weight="400" fill="#7B2D26" opacity="0.85">×</text>
-      <text x="60"  y="-22" text-anchor="middle" font-size="17" font-weight="400" fill="#7B2D26" opacity="0.85">×</text>
-    </g>
-
-    <!-- Equals dashed line (hand-drawn double bar) -->
-    <g stroke="#C49A3C" stroke-linecap="round" stroke-dasharray="1 8" opacity="0.85">
-      <line x1="-180" y1="22" x2="180" y2="22" stroke-width="1.8"/>
-      <line x1="-180" y1="32" x2="180" y2="32" stroke-width="1.8"/>
-    </g>
-
-    <!-- Result: ≈ ¥62.5 兆 -->
-    <text x="0" y="86" text-anchor="middle"
-          font-family="'Helvetica Neue','Hiragino Sans','Yu Gothic',sans-serif"
-          font-size="38" font-weight="700" fill="#7B2D26" letter-spacing="2">≈ ¥62.5 兆</text>
-
-    <!-- Margin doodle (top-right): magnifying-glass-style mark -->
-    <g stroke="#3B4258" stroke-width="0.9" fill="none" opacity="0.32">
-      <circle cx="222" cy="-110" r="13"/>
-      <circle cx="222" cy="-110" r="8"/>
-      <line x1="231" y1="-101" x2="240" y2="-92"/>
-    </g>
-
-    <!-- Pencil tick marks at lower-left (margin notes) -->
-    <g stroke="#3B4258" stroke-width="0.9" fill="none" opacity="0.4">
-      <line x1="-220" y1="105" x2="-198" y2="105"/>
-      <line x1="-220" y1="115" x2="-206" y2="115"/>
-      <line x1="-220" y1="125" x2="-202" y2="125"/>
-    </g>
-
-    <!-- Torn / dog-eared bottom-right corner -->
-    <g>
-      <path d="M 252 130 L 264 138 L 250 142 Z" fill="#C8B582" opacity="0.75"/>
-      <path d="M 256 134 L 262 138 L 252 141" fill="none" stroke="#8B7848" stroke-width="0.5" opacity="0.6"/>
-    </g>
+  <!-- ───────────── Layer 4: Mid city ───────────── -->
+  <g fill="url(#cityMid-f1)">
+    <!-- Foreground / mid skyline buildings (taller, fuller) -->
+    <rect x="40"  y="240" width="38" height="120"/>
+    <rect x="82"  y="220" width="44" height="140"/>
+    <!-- Rooftop water tank on building 2 -->
+    <rect x="92"  y="210" width="14" height="10"/>
+    <rect x="130" y="260" width="36" height="100"/>
+    <rect x="170" y="232" width="42" height="128"/>
+    <!-- Stepped rooftop on building 4 -->
+    <rect x="180" y="222" width="22" height="10"/>
+    <rect x="216" y="218" width="38" height="142"/>
+    <rect x="258" y="248" width="34" height="112"/>
+    <rect x="296" y="226" width="46" height="134"/>
+    <!-- Antenna on building 7 -->
+    <line x1="319" y1="226" x2="319" y2="208" stroke="#0E1424" stroke-width="1.2"/>
+    <!-- Iconic central tower -->
+    <polygon points="370,180 386,160 386,360 354,360 354,180"/>
+    <rect x="396" y="248" width="36" height="112"/>
+    <rect x="436" y="234" width="42" height="126"/>
+    <!-- Rooftop antenna on building right of tower -->
+    <line x1="457" y1="234" x2="457" y2="218" stroke="#0E1424" stroke-width="1.2"/>
+    <rect x="482" y="220" width="38" height="140"/>
+    <!-- Dome / cylindrical top on building -->
+    <ellipse cx="501" cy="220" rx="19" ry="6"/>
+    <rect x="524" y="244" width="44" height="116"/>
+    <rect x="572" y="232" width="36" height="128"/>
+    <!-- Rooftop tank -->
+    <rect x="582" y="222" width="16" height="10"/>
+    <rect x="612" y="248" width="40" height="112"/>
+    <rect x="656" y="226" width="34" height="134"/>
+    <line x1="673" y1="226" x2="673" y2="206" stroke="#0E1424" stroke-width="1.2"/>
+    <rect x="694" y="240" width="44" height="120"/>
+    <rect x="742" y="220" width="38" height="140"/>
+    <!-- Pyramidal roof on tallest right building -->
+    <polygon points="742,220 780,220 761,204"/>
   </g>
 
-  <!-- Pencil lying on the desk (lower-right of canvas, off the card) -->
-  <g transform="translate(610,378) rotate(18)">
-    <!-- Pencil shadow -->
-    <ellipse cx="-12" cy="11" rx="64" ry="2.4" fill="#000000" opacity="0.45"/>
-    <!-- Wood body -->
-    <rect x="-82" y="-5" width="130" height="9" rx="1.5" fill="url(#pencil-f1)"/>
-    <!-- Wood grain (subtle stripes along length) -->
-    <g stroke="#8AA8E8" stroke-width="0.4" opacity="0.35">
-      <line x1="-78" y1="-2.5" x2="44" y2="-2.5"/>
-      <line x1="-72" y1="0"    x2="46" y2="0"/>
-      <line x1="-76" y1="2"    x2="42" y2="2"/>
-    </g>
-    <!-- Eraser end (warm amber) -->
-    <rect x="-90" y="-5" width="9"  height="9" rx="1.8" fill="#C49A3C"/>
-    <!-- Metal ferrule with tiny ridges -->
-    <rect x="-81" y="-5" width="3"  height="9" fill="#A89466"/>
-    <line x1="-80" y1="-5" x2="-80" y2="4" stroke="#7C6940" stroke-width="0.4"/>
-    <line x1="-79" y1="-5" x2="-79" y2="4" stroke="#7C6940" stroke-width="0.4"/>
-    <!-- Wood tip (sharpened cone) -->
-    <polygon points="48,-5 48,4 68,0" fill="#A89466"/>
-    <line x1="50" y1="-3.5" x2="64" y2="0"   stroke="#7C6940" stroke-width="0.4" opacity="0.6"/>
-    <line x1="50" y1="3.5"  x2="64" y2="0"   stroke="#7C6940" stroke-width="0.4" opacity="0.6"/>
-    <!-- Graphite tip -->
-    <polygon points="61,-2 61,1 68,0" fill="#1A2238"/>
-    <!-- Specular highlight -->
-    <line x1="-78" y1="-3" x2="46" y2="-3" stroke="#FFFFFF" stroke-width="0.8" opacity="0.22"/>
+  <!-- Mid-city windows (warmer, more visible) -->
+  <g fill="#F4D26A">
+    <!-- Building 1 -->
+    <circle cx="50" cy="252" r="1" opacity="0.85"/>
+    <circle cx="62" cy="252" r="0.9" opacity="0.7"/>
+    <circle cx="50" cy="270" r="0.9" opacity="0.7"/>
+    <circle cx="62" cy="270" r="1" opacity="0.85"/>
+    <circle cx="50" cy="288" r="0.9" opacity="0.65"/>
+    <circle cx="62" cy="288" r="0.9" opacity="0.7"/>
+    <circle cx="50" cy="306" r="1" opacity="0.85"/>
+    <circle cx="62" cy="306" r="0.9" opacity="0.7"/>
+    <circle cx="50" cy="324" r="0.9" opacity="0.65"/>
+    <circle cx="62" cy="324" r="0.9" opacity="0.7"/>
+    <!-- Building 2 -->
+    <circle cx="92"  cy="232" r="1" opacity="0.85"/>
+    <circle cx="104" cy="232" r="0.9" opacity="0.7"/>
+    <circle cx="116" cy="232" r="1" opacity="0.85"/>
+    <circle cx="92"  cy="250" r="0.9" opacity="0.65"/>
+    <circle cx="104" cy="250" r="1" opacity="0.85"/>
+    <circle cx="116" cy="250" r="0.9" opacity="0.7"/>
+    <circle cx="92"  cy="268" r="1" opacity="0.85"/>
+    <circle cx="104" cy="268" r="0.9" opacity="0.7"/>
+    <circle cx="116" cy="268" r="0.9" opacity="0.65"/>
+    <circle cx="92"  cy="286" r="0.9" opacity="0.65"/>
+    <circle cx="104" cy="286" r="1" opacity="0.85"/>
+    <circle cx="116" cy="286" r="0.9" opacity="0.7"/>
+    <circle cx="92"  cy="304" r="1" opacity="0.85"/>
+    <circle cx="104" cy="304" r="0.9" opacity="0.7"/>
+    <circle cx="116" cy="304" r="1" opacity="0.85"/>
+    <!-- Building 3 -->
+    <circle cx="140" cy="272" r="0.9" opacity="0.7"/>
+    <circle cx="152" cy="272" r="1" opacity="0.85"/>
+    <circle cx="140" cy="290" r="1" opacity="0.85"/>
+    <circle cx="152" cy="290" r="0.9" opacity="0.7"/>
+    <circle cx="140" cy="308" r="0.9" opacity="0.65"/>
+    <circle cx="152" cy="308" r="1" opacity="0.85"/>
+    <circle cx="140" cy="326" r="1" opacity="0.85"/>
+    <circle cx="152" cy="326" r="0.9" opacity="0.7"/>
+    <!-- Building 4 -->
+    <circle cx="180" cy="244" r="1" opacity="0.85"/>
+    <circle cx="192" cy="244" r="0.9" opacity="0.7"/>
+    <circle cx="204" cy="244" r="1" opacity="0.85"/>
+    <circle cx="180" cy="262" r="0.9" opacity="0.65"/>
+    <circle cx="192" cy="262" r="1" opacity="0.85"/>
+    <circle cx="204" cy="262" r="0.9" opacity="0.7"/>
+    <circle cx="180" cy="280" r="1" opacity="0.85"/>
+    <circle cx="192" cy="280" r="0.9" opacity="0.65"/>
+    <circle cx="204" cy="280" r="1" opacity="0.85"/>
+    <circle cx="180" cy="298" r="0.9" opacity="0.7"/>
+    <circle cx="192" cy="298" r="1" opacity="0.85"/>
+    <circle cx="204" cy="298" r="0.9" opacity="0.7"/>
+    <circle cx="180" cy="316" r="1" opacity="0.85"/>
+    <circle cx="192" cy="316" r="0.9" opacity="0.65"/>
+    <circle cx="204" cy="316" r="1" opacity="0.85"/>
+    <!-- Building 5 -->
+    <circle cx="226" cy="230" r="0.9" opacity="0.7"/>
+    <circle cx="240" cy="230" r="1" opacity="0.85"/>
+    <circle cx="226" cy="250" r="1" opacity="0.85"/>
+    <circle cx="240" cy="250" r="0.9" opacity="0.7"/>
+    <circle cx="226" cy="270" r="0.9" opacity="0.65"/>
+    <circle cx="240" cy="270" r="1" opacity="0.85"/>
+    <circle cx="226" cy="290" r="1" opacity="0.85"/>
+    <circle cx="240" cy="290" r="0.9" opacity="0.7"/>
+    <circle cx="226" cy="310" r="0.9" opacity="0.7"/>
+    <circle cx="240" cy="310" r="1" opacity="0.85"/>
+    <!-- Building 6 -->
+    <circle cx="268" cy="260" r="1" opacity="0.85"/>
+    <circle cx="280" cy="260" r="0.9" opacity="0.7"/>
+    <circle cx="268" cy="280" r="0.9" opacity="0.65"/>
+    <circle cx="280" cy="280" r="1" opacity="0.85"/>
+    <circle cx="268" cy="300" r="1" opacity="0.85"/>
+    <circle cx="280" cy="300" r="0.9" opacity="0.7"/>
+    <circle cx="268" cy="320" r="0.9" opacity="0.65"/>
+    <circle cx="280" cy="320" r="1" opacity="0.85"/>
+    <!-- Building 7 -->
+    <circle cx="306" cy="240" r="0.9" opacity="0.7"/>
+    <circle cx="318" cy="240" r="1" opacity="0.85"/>
+    <circle cx="332" cy="240" r="0.9" opacity="0.7"/>
+    <circle cx="306" cy="258" r="1" opacity="0.85"/>
+    <circle cx="318" cy="258" r="0.9" opacity="0.65"/>
+    <circle cx="332" cy="258" r="1" opacity="0.85"/>
+    <circle cx="306" cy="276" r="0.9" opacity="0.7"/>
+    <circle cx="318" cy="276" r="1" opacity="0.85"/>
+    <circle cx="332" cy="276" r="0.9" opacity="0.7"/>
+    <circle cx="306" cy="294" r="1" opacity="0.85"/>
+    <circle cx="318" cy="294" r="0.9" opacity="0.65"/>
+    <circle cx="332" cy="294" r="1" opacity="0.85"/>
+    <circle cx="306" cy="312" r="0.9" opacity="0.7"/>
+    <circle cx="318" cy="312" r="1" opacity="0.85"/>
+    <circle cx="332" cy="312" r="0.9" opacity="0.7"/>
+    <!-- Buildings to the right -->
+    <circle cx="406" cy="262" r="1" opacity="0.85"/>
+    <circle cx="418" cy="262" r="0.9" opacity="0.7"/>
+    <circle cx="406" cy="282" r="0.9" opacity="0.65"/>
+    <circle cx="418" cy="282" r="1" opacity="0.85"/>
+    <circle cx="406" cy="302" r="1" opacity="0.85"/>
+    <circle cx="418" cy="302" r="0.9" opacity="0.7"/>
+    <circle cx="406" cy="322" r="0.9" opacity="0.65"/>
+    <circle cx="418" cy="322" r="1" opacity="0.85"/>
+    <circle cx="446" cy="248" r="0.9" opacity="0.7"/>
+    <circle cx="458" cy="248" r="1" opacity="0.85"/>
+    <circle cx="470" cy="248" r="0.9" opacity="0.7"/>
+    <circle cx="446" cy="268" r="1" opacity="0.85"/>
+    <circle cx="458" cy="268" r="0.9" opacity="0.65"/>
+    <circle cx="470" cy="268" r="1" opacity="0.85"/>
+    <circle cx="446" cy="288" r="0.9" opacity="0.7"/>
+    <circle cx="458" cy="288" r="1" opacity="0.85"/>
+    <circle cx="470" cy="288" r="0.9" opacity="0.7"/>
+    <circle cx="446" cy="308" r="1" opacity="0.85"/>
+    <circle cx="458" cy="308" r="0.9" opacity="0.65"/>
+    <circle cx="470" cy="308" r="1" opacity="0.85"/>
+    <circle cx="446" cy="328" r="0.9" opacity="0.7"/>
+    <circle cx="458" cy="328" r="1" opacity="0.85"/>
+    <circle cx="470" cy="328" r="0.9" opacity="0.7"/>
+    <!-- Mid-right buildings -->
+    <circle cx="492" cy="232" r="1" opacity="0.85"/>
+    <circle cx="506" cy="232" r="0.9" opacity="0.7"/>
+    <circle cx="492" cy="252" r="0.9" opacity="0.65"/>
+    <circle cx="506" cy="252" r="1" opacity="0.85"/>
+    <circle cx="492" cy="272" r="1" opacity="0.85"/>
+    <circle cx="506" cy="272" r="0.9" opacity="0.7"/>
+    <circle cx="492" cy="292" r="0.9" opacity="0.65"/>
+    <circle cx="506" cy="292" r="1" opacity="0.85"/>
+    <circle cx="492" cy="312" r="1" opacity="0.85"/>
+    <circle cx="506" cy="312" r="0.9" opacity="0.7"/>
+    <circle cx="534" cy="258" r="0.9" opacity="0.7"/>
+    <circle cx="548" cy="258" r="1" opacity="0.85"/>
+    <circle cx="562" cy="258" r="0.9" opacity="0.7"/>
+    <circle cx="534" cy="278" r="1" opacity="0.85"/>
+    <circle cx="548" cy="278" r="0.9" opacity="0.65"/>
+    <circle cx="562" cy="278" r="1" opacity="0.85"/>
+    <circle cx="534" cy="298" r="0.9" opacity="0.7"/>
+    <circle cx="548" cy="298" r="1" opacity="0.85"/>
+    <circle cx="562" cy="298" r="0.9" opacity="0.7"/>
+    <circle cx="534" cy="318" r="1" opacity="0.85"/>
+    <circle cx="548" cy="318" r="0.9" opacity="0.65"/>
+    <circle cx="562" cy="318" r="1" opacity="0.85"/>
+    <circle cx="582" cy="244" r="0.9" opacity="0.7"/>
+    <circle cx="594" cy="244" r="1" opacity="0.85"/>
+    <circle cx="582" cy="264" r="1" opacity="0.85"/>
+    <circle cx="594" cy="264" r="0.9" opacity="0.7"/>
+    <circle cx="582" cy="284" r="0.9" opacity="0.65"/>
+    <circle cx="594" cy="284" r="1" opacity="0.85"/>
+    <circle cx="582" cy="304" r="1" opacity="0.85"/>
+    <circle cx="594" cy="304" r="0.9" opacity="0.7"/>
+    <circle cx="582" cy="324" r="0.9" opacity="0.7"/>
+    <circle cx="594" cy="324" r="1" opacity="0.85"/>
+    <!-- Far right buildings -->
+    <circle cx="622" cy="260" r="1" opacity="0.85"/>
+    <circle cx="634" cy="260" r="0.9" opacity="0.7"/>
+    <circle cx="622" cy="280" r="0.9" opacity="0.65"/>
+    <circle cx="634" cy="280" r="1" opacity="0.85"/>
+    <circle cx="622" cy="300" r="1" opacity="0.85"/>
+    <circle cx="634" cy="300" r="0.9" opacity="0.7"/>
+    <circle cx="622" cy="320" r="0.9" opacity="0.65"/>
+    <circle cx="634" cy="320" r="1" opacity="0.85"/>
+    <circle cx="664" cy="240" r="0.9" opacity="0.7"/>
+    <circle cx="676" cy="240" r="1" opacity="0.85"/>
+    <circle cx="664" cy="260" r="1" opacity="0.85"/>
+    <circle cx="676" cy="260" r="0.9" opacity="0.65"/>
+    <circle cx="664" cy="280" r="0.9" opacity="0.7"/>
+    <circle cx="676" cy="280" r="1" opacity="0.85"/>
+    <circle cx="664" cy="300" r="1" opacity="0.85"/>
+    <circle cx="676" cy="300" r="0.9" opacity="0.7"/>
+    <circle cx="664" cy="320" r="0.9" opacity="0.65"/>
+    <circle cx="676" cy="320" r="1" opacity="0.85"/>
+    <circle cx="704" cy="252" r="1" opacity="0.85"/>
+    <circle cx="716" cy="252" r="0.9" opacity="0.7"/>
+    <circle cx="728" cy="252" r="1" opacity="0.85"/>
+    <circle cx="704" cy="272" r="0.9" opacity="0.65"/>
+    <circle cx="716" cy="272" r="1" opacity="0.85"/>
+    <circle cx="728" cy="272" r="0.9" opacity="0.7"/>
+    <circle cx="704" cy="292" r="1" opacity="0.85"/>
+    <circle cx="716" cy="292" r="0.9" opacity="0.7"/>
+    <circle cx="728" cy="292" r="1" opacity="0.85"/>
+    <circle cx="704" cy="312" r="0.9" opacity="0.65"/>
+    <circle cx="716" cy="312" r="1" opacity="0.85"/>
+    <circle cx="728" cy="312" r="0.9" opacity="0.7"/>
+    <circle cx="704" cy="332" r="1" opacity="0.85"/>
+    <circle cx="716" cy="332" r="0.9" opacity="0.7"/>
+    <circle cx="728" cy="332" r="1" opacity="0.85"/>
+    <circle cx="754" cy="232" r="0.9" opacity="0.7"/>
+    <circle cx="766" cy="232" r="1" opacity="0.85"/>
+    <circle cx="754" cy="252" r="1" opacity="0.85"/>
+    <circle cx="766" cy="252" r="0.9" opacity="0.65"/>
+    <circle cx="754" cy="272" r="0.9" opacity="0.7"/>
+    <circle cx="766" cy="272" r="1" opacity="0.85"/>
+    <circle cx="754" cy="292" r="1" opacity="0.85"/>
+    <circle cx="766" cy="292" r="0.9" opacity="0.7"/>
+    <circle cx="754" cy="312" r="0.9" opacity="0.65"/>
+    <circle cx="766" cy="312" r="1" opacity="0.85"/>
   </g>
 
-  <!-- Eraser shavings + desk dust -->
-  <g fill="#C49A3C">
-    <circle cx="180" cy="350" r="1.4" opacity="0.55"/>
-    <circle cx="195" cy="358" r="1.0" opacity="0.45"/>
-    <circle cx="172" cy="365" r="0.8" opacity="0.40"/>
-    <circle cx="650" cy="358" r="1.0" opacity="0.50"/>
-    <circle cx="635" cy="350" r="0.7" opacity="0.40"/>
-    <circle cx="668" cy="346" r="0.5" opacity="0.30"/>
-    <circle cx="715" cy="370" r="0.9" opacity="0.45"/>
-    <circle cx="155" cy="338" r="0.6" opacity="0.35"/>
+  <!-- Iconic central tower antenna + windows + warm tip light -->
+  <line x1="370" y1="180" x2="370" y2="155" stroke="#0E1424" stroke-width="2"/>
+  <g fill="#F4D26A">
+    <circle cx="370" cy="200" r="0.9" opacity="0.85"/>
+    <circle cx="370" cy="220" r="1.0" opacity="0.85"/>
+    <circle cx="370" cy="240" r="0.9" opacity="0.7"/>
+    <circle cx="370" cy="260" r="1.0" opacity="0.85"/>
+    <circle cx="370" cy="280" r="0.9" opacity="0.7"/>
+    <circle cx="370" cy="300" r="1.0" opacity="0.85"/>
+    <circle cx="370" cy="320" r="0.9" opacity="0.7"/>
+    <circle cx="370" cy="340" r="1.0" opacity="0.85"/>
+  </g>
+
+  <!-- Light beam from tower beacon up to the constellation convergence point -->
+  <defs>
+    <linearGradient id="beam-f1" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%"  stop-color="#F4D26A" stop-opacity="0.55"/>
+      <stop offset="60%" stop-color="#7AAEFF" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#7AAEFF" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <polygon points="368,158 372,158 376,90 364,90" fill="url(#beam-f1)" opacity="0.85"/>
+  <line x1="370" y1="155" x2="370" y2="92" stroke="#F4D26A" stroke-width="0.8" opacity="0.45"/>
+
+  <!-- Tower beacon (warm pulse atop) — bigger, more prominent -->
+  <circle cx="370" cy="160" r="22" fill="url(#rootGlow-f1)" opacity="0.55"/>
+  <circle cx="370" cy="160" r="12" fill="url(#rootGlow-f1)" opacity="0.95"/>
+  <circle cx="370" cy="160" r="3.5" fill="#FFF5D6" opacity="1"/>
+
+  <!-- ───────────── Layer 5: Decomposition tree (luminous overlay) ───────────── -->
+  <!-- Root at the central tower beacon (370,160) -->
+  <!-- Branches reach out to landmark buildings across the city -->
+  <g fill="none" stroke="#7AAEFF" stroke-width="1.4" stroke-linecap="round" opacity="0.85" filter="url(#softGlow-f1)">
+    <!-- Primary branches: 3 directions -->
+    <path d="M 370 160 C 320 130, 240 110, 160 100"/>
+    <path d="M 370 160 C 410 130, 470 110, 540 100"/>
+    <path d="M 370 160 C 380 120, 400 90, 420 70"/>
+
+    <!-- Secondary branches off each primary -->
+    <path d="M 160 100 C 140 90, 110 86, 80 80"/>
+    <path d="M 160 100 C 150 80, 130 66, 110 56"/>
+    <path d="M 160 100 C 180 86, 200 72, 220 60"/>
+    <path d="M 540 100 C 580 90, 620 84, 660 78"/>
+    <path d="M 540 100 C 570 78, 610 60, 650 50"/>
+    <path d="M 540 100 C 510 80, 480 60, 450 46"/>
+    <path d="M 420 70  C 430 50, 440 36, 450 26"/>
+    <path d="M 420 70  C 380 50, 350 36, 320 28"/>
+  </g>
+  <!-- Sharper inner stroke on top for luminance -->
+  <g fill="none" stroke="#C9DBFF" stroke-width="0.6" stroke-linecap="round" opacity="0.9">
+    <path d="M 370 160 C 320 130, 240 110, 160 100"/>
+    <path d="M 370 160 C 410 130, 470 110, 540 100"/>
+    <path d="M 370 160 C 380 120, 400 90, 420 70"/>
+    <path d="M 160 100 C 140 90, 110 86, 80 80"/>
+    <path d="M 160 100 C 150 80, 130 66, 110 56"/>
+    <path d="M 160 100 C 180 86, 200 72, 220 60"/>
+    <path d="M 540 100 C 580 90, 620 84, 660 78"/>
+    <path d="M 540 100 C 570 78, 610 60, 650 50"/>
+    <path d="M 540 100 C 510 80, 480 60, 450 46"/>
+    <path d="M 420 70  C 430 50, 440 36, 450 26"/>
+    <path d="M 420 70  C 380 50, 350 36, 320 28"/>
+  </g>
+
+  <!-- Decomposition nodes (glowing dots at junctions) -->
+  <g>
+    <!-- Primary nodes -->
+    <circle cx="160" cy="100" r="14" fill="url(#nodeGlow-f1)" opacity="0.9"/>
+    <circle cx="160" cy="100" r="3"  fill="#C9DBFF"/>
+    <circle cx="540" cy="100" r="14" fill="url(#nodeGlow-f1)" opacity="0.9"/>
+    <circle cx="540" cy="100" r="3"  fill="#C9DBFF"/>
+    <circle cx="420" cy="70"  r="12" fill="url(#nodeGlow-f1)" opacity="0.9"/>
+    <circle cx="420" cy="70"  r="2.6" fill="#C9DBFF"/>
+    <!-- Secondary leaf nodes -->
+    <circle cx="80"  cy="80"  r="7" fill="url(#nodeGlow-f1)" opacity="0.85"/>
+    <circle cx="80"  cy="80"  r="1.6" fill="#C9DBFF"/>
+    <circle cx="110" cy="56"  r="7" fill="url(#nodeGlow-f1)" opacity="0.85"/>
+    <circle cx="110" cy="56"  r="1.6" fill="#C9DBFF"/>
+    <circle cx="220" cy="60"  r="7" fill="url(#nodeGlow-f1)" opacity="0.85"/>
+    <circle cx="220" cy="60"  r="1.6" fill="#C9DBFF"/>
+    <circle cx="660" cy="78"  r="7" fill="url(#nodeGlow-f1)" opacity="0.85"/>
+    <circle cx="660" cy="78"  r="1.6" fill="#C9DBFF"/>
+    <circle cx="650" cy="50"  r="7" fill="url(#nodeGlow-f1)" opacity="0.85"/>
+    <circle cx="650" cy="50"  r="1.6" fill="#C9DBFF"/>
+    <circle cx="450" cy="46"  r="7" fill="url(#nodeGlow-f1)" opacity="0.85"/>
+    <circle cx="450" cy="46"  r="1.6" fill="#C9DBFF"/>
+    <circle cx="450" cy="26"  r="7" fill="url(#nodeGlow-f1)" opacity="0.85"/>
+    <circle cx="450" cy="26"  r="1.6" fill="#C9DBFF"/>
+    <circle cx="320" cy="28"  r="7" fill="url(#nodeGlow-f1)" opacity="0.85"/>
+    <circle cx="320" cy="28"  r="1.6" fill="#C9DBFF"/>
+  </g>
+
+  <!-- ───────────── Layer 6: Foreground floor / reflection ───────────── -->
+  <rect x="0" y="350" width="800" height="50" fill="url(#floor-f1)"/>
+
+  <!-- Subtle vertical reflection streaks (city lights bouncing) -->
+  <g fill="#F4D26A" opacity="0.45" filter="url(#cityHaze-f1)">
+    <rect x="49" y="360" width="1.2" height="14"/>
+    <rect x="103" y="360" width="1" height="22"/>
+    <rect x="195" y="360" width="1.4" height="20"/>
+    <rect x="270" y="360" width="1" height="18"/>
+    <rect x="318" y="360" width="1.2" height="22"/>
+    <rect x="370" y="360" width="2" height="36" opacity="0.7"/>
+    <rect x="455" y="360" width="1" height="18"/>
+    <rect x="500" y="360" width="1.2" height="20"/>
+    <rect x="548" y="360" width="1" height="22"/>
+    <rect x="635" y="360" width="1.2" height="18"/>
+    <rect x="715" y="360" width="1" height="20"/>
+    <rect x="765" y="360" width="1.2" height="16"/>
+  </g>
+
+  <!-- ───────────── Layer 7: Atmospheric grain on whole frame ───────────── -->
+  <rect width="800" height="400" filter="url(#grain-f1)" opacity="0.5"/>
+
+  <!-- Fine atmospheric particles (foreground dust / floating) -->
+  <g fill="#F4D26A">
+    <circle cx="120" cy="180" r="0.7" opacity="0.45"/>
+    <circle cx="280" cy="150" r="0.5" opacity="0.35"/>
+    <circle cx="500" cy="170" r="0.6" opacity="0.40"/>
+    <circle cx="640" cy="140" r="0.5" opacity="0.35"/>
+    <circle cx="180" cy="130" r="0.4" opacity="0.30"/>
+    <circle cx="700" cy="180" r="0.6" opacity="0.40"/>
+    <circle cx="380" cy="120" r="0.5" opacity="0.35"/>
   </g>
 </svg>

--- a/public/images/v3/lesson-77.svg
+++ b/public/images/v3/lesson-77.svg
@@ -1,0 +1,353 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <!-- Ancient study: deep umber → warm dark wood -->
+    <linearGradient id="study-l77" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%"  stop-color="#3A2A1A"/>
+      <stop offset="50%" stop-color="#28190E"/>
+      <stop offset="100%" stop-color="#160C04"/>
+    </linearGradient>
+
+    <!-- Oil lamp glow (upper-right, more saturated than fermi) -->
+    <radialGradient id="lamp-l77" cx="0.84" cy="0.18" r="0.7">
+      <stop offset="0%"   stop-color="#FFC65A" stop-opacity="0.65"/>
+      <stop offset="22%"  stop-color="#E89540" stop-opacity="0.40"/>
+      <stop offset="55%"  stop-color="#A85F2B" stop-opacity="0.18"/>
+      <stop offset="100%" stop-color="#A85F2B" stop-opacity="0"/>
+    </radialGradient>
+
+    <!-- Diagonal warm light rays -->
+    <linearGradient id="ray-l77" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%"   stop-color="#FFC65A" stop-opacity="0.22"/>
+      <stop offset="40%"  stop-color="#FFC65A" stop-opacity="0.07"/>
+      <stop offset="100%" stop-color="#FFC65A" stop-opacity="0"/>
+    </linearGradient>
+
+    <!-- Parchment: aged cream → warm orange-tan -->
+    <linearGradient id="parch-l77" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%"  stop-color="#F0DFA8"/>
+      <stop offset="55%" stop-color="#DBC384"/>
+      <stop offset="100%" stop-color="#B89854"/>
+    </linearGradient>
+    <!-- Lamp warm cast on parchment top-right -->
+    <radialGradient id="parchWarm-l77" cx="0.92" cy="0.08" r="0.95">
+      <stop offset="0%"  stop-color="#FFC65A" stop-opacity="0.45"/>
+      <stop offset="55%" stop-color="#FFC65A" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="#FFC65A" stop-opacity="0"/>
+    </radialGradient>
+    <!-- Rolled-end shading -->
+    <linearGradient id="rollEnd-l77" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%"  stop-color="#7C5A28"/>
+      <stop offset="50%" stop-color="#A88848"/>
+      <stop offset="100%" stop-color="#7C5A28"/>
+    </linearGradient>
+
+    <!-- Greek column gradient (faded warm grey) -->
+    <linearGradient id="col-l77" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%"  stop-color="#5A4838" stop-opacity="0.7"/>
+      <stop offset="50%" stop-color="#8A7860" stop-opacity="0.7"/>
+      <stop offset="100%" stop-color="#5A4838" stop-opacity="0.7"/>
+    </linearGradient>
+
+    <!-- Quill feather gradient -->
+    <linearGradient id="feather-l77" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%"  stop-color="#E8D8A8"/>
+      <stop offset="50%" stop-color="#C8A878"/>
+      <stop offset="100%" stop-color="#A88848"/>
+    </linearGradient>
+
+    <!-- Brass / ink well -->
+    <radialGradient id="brass-l77" cx="0.4" cy="0.3" r="0.7">
+      <stop offset="0%"  stop-color="#D4A848"/>
+      <stop offset="60%" stop-color="#8A6028"/>
+      <stop offset="100%" stop-color="#3A2810"/>
+    </radialGradient>
+
+    <!-- Filters -->
+    <filter id="grain-l77" x="0%" y="0%" width="100%" height="100%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="11"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.36  0 0 0 0 0.28  0 0 0 0 0.18  0 0 0 0.20 0"/>
+      <feComposite operator="in" in2="SourceGraphic"/>
+    </filter>
+    <filter id="parchGrain-l77" x="0%" y="0%" width="100%" height="100%">
+      <feTurbulence type="fractalNoise" baseFrequency="1.3" numOctaves="2" seed="5"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.50  0 0 0 0 0.38  0 0 0 0 0.20  0 0 0 0.22 0"/>
+      <feComposite operator="in" in2="SourceGraphic"/>
+    </filter>
+    <filter id="scrollShadow-l77" x="-15%" y="-15%" width="130%" height="135%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="11"/>
+      <feOffset dx="0" dy="14"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.6"/></feComponentTransfer>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="softBlur-l77"><feGaussianBlur stdDeviation="2"/></filter>
+    <filter id="flameGlow-l77" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4"/>
+    </filter>
+
+    <!-- Parchment shape (irregular scroll body, both ends with rolled bumps) -->
+    <clipPath id="scrollShape-l77">
+      <path d="
+        M -240 -100
+        C -180 -106, -80 -103, 0 -105
+        C 80 -107, 180 -104, 240 -100
+        C 244 -50, 243 -10, 244 50
+        C 245 90, 244 100, 240 102
+        C 180 106, 80 102, 0 103
+        C -80 104, -180 107, -240 102
+        C -244 60, -243 10, -244 -50
+        C -245 -90, -244 -95, -240 -100
+        Z"/>
+    </clipPath>
+  </defs>
+
+  <!-- ───── Layer 1: Ancient study background ───── -->
+  <rect width="800" height="400" fill="url(#study-l77)"/>
+  <rect width="800" height="400" fill="url(#lamp-l77)"/>
+
+  <!-- Diagonal warm rays -->
+  <g opacity="0.85">
+    <polygon points="800,0 800,90 220,400 140,400" fill="url(#ray-l77)"/>
+    <polygon points="800,50 800,150 380,400 300,400" fill="url(#ray-l77)" opacity="0.7"/>
+    <polygon points="800,140 800,240 540,400 480,400" fill="url(#ray-l77)" opacity="0.5"/>
+  </g>
+
+  <!-- Wood-grain hints on desk surface -->
+  <g stroke="#1A0E04" stroke-width="0.5" opacity="0.35">
+    <line x1="0" y1="280" x2="800" y2="290"/>
+    <line x1="0" y1="320" x2="800" y2="328"/>
+    <line x1="0" y1="350" x2="800" y2="358"/>
+  </g>
+  <rect width="800" height="400" filter="url(#grain-l77)" opacity="0.55"/>
+
+  <!-- ───── Layer 2: Greek Doric column (left, faded) ───── -->
+  <g transform="translate(95,200)" opacity="0.78">
+    <!-- Capital (top block) -->
+    <rect x="-44" y="-180" width="88" height="10" fill="url(#col-l77)"/>
+    <rect x="-40" y="-170" width="80" height="6"  fill="#3A2810" opacity="0.5"/>
+    <!-- Echinus -->
+    <path d="M -38 -164 Q -32 -156, 0 -156 Q 32 -156, 38 -164 Z" fill="url(#col-l77)"/>
+    <!-- Shaft (fluted) -->
+    <rect x="-30" y="-156" width="60" height="320" fill="url(#col-l77)"/>
+    <g stroke="#3A2810" stroke-width="0.8" opacity="0.55">
+      <line x1="-22" y1="-150" x2="-22" y2="160"/>
+      <line x1="-12" y1="-150" x2="-12" y2="160"/>
+      <line x1="-2"  y1="-150" x2="-2"  y2="160"/>
+      <line x1="8"   y1="-150" x2="8"   y2="160"/>
+      <line x1="18"  y1="-150" x2="18"  y2="160"/>
+    </g>
+    <!-- Highlight from lamp on right side of shaft -->
+    <rect x="22" y="-156" width="8" height="320" fill="#FFC65A" opacity="0.18"/>
+    <!-- Base -->
+    <rect x="-40" y="160" width="80" height="6" fill="#3A2810" opacity="0.5"/>
+    <rect x="-44" y="166" width="88" height="10" fill="url(#col-l77)"/>
+    <!-- Soft halo around column -->
+    <rect x="-50" y="-186" width="100" height="368" filter="url(#softBlur-l77)" fill="#5A4838" opacity="0.18"/>
+  </g>
+
+  <!-- ───── Layer 3: Oil lamp (upper-right) — clay vessel with flame ───── -->
+  <g transform="translate(680,108)">
+    <!-- Lamp body (clay/brass) -->
+    <ellipse cx="0" cy="14" rx="48" ry="10" fill="#3A2810" opacity="0.55"/>
+    <path d="M -42 0 Q -48 -16, -28 -22 L 28 -22 Q 48 -16, 42 0 Q 38 12, 0 14 Q -38 12, -42 0 Z"
+          fill="url(#brass-l77)"/>
+    <!-- Wick housing -->
+    <path d="M 28 -22 L 56 -28 L 60 -18 L 36 -8 Z" fill="url(#brass-l77)"/>
+    <!-- Highlight band -->
+    <path d="M -32 -14 Q 0 -20, 32 -14" stroke="#F4D26A" stroke-width="1.2" opacity="0.7" fill="none" stroke-linecap="round"/>
+    <!-- Handle on left (loop) -->
+    <path d="M -42 -8 Q -58 -10, -56 -2 Q -50 4, -42 0" stroke="#8A6028" stroke-width="2.5" fill="none"/>
+    <!-- Flame -->
+    <g filter="url(#flameGlow-l77)">
+      <path d="M 50 -28 Q 56 -42, 60 -28 Q 56 -36, 52 -42 Q 48 -36, 50 -28 Z"
+            fill="#FFC65A" opacity="0.95"/>
+    </g>
+    <path d="M 50 -28 Q 56 -42, 60 -28 Q 56 -36, 52 -42 Q 48 -36, 50 -28 Z"
+          fill="#FFF0C4" opacity="0.95"/>
+    <ellipse cx="55" cy="-28" rx="3" ry="6" fill="#E8965D" opacity="0.7"/>
+  </g>
+
+  <!-- ───── Layer 4: Atmospheric dust motes / smoke from flame ───── -->
+  <g fill="#FFC65A">
+    <circle cx="730" cy="60"  r="0.7" opacity="0.45"/>
+    <circle cx="755" cy="80"  r="1.1" opacity="0.55"/>
+    <circle cx="710" cy="40"  r="0.6" opacity="0.40"/>
+    <circle cx="700" cy="20"  r="0.4" opacity="0.30"/>
+    <circle cx="680" cy="160" r="0.6" opacity="0.40"/>
+    <circle cx="600" cy="180" r="0.7" opacity="0.40"/>
+    <circle cx="540" cy="130" r="0.5" opacity="0.35"/>
+    <circle cx="640" cy="220" r="0.6" opacity="0.35"/>
+    <circle cx="450" cy="100" r="0.5" opacity="0.30"/>
+  </g>
+
+  <!-- ───── Layer 5: Parchment scroll (center, both ends rolled) ───── -->
+  <g transform="translate(400,210) rotate(-1)" filter="url(#scrollShadow-l77)">
+    <!-- Left rolled end -->
+    <g>
+      <ellipse cx="-242" cy="0" rx="20" ry="105" fill="url(#rollEnd-l77)"/>
+      <ellipse cx="-234" cy="0" rx="14" ry="100" fill="#3A2810" opacity="0.6"/>
+      <!-- Inner roll texture lines -->
+      <g stroke="#3A2810" stroke-width="0.5" opacity="0.5">
+        <line x1="-244" y1="-95" x2="-238" y2="-95"/>
+        <line x1="-244" y1="-60" x2="-238" y2="-60"/>
+        <line x1="-244" y1="-30" x2="-238" y2="-30"/>
+        <line x1="-244" y1="0"   x2="-238" y2="0"/>
+        <line x1="-244" y1="30"  x2="-238" y2="30"/>
+        <line x1="-244" y1="60"  x2="-238" y2="60"/>
+        <line x1="-244" y1="95"  x2="-238" y2="95"/>
+      </g>
+    </g>
+    <!-- Right rolled end -->
+    <g>
+      <ellipse cx="242" cy="0" rx="20" ry="105" fill="url(#rollEnd-l77)"/>
+      <ellipse cx="234" cy="0" rx="14" ry="100" fill="#3A2810" opacity="0.6"/>
+      <g stroke="#3A2810" stroke-width="0.5" opacity="0.5">
+        <line x1="238" y1="-95" x2="244" y2="-95"/>
+        <line x1="238" y1="-60" x2="244" y2="-60"/>
+        <line x1="238" y1="-30" x2="244" y2="-30"/>
+        <line x1="238" y1="0"   x2="244" y2="0"/>
+        <line x1="238" y1="30"  x2="244" y2="30"/>
+        <line x1="238" y1="60"  x2="244" y2="60"/>
+        <line x1="238" y1="95"  x2="244" y2="95"/>
+      </g>
+    </g>
+
+    <!-- Parchment body (irregular shape, between the two rolls) -->
+    <path d="
+      M -240 -100
+      C -180 -106, -80 -103, 0 -105
+      C 80 -107, 180 -104, 240 -100
+      C 244 -50, 243 -10, 244 50
+      C 245 90, 244 100, 240 102
+      C 180 106, 80 102, 0 103
+      C -80 104, -180 107, -240 102
+      C -244 60, -243 10, -244 -50
+      C -245 -90, -244 -95, -240 -100
+      Z" fill="url(#parch-l77)"/>
+
+    <!-- Warm cast + parchment grain -->
+    <g clip-path="url(#scrollShape-l77)">
+      <rect x="-245" y="-110" width="495" height="220" fill="url(#parchWarm-l77)"/>
+      <rect x="-245" y="-110" width="495" height="220" filter="url(#parchGrain-l77)" opacity="0.55"/>
+    </g>
+
+    <!-- Faint horizontal lines (where dialogue would go) -->
+    <g stroke="#7C5A28" stroke-width="0.4" opacity="0.20">
+      <line x1="-220" y1="-70" x2="220" y2="-68"/>
+      <line x1="-220" y1="-40" x2="220" y2="-38"/>
+      <line x1="-220" y1="-10" x2="220" y2="-8"/>
+      <line x1="-220" y1="20"  x2="220" y2="22"/>
+      <line x1="-220" y1="50"  x2="220" y2="52"/>
+      <line x1="-220" y1="80"  x2="220" y2="82"/>
+    </g>
+
+    <!-- Big central question mark (the Socratic core) -->
+    <g font-family="'Trajan Pro','Times New Roman','Hiragino Mincho ProN',serif" fill="#5C2E1F">
+      <text x="0" y="40" text-anchor="middle" font-size="120" font-weight="700" opacity="0.85">?</text>
+    </g>
+    <!-- Brush stroke under the question mark -->
+    <path d="M -42 70 C -20 76, 22 76, 44 70" stroke="#5C2E1F" stroke-width="2.4" stroke-linecap="round" fill="none" opacity="0.6"/>
+
+    <!-- Smaller satellite question marks (the cascade of questions) -->
+    <g font-family="'Trajan Pro','Times New Roman','Hiragino Mincho ProN',serif" fill="#5C2E1F">
+      <text x="-180" y="-40" text-anchor="middle" font-size="32" font-weight="700" opacity="0.55" transform="rotate(-12 -180 -40)">?</text>
+      <text x="-130" y="-70" text-anchor="middle" font-size="22" font-weight="700" opacity="0.40" transform="rotate(8 -130 -70)">?</text>
+      <text x="160" y="-50" text-anchor="middle" font-size="36" font-weight="700" opacity="0.55" transform="rotate(15 160 -50)">?</text>
+      <text x="125" y="-78" text-anchor="middle" font-size="20" font-weight="700" opacity="0.42" transform="rotate(-6 125 -78)">?</text>
+      <text x="-150" y="80" text-anchor="middle" font-size="26" font-weight="700" opacity="0.45" transform="rotate(-8 -150 80)">?</text>
+      <text x="170" y="80" text-anchor="middle" font-size="24" font-weight="700" opacity="0.45" transform="rotate(10 170 80)">?</text>
+    </g>
+
+    <!-- Greek alpha and omega (philosophical bookends) — small, faint, in corners -->
+    <g font-family="'Times New Roman',serif" fill="#5C2E1F" opacity="0.5">
+      <text x="-205" y="-72" font-size="20" font-style="italic">α</text>
+      <text x="195"  y="92"  font-size="20" font-style="italic">ω</text>
+    </g>
+
+    <!-- Connecting curve lines between the questions (Socratic chain) -->
+    <g stroke="#5C2E1F" stroke-width="1.0" stroke-linecap="round" fill="none" opacity="0.32" stroke-dasharray="2 5">
+      <path d="M -150 -45 C -110 -30, -50 -15, 0 0"/>
+      <path d="M 0 0 C 60 -10, 110 -25, 155 -45"/>
+      <path d="M -130 80 C -80 65, -30 55, 0 50"/>
+      <path d="M 0 50 C 60 60, 110 70, 160 80"/>
+    </g>
+
+    <!-- Wax seal at lower-right -->
+    <g transform="translate(200,75)">
+      <circle cx="0" cy="0" r="14" fill="#7B2D26" opacity="0.85"/>
+      <circle cx="0" cy="0" r="14" fill="none" stroke="#3A1010" stroke-width="0.5" opacity="0.6"/>
+      <text x="0" y="4" text-anchor="middle" font-family="'Times New Roman',serif" font-size="14" font-weight="700" fill="#F0DFA8">Σ</text>
+    </g>
+  </g>
+
+  <!-- ───── Layer 6: Quill pen lying on lower right ───── -->
+  <g transform="translate(620,360) rotate(-32)">
+    <!-- Shadow -->
+    <ellipse cx="0" cy="14" rx="80" ry="3" fill="#000000" opacity="0.45"/>
+    <!-- Shaft (taper) -->
+    <path d="M -90 -2 L 50 -3 L 60 0 L 50 3 L -90 2 Z" fill="#A88848"/>
+    <!-- Nib (metal tip) -->
+    <polygon points="50,-3 64,0 50,3 56,0" fill="#3A2810"/>
+    <!-- Ink at nib -->
+    <circle cx="64" cy="0" r="1.2" fill="#0A0A14"/>
+    <!-- Feather plume -->
+    <g transform="translate(-90,0)">
+      <!-- Main feather body -->
+      <path d="M 0 0 Q -30 -22, -86 -18 Q -110 -10, -120 0 Q -110 10, -86 18 Q -30 22, 0 0 Z"
+            fill="url(#feather-l77)" opacity="0.95"/>
+      <!-- Spine -->
+      <line x1="0" y1="0" x2="-120" y2="0" stroke="#7C5A28" stroke-width="0.8"/>
+      <!-- Barbs (radiating lines for feather texture) -->
+      <g stroke="#7C5A28" stroke-width="0.4" opacity="0.6">
+        <line x1="-12" y1="0" x2="-22" y2="-10"/>
+        <line x1="-22" y1="0" x2="-32" y2="-14"/>
+        <line x1="-32" y1="0" x2="-44" y2="-16"/>
+        <line x1="-44" y1="0" x2="-56" y2="-17"/>
+        <line x1="-56" y1="0" x2="-70" y2="-17"/>
+        <line x1="-70" y1="0" x2="-86" y2="-16"/>
+        <line x1="-86" y1="0" x2="-102" y2="-12"/>
+        <line x1="-12" y1="0" x2="-22" y2="10"/>
+        <line x1="-22" y1="0" x2="-32" y2="14"/>
+        <line x1="-32" y1="0" x2="-44" y2="16"/>
+        <line x1="-44" y1="0" x2="-56" y2="17"/>
+        <line x1="-56" y1="0" x2="-70" y2="17"/>
+        <line x1="-70" y1="0" x2="-86" y2="16"/>
+        <line x1="-86" y1="0" x2="-102" y2="12"/>
+      </g>
+    </g>
+  </g>
+
+  <!-- ───── Layer 7: Brass ink well (left of scroll, on the desk) ───── -->
+  <g transform="translate(135,335)">
+    <!-- Shadow -->
+    <ellipse cx="0" cy="14" rx="22" ry="3" fill="#000000" opacity="0.5"/>
+    <!-- Body -->
+    <path d="M -18 -4 L -16 12 Q 0 16, 16 12 L 18 -4 Q 0 -8, -18 -4 Z" fill="url(#brass-l77)"/>
+    <!-- Rim -->
+    <ellipse cx="0" cy="-4" rx="18" ry="4" fill="#8A6028"/>
+    <ellipse cx="0" cy="-4" rx="14" ry="3" fill="#0A0A14"/>
+    <!-- Ink surface highlight -->
+    <ellipse cx="-3" cy="-5" rx="5" ry="0.8" fill="#3A4060" opacity="0.6"/>
+    <!-- Brass highlight -->
+    <path d="M -14 0 Q -12 8, -10 11" stroke="#F4D26A" stroke-width="0.8" opacity="0.7" fill="none"/>
+  </g>
+
+  <!-- Ink droplets / blots scattered near ink well -->
+  <g fill="#0A0A14" opacity="0.7">
+    <circle cx="170" cy="345" r="1.4"/>
+    <circle cx="178" cy="352" r="0.8"/>
+    <circle cx="155" cy="360" r="1.0"/>
+    <circle cx="105" cy="350" r="0.7"/>
+  </g>
+
+  <!-- Eraser-like dust + scattered desk marks -->
+  <g fill="#A88848">
+    <circle cx="240" cy="370" r="1.2" opacity="0.55"/>
+    <circle cx="265" cy="378" r="0.9" opacity="0.45"/>
+    <circle cx="525" cy="372" r="1.0" opacity="0.5"/>
+    <circle cx="555" cy="380" r="0.7" opacity="0.4"/>
+    <circle cx="700" cy="370" r="0.6" opacity="0.35"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

レッスン・コースのビジュアル（サムネイル、図解、コース画像）を「概念 → 形」の対応を出してから生成する、書き込み可能なサブエージェントを追加。

スコープは Logic アプリで実在する 4 つのビジュアル表面に限定：

1. **レッスン別 SVG サムネイル** — `src/components/LessonThumbnail.tsx` の `SHAPES` マップ + `getPalette` への配線。100×100 viewBox、ダークマット背景＋単色ストローク。
2. **レッスン内コンセプト図解** — `src/LessonDiagrams.tsx` + `LessonDiagrams.css`。レッスンの `step.visual: 'XxxDiagram'` 文字列で参照される `Lesson.tsx` の `diagramMap` も自動更新。
3. **コースサムネイル** — `public/images/v3/course-*.svg`（800×400 viewBox、Slate Blue グラデ＋ホワイトボード等の Awarefy 風シーン）と `src/courseData.ts` の `image:` 配線。
4. **レッスンヒーロー画像のプロンプト** — `docs/THUMBNAILS_MANIFEST.md` の Pixa 生成フロー前提で、テンプレ＋優先度付きの一覧を出力し `src/lessonSlides.ts` の `LESSON_IMAGES` 更新案も合わせて提示。

## 既存サブエージェントとの境界

- `content-reviewer` — レッスン本文・フェルミ計算・正答の妥当性。
- `ux-reviewer` — UI/UX/a11y/デザインシステム整合（絵文字禁止・色トークン経由・SVG リテラル禁止 を共有）。
- `design-visualizer`（本 PR）— ビジュアルの **生成**。`ux-reviewer` の制約をハード制約として継承。

## 設計上の判断

- 既存 2 エージェントは read-only だが、本エージェントは成果物自体が SVG / TSX コードなので Edit / Write / Bash を付与。
- ただし「概念タグ → メタファ → パレット」の 3 行を必ず先に出させ、装飾だけのビジュアルが滑り込まないようにしている。曖昧な依頼ではまず提案、`適用して` と言われてから書き込む運用。
- 新トークン・新色 tribe・新アイコンの導入は禁止。必要なら停止してユーザーに確認。

## Test plan

- [ ] `/agents` から design-visualizer が選択できる
- [ ] 「Lesson XX のサムネイル提案して」で `SHAPES` の差分パッチと配線箇所が返ってくる
- [ ] 「コース YY の画像作って」で `public/images/v3/course-YY.svg` と `courseData.ts` の `image:` 行が提示される
- [ ] `step.visual: 'NewDiagram'` を持つレッスンを与えると `LessonDiagrams.tsx` の export と `Lesson.tsx` の `diagramMap` 配線が両方提示される
- [ ] 絵文字 / 直書きhex / 新トークン作成 を試みた出力には自己ブロックがかかる

https://claude.ai/code/session_01WfriU7bXaW3qMK1P5J6f9Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfriU7bXaW3qMK1P5J6f9Y)_