### PR TITLE
fix(i18n): add missing locale coverage so language switch actually works

### DIFF
--- a/e2e/locale-switch.spec.ts
+++ b/e2e/locale-switch.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect, type Page } from '@playwright/test'
+
+async function bootJa(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('logic-onboarded', '1')
+    localStorage.setItem('logic-install-id', 'test')
+    localStorage.setItem('logic-locale', 'ja')
+  })
+  await page.goto('/')
+  await page.waitForSelector('.app-shell', { timeout: 10_000 })
+}
+
+async function bootEn(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('logic-onboarded', '1')
+    localStorage.setItem('logic-install-id', 'test')
+    localStorage.setItem('logic-locale', 'en')
+  })
+  await page.goto('/')
+  await page.waitForSelector('.app-shell', { timeout: 10_000 })
+}
+
+test.describe('Locale switch — Japanese baseline', () => {
+  test('home renders Japanese title', async ({ page }) => {
+    await bootJa(page)
+    await expect(page.locator('.tabbar')).toBeVisible()
+  })
+
+  test('roadmap shows Japanese course group label', async ({ page }) => {
+    await bootJa(page)
+    await page.locator('.tabbar .tab').nth(1).click()
+    await page.waitForSelector('text=トレーニング', { timeout: 5_000 })
+    await expect(page.locator('text=論理的に考える').first()).toBeVisible()
+  })
+})
+
+test.describe('Locale switch — English coverage', () => {
+  test('roadmap shows English course group label (not Japanese)', async ({ page }) => {
+    await bootEn(page)
+    await page.locator('.tabbar .tab').nth(1).click()
+    await page.waitForSelector('text=Training', { timeout: 5_000 })
+    await expect(page.locator('text=Think Logically').first()).toBeVisible()
+    await expect(page.locator('text=論理的に考える')).toHaveCount(0)
+  })
+
+  test('roadmap shows English course title (not Japanese)', async ({ page }) => {
+    await bootEn(page)
+    await page.locator('.tabbar .tab').nth(1).click()
+    await page.waitForSelector('text=Training', { timeout: 5_000 })
+    await expect(page.locator('text=Think Logically and Organize Your Ideas').first()).toBeVisible()
+    await expect(page.locator('text=ロジカルに考えて、整理する')).toHaveCount(0)
+  })
+
+  test('home daily fermi shows English question (not Japanese)', async ({ page }) => {
+    await bootEn(page)
+    await expect(page.locator('text=日本国内|日本のスタバ|日本のEC|何円か')).toHaveCount(0)
+  })
+})

--- a/src/components/platform/ConfirmDialog.tsx
+++ b/src/components/platform/ConfirmDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { isIOS } from '../../platform'
 import { haptic } from '../../platform/haptics'
+import { t } from '../../i18n'
 import './ConfirmDialog.css'
 
 export interface ConfirmDialogProps {
@@ -71,7 +72,7 @@ export function ConfirmDialog(p: ConfirmDialogProps) {
             className="m3-dialog__btn"
             onClick={cancel}
           >
-            {p.cancelText ?? 'キャンセル'}
+            {p.cancelText ?? t('common.cancel')}
           </button>
           <button
             type="button"

--- a/src/components/platform/Header.tsx
+++ b/src/components/platform/Header.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { isIOS } from '../../platform'
 import { haptic } from '../../platform/haptics'
+import { t } from '../../i18n'
 import './Header.css'
 
 export interface HeaderProps {
@@ -35,10 +36,10 @@ export function Header({ title, largeTitle, onBack, trailing }: HeaderProps) {
             type="button"
             className="pf-header__back"
             onClick={() => { haptic.light(); onBack() }}
-            aria-label="戻る"
+            aria-label={t('common.back')}
           >
             {ios ? <ChevronLeftIcon /> : <ArrowLeftIcon />}
-            {ios && <span className="pf-header__back-label">戻る</span>}
+            {ios && <span className="pf-header__back-label">{t('common.back')}</span>}
           </button>
         ) : (
           <span className="pf-header__back pf-header__back--placeholder" aria-hidden="true" />

--- a/src/courseData.ts
+++ b/src/courseData.ts
@@ -1,4 +1,12 @@
 // courseData.ts — コース定義（1コース = 5レッスン）
+//
+// title / description / グループ label / description は ja / en の両言語版を持ち、
+// 起動時の getLocale() に応じて COURSE_GROUPS / COURSES として export する。
+//
+// category と level は内部識別子（日本語）として保持。表示時は呼び出し側で
+// CATEGORY_TO_KEY / levelLabel() 等のマッピングを通して t() で翻訳する。
+
+import { getLocale } from './i18n'
 
 export type CourseGroupId =
   | 'foundations'    // 思考の基礎
@@ -10,7 +18,7 @@ export type CourseGroupId =
 export type Course = {
   id: string
   title: string           // Doingタイトル
-  category: string        // カテゴリ（大分類）
+  category: string        // カテゴリ（大分類）— 内部識別子（日本語固定）
   group: CourseGroupId    // コース一覧でのグルーピング
   lessonIds: number[]     // コース内のレッスンID（5〜7件）
   level: '初級' | '中級' | '上級'
@@ -24,7 +32,7 @@ export type CourseGroup = {
   description: string
 }
 
-export const COURSE_GROUPS: CourseGroup[] = [
+const COURSE_GROUPS_JA: CourseGroup[] = [
   { id: 'foundations',     label: '論理的に考える',  description: '論理・批判・哲学で土台を固める' },
   { id: 'problem-solving', label: '課題を解決する',  description: '仮説と構造で本質に迫る' },
   { id: 'creative',        label: '発想を広げる',    description: '常識を超えて、新しい切り口を生む' },
@@ -32,7 +40,15 @@ export const COURSE_GROUPS: CourseGroup[] = [
   { id: 'business',        label: '現場で実践する',  description: '戦略・数字・クライアント実務に活かす' },
 ]
 
-export const COURSES: Course[] = [
+const COURSE_GROUPS_EN: CourseGroup[] = [
+  { id: 'foundations',     label: 'Think Logically',       description: 'Build foundations with logic, criticism, and philosophy' },
+  { id: 'problem-solving', label: 'Solve Problems',        description: 'Use hypotheses and structure to reach the essence' },
+  { id: 'creative',        label: 'Expand Your Thinking',  description: 'Go beyond convention to create new angles' },
+  { id: 'communication',   label: 'Move People',           description: 'Deliver logic through proposals, interviews, and listening' },
+  { id: 'business',        label: 'Apply in Practice',     description: 'Strategy, numbers, and client work in the real world' },
+]
+
+const COURSES_JA: Course[] = [
   // ── ロジカルシンキング ──────────────────────────────
   {
     id: 'logic-01',
@@ -329,6 +345,124 @@ export const COURSES: Course[] = [
     description: 'クロノタイプ・睡眠・運動・集中の波・自己計測の5レッスンで、自分の体に合った最高の働き方を設計する。',
   },
 ]
+
+// 英訳: id / category / group / lessonIds / level / image は ja と完全に同じ。
+// title / description のみ英訳。id をキーに ja → en にマッピングする。
+const COURSE_EN_OVERRIDES: Record<string, { title: string; description: string }> = {
+  'logic-01': {
+    title: 'Think Logically and Organize Your Ideas',
+    description: 'Master MECE and logic trees to organize your thinking without gaps or overlaps.',
+  },
+  'logic-02': {
+    title: 'Build Logic to Persuade',
+    description: 'Use So What / Why So to test your logic, and master the Pyramid structure to communicate clearly.',
+  },
+  'critical-01': {
+    title: 'Challenge Assumptions, Judge Correctly',
+    description: 'From the basics of critical thinking to spotting logical fallacies — sharpen your judgment.',
+  },
+  'critical-02': {
+    title: 'Remove Bias, See Objectively',
+    description: 'Understand cognitive distortions starting with confirmation bias for more accurate judgment.',
+  },
+  'hypothesis-01': {
+    title: 'Hypothesize First, Then Investigate',
+    description: 'Build a hypothesis first, then sharpen it through validation.',
+  },
+  'problem-01': {
+    title: 'Identify and Define the Real Problem',
+    description: 'Understand the difference between problems and issues, and develop the ability to set essential questions.',
+  },
+  'design-01': {
+    title: 'Uncover User Needs and Solve',
+    description: 'Practice the human-centered design thinking process from empathy to prototype.',
+  },
+  'systems-01': {
+    title: 'See the Whole, Change at the Root',
+    description: 'Use feedback loops and the iceberg model to structurally grasp root causes.',
+  },
+  'whywhy-01': {
+    title: 'Reach Root Causes with the 5 Whys',
+    description: 'Dig down to root causes instead of treating symptoms. Learn the Toyota classic with principles like no-blame, no-leaps, and falsifiability.',
+  },
+  'lateral-01': {
+    title: 'Challenge the Obvious, Find Breakthroughs',
+    description: 'Use reframing and reverse thinking to generate ideas beyond fixed assumptions.',
+  },
+  'analogy-01': {
+    title: 'Borrow Wisdom from Other Fields',
+    description: 'Spot structural similarities and apply insights from other domains to your own challenges.',
+  },
+  'philosophy-01': {
+    title: 'Deepen Thinking with Philosophical Questions',
+    description: 'Learn the principles of thinking through Socratic dialogue and falsifiability.',
+  },
+  'eastern-01': {
+    title: 'See People and Organizations through Ancient Chinese Thought',
+    description: 'Learn principles of relationships, definitions, human nature, and system design through Confucius, Mencius, Xunzi, and Mozi.',
+  },
+  'eastern-02': {
+    title: 'See Strategy and Decisions through Ancient Chinese Thought',
+    description: 'Learn wu wei, suppleness, perspective, systems, and winning without fighting through Laozi, Zhuangzi, Han Feizi, and Sun Tzu.',
+  },
+  'proposal-01': {
+    title: 'Craft Proposals That Move People',
+    description: "Work backward from the reader's decision criteria to master the structure that drives action.",
+  },
+  'proposal-course-01': {
+    title: 'Finish Proposals with Hypothesis and Validation',
+    description: "Take a consultant's approach: hypothesize, validate, and complete a compelling proposal.",
+  },
+  'client-01': {
+    title: 'Read Situations Quickly with Numbers',
+    description: 'Train your sense of scale and estimation so you can handle numbers fluently in client settings.',
+  },
+  'client-02': {
+    title: 'Set the Right Issues, Listen Deeply',
+    description: "Use sharp issue-setting and listening techniques to surface clients' real challenges.",
+  },
+  'client-03': {
+    title: 'Ramp Up Fast in an Unfamiliar Industry',
+    description: 'Use books, cases, experts, and hypotheses to deliver value as an "expert" on new engagements.',
+  },
+  'client-04': {
+    title: 'Turn Feedback into the Next Step',
+    description: 'When a manager says "your thinking is shallow," "your analysis is weak," or "your implications are thin" — learn what to ask and how to convert it into action through real cases.',
+  },
+  'case-01': {
+    title: 'Prove Your Logic in Case Interviews',
+    description: 'Systematically tackle frequent case interview themes from profit structure to market entry.',
+  },
+  'strategy-01': {
+    title: 'Learn the Origins and Competitive Strategy',
+    description: 'From Taylor and Ford to Ansoff, PPM, and Porter — cover the classics of strategy chronologically.',
+  },
+  'strategy-02': {
+    title: 'Resources, Capabilities, and Co-evolution',
+    description: 'From RBV and core competencies to Blue Ocean, dynamic capabilities, and platform strategy — learn modern strategy evolution.',
+  },
+  'fermi-01': {
+    title: "Grasp the World's Scale with Estimation",
+    description: 'Build equations, decompose, and produce "roughly right" answers quickly — accuracy comes second.',
+  },
+  'numeracy-01': {
+    title: 'Get Strong with Numbers',
+    description: 'Seven lessons — presentation, mental math, ratios, unit conversion, compounding, statistics, and pitfalls — to systematically build business numeracy.',
+  },
+  'peak-performance-01': {
+    title: 'Work at Your Peak Performance',
+    description: 'Five lessons on chronotype, sleep, exercise, focus rhythms, and self-tracking — design your best-fit way of working.',
+  },
+}
+
+const COURSES_EN: Course[] = COURSES_JA.map(c => {
+  const en = COURSE_EN_OVERRIDES[c.id]
+  return en ? { ...c, title: en.title, description: en.description } : c
+})
+
+// 起動時の locale で決定（setLocale は window.location.reload を呼ぶので再評価される）
+export const COURSE_GROUPS: CourseGroup[] = getLocale() === 'en' ? COURSE_GROUPS_EN : COURSE_GROUPS_JA
+export const COURSES: Course[] = getLocale() === 'en' ? COURSES_EN : COURSES_JA
 
 // カテゴリ別コース一覧
 export function getCoursesByCategory(category: string): Course[] {

--- a/src/fermiData.ts
+++ b/src/fermiData.ts
@@ -1,12 +1,17 @@
 // fermiData.ts — フェルミ問題プール（ホーム・DailyFermiScreen共通）
 // ビジネス系 × ちょっと面白い系に厳選
+//
+// 28問の question / hint と対応する FERMI_STATS を ja / en で持つ。
+// 起動時の getLocale() で FERMI_POOL / FERMI_STATS が決まる。
+
+import { getLocale } from './i18n'
 
 export type FermiQuestion = {
   question: string
   hint: string
 }
 
-export const FERMI_POOL: FermiQuestion[] = [
+const FERMI_POOL_JA: FermiQuestion[] = [
   // ── 王道ビジネス：市場規模・売上 ──
   { question: '日本国内のSaaS市場の年間売上規模は何円か？', hint: '日本の法人数×SaaS導入率×1社あたり年間支出で分解。中小と大企業で支出額が大きく違う。' },
   { question: '日本のスタバ全店舗が1日に売り上げる総額は何円か？', hint: '店舗数×1店舗の客数×客単価で分解。営業時間と回転率も意識しよう。' },
@@ -40,6 +45,42 @@ export const FERMI_POOL: FermiQuestion[] = [
   { question: '日本のプロ野球（NPB）の年間観客動員数は何人か？', hint: '12球団×1球団のホーム試合数×1試合の平均観客（球場収容人数×稼働率）で分解。' },
 ]
 
+const FERMI_POOL_EN: FermiQuestion[] = [
+  // ── Classic business: market size / revenue ──
+  { question: 'What is the annual revenue size of the SaaS market in Japan (JPY)?', hint: 'Break down as: number of companies × SaaS adoption rate × annual spend per company. SMB and enterprise spend differ greatly.' },
+  { question: 'What is the total daily revenue of all Starbucks stores in Japan (JPY)?', hint: 'Break down as: number of stores × customers per store × spend per customer. Consider operating hours and turnover.' },
+  { question: 'What is the daily total revenue of a 300-store izakaya chain (JPY)?', hint: 'Compute as: seats per store × turnover × spend per customer × number of stores. Mind weekday vs weekend.' },
+  { question: 'What is the annual GMV of the EC market in Japan (JPY)?', hint: 'Break down as: internet users × EC usage rate × annual EC spend per person. Include travel and tickets, not just goods.' },
+  { question: 'How many M&A deals are closed annually in Japan?', hint: 'Split into strategic deals at listed firms + succession deals at SMBs. The successor-shortage problem is the key scale driver.' },
+
+  // ── Business cost / operations ──
+  { question: 'What is the annual office rent for a 50-person SMB in Japan (JPY)?', hint: 'Compute as: floor area per person × rent per tsubo × 12 months. Central Tokyo and suburbs differ widely.' },
+  { question: 'How many projects do major consulting firms win annually in Japan?', hint: 'Think: headcount ÷ people per project × number of project cycles per year.' },
+
+  // ── Quirky business observations ──
+  { question: 'How many hanko (stamps) do Japanese office workers press in a year nationwide?', hint: 'Break down as: workforce × white-collar ratio × stamps per person per day × working days per year. Subtract digitization progress.' },
+  { question: 'How many times per day is "otsukaresama desu" uttered by Japanese business people in total?', hint: 'Workforce × utterances per person per day. Count by scene: greetings, signing off, email openings, chat openings…' },
+  { question: 'How many "ryōkai desu / shōchi shimashita" (acknowledgment) messages are sent in business chat (Slack/Teams etc.) per day in Japan?', hint: 'Business-chat users × messages per person per day × ratio that are acknowledgments.' },
+  { question: 'How many cups of coffee are brewed daily in Japanese offices?', hint: 'White-collar population × cups per person per day at the office. Include both coffee machines and café take-ins.' },
+  { question: 'How many times per day, nationwide, does someone say "your mic is on mute" in online meetings?', hint: 'Daily online meetings × probability that this happens per meeting. Factor in remote/hybrid penetration.' },
+  { question: 'How many receipts are filed through expense reports annually in Japan?', hint: 'White-collar population × receipts per person per month × 12 months. Sales roles file far more than back-office.' },
+  { question: 'How many "no-longer-needed" business cards sit unused in business-card holders across Japan?', hint: 'Workforce × sales-role ratio × lifetime cards collected per salesperson. Adjust for cards that "go to sleep" when people change roles or retire.' },
+
+  // ── Consulting case-interview staples (market sizing) ──
+  { question: 'What is the annual size of the golf market in Japan (JPY)?', hint: 'Golf population × rounds per year × cost per round (greens fee + equipment + food). Mind the skew across age groups.' },
+  { question: 'What is the annual size of the pet food market in Japan (JPY)?', hint: 'Dogs and cats owned × annual food spend per animal. Per-animal spend differs between dogs and cats.' },
+  { question: 'How many fitness gym members are there in Tokyo?', hint: 'Tokyo population × age-group gym membership rates. Urban workers in their 20s–40s are the core; don\'t forget senior gyms.' },
+  { question: 'What is the annual size of the wedding market in Japan (JPY)?', hint: 'Annual marriages × ceremony rate × reception cost per couple. Subtracting "no-ceremony" couples is the key.' },
+  { question: 'What is the annual size of the online advertising market in Japan (JPY)?', hint: 'Total ad spend (~1–1.2% of GDP) × digital share. Mind the mix: search + display + video + social.' },
+  { question: 'What is the annual size of the eyewear market in Japan (JPY)?', hint: 'Population × vision-correction rate ÷ average replacement cycle × price per pair. Watch substitution with contact lenses.' },
+  { question: 'How many parcels does the delivery industry handle annually in Japan?', hint: 'Split into consumer receipts + BtoB logistics: population × parcels per person per year + business volume. Mind the rise in EC penetration.' },
+  { question: 'What is the annual size of the subscription video market (Netflix, Prime Video, etc.) in Japan (JPY)?', hint: 'Households × SVOD adoption × services subscribed per household × monthly fee × 12 months. Multi-subscription is common.' },
+  { question: 'What is the annual total revenue of the drugstore industry in Japan (JPY)?', hint: 'Number of stores × daily sales per store × operating days. Check per-store mix of cosmetics, food, and OTC drugs.' },
+  { question: 'What is the annual attendance at Japan\'s professional baseball (NPB) games?', hint: '12 teams × home games per team × average attendance per game (stadium capacity × utilization).' },
+]
+
+export const FERMI_POOL: FermiQuestion[] = getLocale() === 'en' ? FERMI_POOL_EN : FERMI_POOL_JA
+
 /** 今日の問題インデックス（日付ベース・全画面共通） */
 export function getDailyFermiIndex(): number {
   return Math.floor(Date.now() / 86400000) % FERMI_POOL.length
@@ -53,7 +94,7 @@ export function getDailyFermi(): FermiQuestion {
 // 問題ごとの参考データ（最小限・問題に直結するものだけ）
 export type FermiStat = { label: string; value: string }
 
-export const FERMI_STATS: FermiStat[][] = [
+const FERMI_STATS_JA: FermiStat[][] = [
   // 0: SaaS市場規模
   [{ label: '日本の法人数', value: '約400万社' }, { label: 'SaaS導入率（参考）', value: '約30〜50%' }, { label: '1社あたりSaaS年間支出（参考）', value: '約10万〜500万円' }],
   // 1: スタバ全店舗の1日売上
@@ -103,6 +144,59 @@ export const FERMI_STATS: FermiStat[][] = [
   // 23: プロ野球年間観客動員数
   [{ label: 'NPB球団数', value: '12球団' }, { label: '1球団のホーム試合数（参考）', value: '約70試合' }, { label: '1試合あたり平均観客（参考）', value: '約3万人' }],
 ]
+
+const FERMI_STATS_EN: FermiStat[][] = [
+  // 0: SaaS market
+  [{ label: 'Companies in Japan', value: '~4 million' }, { label: 'SaaS adoption rate (ref.)', value: '~30–50%' }, { label: 'Annual SaaS spend per company (ref.)', value: '~¥100K–5M' }],
+  // 1: Starbucks daily revenue
+  [{ label: 'Starbucks stores in Japan', value: '~1,900' }, { label: 'Spend per customer (ref.)', value: '~¥700' }, { label: 'Customers per store per day (ref.)', value: '~500–800' }],
+  // 2: Izakaya chain daily revenue
+  [{ label: 'Seats per izakaya (ref.)', value: '~60–80' }, { label: 'Spend per customer (ref.)', value: '~¥3,000–4,500' }, { label: 'Daily turnover (ref.)', value: '~1.5–2.5×' }],
+  // 3: EC GMV
+  [{ label: 'Internet users in Japan', value: '~100 million' }, { label: 'EC usage rate (ref.)', value: '~75%' }, { label: 'Annual EC spend per person (ref.)', value: '~¥150,000' }],
+  // 4: M&A annual count
+  [{ label: 'Companies in Japan', value: '~4 million' }, { label: 'SMB successor-shortage rate (ref.)', value: '~60%' }, { label: 'Listed companies', value: '~4,000' }],
+  // 5: SMB office rent
+  [{ label: 'Floor area per person', value: '~3–5 tsubo' }, { label: 'Central Tokyo rent per tsubo (monthly)', value: '~¥20K–30K' }, { label: 'Suburban rent per tsubo (monthly)', value: '~¥10K' }],
+  // 6: Consulting projects
+  [{ label: 'Headcount at major consulting firms (ref.)', value: '~2,000–5,000 / firm' }, { label: 'People per project', value: '~3–10' }, { label: 'Projects per person per year (ref.)', value: '~3–5' }],
+  // 7: Hanko stamps
+  [{ label: 'Workforce', value: '~69 million' }, { label: 'White-collar ratio (ref.)', value: '~50%' }, { label: 'Stamps per person per day (ref.)', value: '~3–10' }, { label: 'Working days per year', value: '~240' }],
+  // 8: "Otsukaresama" utterances
+  [{ label: 'Workforce', value: '~69 million' }, { label: 'Utterances per person per day (in-person + email + chat, ref.)', value: '~10–30' }],
+  // 9: "Ryōkai" chat messages
+  [{ label: 'Business chat users in Japan (ref.)', value: '~20 million' }, { label: 'Messages per person per day (ref.)', value: '~30–50' }, { label: 'Acknowledgment ratio (ref.)', value: '~10%' }],
+  // 10: Office coffee cups
+  [{ label: 'White-collar population (ref.)', value: '~35 million' }, { label: 'Cups per person per day (ref.)', value: '~2–3' }, { label: 'Share drunk at office (ref.)', value: '~60%' }],
+  // 11: "Mic is muted" moments
+  [{ label: 'White-collar population (ref.)', value: '~35 million' }, { label: 'Online meetings per person per day (ref.)', value: '~2–4' }, { label: 'Mute-incident probability (ref.)', value: '~20–30%' }],
+  // 12: Expense report receipts
+  [{ label: 'White-collar population (ref.)', value: '~35 million' }, { label: 'Receipts per person per month (ref.)', value: '~5–20' }, { label: 'Period', value: '12 months' }],
+  // 13: Dormant business cards
+  [{ label: 'Workforce', value: '~69 million' }, { label: 'Sales role ratio (ref.)', value: '~8–10%' }, { label: 'Lifetime cards per salesperson (ref.)', value: '~3,000–5,000' }],
+  // 14: Golf market
+  [{ label: 'Golf population in Japan (ref.)', value: '~5–6 million' }, { label: 'Rounds per year (ref.)', value: '~8–12' }, { label: 'Cost per round (ref.)', value: '~¥10K–30K' }],
+  // 15: Pet food market
+  [{ label: 'Dogs in Japan', value: '~7 million' }, { label: 'Cats in Japan', value: '~9 million' }, { label: 'Annual food spend per animal (ref.)', value: '~¥20K–40K' }],
+  // 16: Tokyo gym members
+  [{ label: 'Tokyo population', value: '~14 million' }, { label: 'Share aged 20–40s (ref.)', value: '~35%' }, { label: 'Gym membership in that age group (ref.)', value: '~10–15%' }],
+  // 17: Wedding market
+  [{ label: 'Annual marriages in Japan', value: '~500K' }, { label: 'Ceremony rate (ref.)', value: '~60–70%' }, { label: 'Cost per couple (ref.)', value: '~¥3–4 million' }],
+  // 18: Online ad market
+  [{ label: 'Total ad spend in Japan (ref.)', value: '~¥7 trillion' }, { label: 'Digital share (ref.)', value: '~45–50%' }, { label: 'Mix', value: 'Search + display + video + social' }],
+  // 19: Eyewear market
+  [{ label: 'Japan population', value: '~124 million' }, { label: 'Vision-correction rate (ref.)', value: '~60%' }, { label: 'Replacement cycle (ref.)', value: '~3–4 years' }, { label: 'Price per pair (ref.)', value: '~¥20,000' }],
+  // 20: Parcel deliveries
+  [{ label: 'Japan population', value: '~124 million' }, { label: 'Personal parcels per person per year (ref.)', value: '~30–40' }, { label: 'BtoB logistics share', value: 'Similar to or slightly less than consumer' }],
+  // 21: SVOD market
+  [{ label: 'Households in Japan', value: '~57 million' }, { label: 'SVOD adoption (ref.)', value: '~40%' }, { label: 'Services per household (ref.)', value: '~1.5–2' }, { label: 'Monthly fee (ref.)', value: '~¥1,000' }],
+  // 22: Drugstore industry
+  [{ label: 'Drugstore count in Japan', value: '~23,000' }, { label: 'Daily sales per store (ref.)', value: '~¥800K–1.2M' }, { label: 'Operating days (ref.)', value: '~350' }],
+  // 23: NPB attendance
+  [{ label: 'NPB teams', value: '12 teams' }, { label: 'Home games per team (ref.)', value: '~70' }, { label: 'Avg attendance per game (ref.)', value: '~30,000' }],
+]
+
+export const FERMI_STATS: FermiStat[][] = getLocale() === 'en' ? FERMI_STATS_EN : FERMI_STATS_JA
 
 /** 指定インデックスの問題に対応した参考データを返す */
 export function getFermiStatsByIndex(index: number): FermiStat[] {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1289,6 +1289,14 @@ const STRINGS: Record<Locale, Strings> = {
 
     // CompletedLessons (fallback category)
     'completed.fallbackCategory': 'その他',
+    'completed.cat.aiPractice': 'AI練習',
+    'completed.cat.daily': 'デイリー',
+    'completed.cat.review': '復習',
+    'completed.cat.test': 'テスト',
+    'completed.specialName.fermi': 'フェルミ推定',
+    'completed.specialName.daily': '今日の問題',
+    'completed.specialName.flashcards': 'フラッシュカード',
+    'completed.specialName.placementTest': '実力診断テスト',
 
     // DailyFermi residuals
     'dailyFermi.exprPlaceholder': '計算式を入力',
@@ -2656,6 +2664,14 @@ const STRINGS: Record<Locale, Strings> = {
 
     // CompletedLessons (fallback category)
     'completed.fallbackCategory': 'Other',
+    'completed.cat.aiPractice': 'AI Practice',
+    'completed.cat.daily': 'Daily',
+    'completed.cat.review': 'Review',
+    'completed.cat.test': 'Test',
+    'completed.specialName.fermi': 'Fermi Estimation',
+    'completed.specialName.daily': "Today's Problem",
+    'completed.specialName.flashcards': 'Flashcards',
+    'completed.specialName.placementTest': 'Placement Test',
 
     // DailyFermi residuals
     'dailyFermi.exprPlaceholder': 'Enter an expression',

--- a/src/screens/CompletedLessonsScreen.tsx
+++ b/src/screens/CompletedLessonsScreen.tsx
@@ -2,9 +2,11 @@ import { useMemo } from 'react'
 import { getCompletedLessons } from '../stats'
 import { CheckCircleIcon } from '../icons'
 import { Header } from '../components/platform/Header'
+import { allLessons } from '../lessonData'
 import { t } from '../i18n'
 
 // データキー (LESSON_MAP の category) → 表示ラベル翻訳キー解決
+// カテゴリの「内部キー」は日本語で固定。表示時に t() で翻訳する。
 const CATEGORY_LABEL_KEY: Record<string, string> = {
   'ロジカルシンキング': 'category.logical',
   'ケース面接': 'category.case',
@@ -16,10 +18,38 @@ const CATEGORY_LABEL_KEY: Record<string, string> = {
   'アナロジー思考': 'category.analogy',
   'システムシンキング': 'category.systems',
   'フェルミ推定': 'category.fermi',
+  'AI練習': 'completed.cat.aiPractice',
+  'デイリー': 'completed.cat.daily',
+  '復習': 'completed.cat.review',
+  'テスト': 'completed.cat.test',
 }
 function categoryLabel(cat: string): string {
   const key = CATEGORY_LABEL_KEY[cat]
   return key ? t(key) : cat
+}
+
+// 特殊キー（レッスン以外）の表示名翻訳マップ
+const SPECIAL_NAME_KEY: Record<string, string> = {
+  'fermi': 'completed.specialName.fermi',
+  'daily-problem': 'completed.specialName.daily',
+  'flashcards': 'completed.specialName.flashcards',
+  'placement-test': 'completed.specialName.placementTest',
+}
+
+/**
+ * "lesson-20" のような key からレッスン表示名を取得。
+ * lessonData.allLessons は ja/en で自動切り替えされるので、ID 経由で引けば翻訳済みのタイトルが返る。
+ * 特殊キー（fermi 等）は SPECIAL_NAME_KEY 経由で翻訳。
+ */
+function resolveLessonName(key: string, fallback: string): string {
+  const m = /^lesson-(\d+)$/.exec(key)
+  if (m) {
+    const id = Number(m[1])
+    return allLessons[id]?.title ?? fallback
+  }
+  const sp = SPECIAL_NAME_KEY[key]
+  if (sp) return t(sp)
+  return fallback
 }
 
 interface CompletedLessonsScreenProps {
@@ -149,7 +179,7 @@ export function CompletedLessonsScreen({ onBack }: CompletedLessonsScreenProps) 
             <ul className="card" style={{ padding: 0, overflow: 'hidden', listStyle: 'none', margin: 0 }}>
               {catKeys.map((key, i) => {
                 const meta = LESSON_MAP[key]
-                const name = meta?.name ?? key
+                const name = resolveLessonName(key, meta?.name ?? key)
                 return (
                   <li key={key} aria-label={t('completed.itemAria', { name })}>
                     {i > 0 && <div style={{ height: 1, background: 'var(--border)', marginLeft: 'var(--s-4)' }} />}

--- a/src/screens/HomeScreenV3.tsx
+++ b/src/screens/HomeScreenV3.tsx
@@ -12,36 +12,54 @@ import { HomeCoachmark, useShouldShowHomeCoachmark } from '../tutorial/coachmark
 import { PlacementCard } from '../tutorial/placementCard'
 import { hasCompletedPlacement } from '../placementData'
 import { useWindowSize, BREAKPOINTS } from '../hooks/useResponsive'
+import { allLessons } from '../lessonData'
 import { t } from '../i18n'
 
 // フェルミ問題は fermiData.ts の FERMI_POOL を使用（日付ベース共通）
 
 // おすすめレッスンリスト（ランダム表示用）
-const RECOMMENDED_LESSONS = [
-  { id: 20, title: 'MECE — 漏れなくダブりなく', category: 'ロジカルシンキング', level: '初級', image: '/images/v3/lesson-20.webp' },
-  { id: 21, title: 'ロジックツリー — 問題を分解する', category: 'ロジカルシンキング', level: '初級', image: '/images/v3/lesson-21.webp' },
-  { id: 22, title: 'So What / Why So — 論理の検証', category: 'ロジカルシンキング', level: '初級', image: '/images/v3/lesson-22.webp' },
-  { id: 25, title: '演繹法 — 一般から個別を導く', category: 'ロジカルシンキング', level: '初級', image: '/images/v3/lesson-25.webp' },
-  { id: 26, title: '帰納法 — 個別事例から法則を見つける', category: 'ロジカルシンキング', level: '初級', image: '/images/v3/lesson-26.webp' },
-  { id: 40, title: 'クリティカルシンキング入門', category: 'クリティカルシンキング', level: '初級', image: '/images/v3/lesson-40.webp' },
-  { id: 50, title: '仮説思考入門 — 考えてから調べる', category: '仮説思考', level: '中級', image: '/images/v3/lesson-50.webp' },
-  { id: 56, title: 'デザインシンキング入門', category: 'デザインシンキング', level: '初級', image: '/images/v3/lesson-56.webp' },
-  { id: 59, title: 'ラテラルシンキング入門', category: 'ラテラルシンキング', level: '初級', image: '/images/v3/lesson-59.webp' },
-  { id: 62, title: 'アナロジー思考入門 — 類推で考える', category: 'アナロジー思考', level: '中級', image: '/images/v3/lesson-62.webp' },
-  { id: 65, title: 'システムシンキング入門 — 全体を見る', category: 'システムシンキング', level: '中級', image: '/images/v3/lesson-65.webp' },
-  { id: 68, title: '具体と抽象 — 思考の行き来を自在にする', category: 'ロジカルシンキング', level: '中級', image: '/images/v3/lesson-68.webp' },
-  { id: 28, title: 'ケース面接入門', category: 'ケース面接', level: '中級', image: '/images/v3/lesson-28.webp' },
-  { id: 77, title: 'ソクラテスの問答法', category: '哲学・思考の原理', level: '上級', image: '/images/v3/lesson-77.webp' },
-  { id: 78, title: '反証可能性 — 科学と疑似科学の境界', category: '哲学・思考の原理', level: '上級', image: '/images/v3/course-philosophy.webp' },
-  { id: 89, title: '大きい数字の捉え方・概算力', category: 'クライアントワーク', level: '中級', image: '/images/v3/course-client.webp' },
-  { id: 200, title: 'フェルミ推定とは何か', category: 'フェルミ推定', level: '中級', image: '/images/v3/fermi-card.png' },
-  { id: 41, title: '論理的誤謬を見破る', category: 'クリティカルシンキング', level: '中級', image: '/images/v3/lesson-41.webp' },
-  { id: 53, title: '課題設定入門 — 正しい問いを立てる', category: '課題設定', level: '中級', image: '/images/v3/lesson-53.webp' },
-  { id: 23, title: 'ピラミッド原則 — 伝わる話し方', category: 'ロジカルシンキング', level: '初級', image: '/images/v3/lesson-23.webp' },
+// title / category は lessonData から取得して ja/en 自動切り替え。
+// level / image はレッスン本体に持っていないメタデータなのでここで保持する。
+type RecommendedLessonMeta = { id: number; level: '初級' | '中級' | '上級'; image: string }
+const RECOMMENDED_LESSON_META: RecommendedLessonMeta[] = [
+  { id: 20, level: '初級', image: '/images/v3/lesson-20.webp' },
+  { id: 21, level: '初級', image: '/images/v3/lesson-21.webp' },
+  { id: 22, level: '初級', image: '/images/v3/lesson-22.webp' },
+  { id: 25, level: '初級', image: '/images/v3/lesson-25.webp' },
+  { id: 26, level: '初級', image: '/images/v3/lesson-26.webp' },
+  { id: 40, level: '初級', image: '/images/v3/lesson-40.webp' },
+  { id: 50, level: '中級', image: '/images/v3/lesson-50.webp' },
+  { id: 56, level: '初級', image: '/images/v3/lesson-56.webp' },
+  { id: 59, level: '初級', image: '/images/v3/lesson-59.webp' },
+  { id: 62, level: '中級', image: '/images/v3/lesson-62.webp' },
+  { id: 65, level: '中級', image: '/images/v3/lesson-65.webp' },
+  { id: 68, level: '中級', image: '/images/v3/lesson-68.webp' },
+  { id: 28, level: '中級', image: '/images/v3/lesson-28.webp' },
+  { id: 77, level: '上級', image: '/images/v3/lesson-77.webp' },
+  { id: 78, level: '上級', image: '/images/v3/course-philosophy.webp' },
+  { id: 89, level: '中級', image: '/images/v3/course-client.webp' },
+  { id: 200, level: '中級', image: '/images/v3/fermi-card.png' },
+  { id: 41, level: '中級', image: '/images/v3/lesson-41.webp' },
+  { id: 53, level: '中級', image: '/images/v3/lesson-53.webp' },
+  { id: 23, level: '初級', image: '/images/v3/lesson-23.webp' },
 ]
 
+const LEVEL_KEY: Record<string, string> = {
+  '初級': 'roadmap.levelBeginner',
+  '中級': 'roadmap.levelIntermediate',
+  '上級': 'roadmap.levelAdvanced',
+}
+
 function getRandomLesson() {
-  return RECOMMENDED_LESSONS[Math.floor(Math.random() * RECOMMENDED_LESSONS.length)]
+  const meta = RECOMMENDED_LESSON_META[Math.floor(Math.random() * RECOMMENDED_LESSON_META.length)]
+  const data = allLessons[meta.id]
+  return {
+    id: meta.id,
+    title: data?.title ?? '',
+    category: data?.category ?? '',
+    level: t(LEVEL_KEY[meta.level] ?? meta.level),
+    image: meta.image,
+  }
 }
 
 

--- a/src/screens/RankingScreen.tsx
+++ b/src/screens/RankingScreen.tsx
@@ -9,7 +9,8 @@ import { API_BASE } from './apiBase'
 import { getStreak, getStudyDates, getCompletedLessons, getXp } from '../stats'
 import { getPoints } from './homeHelpers'
 import { LoadingIndicator } from '../components/LoadingIndicator'
-import { t } from '../i18n'
+import { allLessons } from '../lessonData'
+import { t, getLocale } from '../i18n'
 
 
 interface RankingScreenProps {
@@ -95,24 +96,18 @@ export function RankingScreen({ onTakeTest }: RankingScreenProps) {
     const yesterday = new Date(mountTime - 86400000).toISOString().slice(0, 10)
     const studyDatesArr = getStudyDates()
 
-    const titleMap: Record<string, string> = {
-      'lesson-20': 'MECE — 漏れなくダブりなく',
-      'lesson-21': 'ロジックツリー',
-      'lesson-22': 'So What / Why So',
-      'lesson-23': 'ピラミッド原則',
-      'lesson-24': 'ケーススタディ総合演習',
-      'lesson-25': '演繹法',
-      'lesson-26': '帰納法',
-      'lesson-27': '形式論理',
-      'lesson-28': 'ケース面接入門',
-      'lesson-29': 'プロフィタビリティケース',
-      'lesson-40': 'クリティカルシンキング入門',
-      'lesson-41': '論理的誤謬を見破る',
-      'lesson-42': 'データを正しく読む',
-      'lesson-43': '問いを立てる力',
-      'mock-exam': '模擬試験',
-      'journal-input': 'ジャーナル',
-      'worksheet': 'ワークシート',
+    // lessonData から ja/en で自動切り替え。レッスン以外の特殊キーは ja/en 両方用意。
+    const specialMap: Record<string, string> = getLocale() === 'en'
+      ? { 'mock-exam': 'Mock Exam', 'journal-input': 'Journal', 'worksheet': 'Worksheet' }
+      : { 'mock-exam': '模擬試験', 'journal-input': 'ジャーナル', 'worksheet': 'ワークシート' }
+    const lessonPrefixLabel = getLocale() === 'en' ? 'Lesson ' : 'レッスン '
+    function resolveTitle(key: string): string {
+      const m = /^lesson-(\d+)$/.exec(key)
+      if (m) {
+        const id = Number(m[1])
+        return allLessons[id]?.title ?? `${lessonPrefixLabel}${m[1]}`
+      }
+      return specialMap[key] ?? key
     }
 
     const lessonIcon = <svg width="18" height="18" viewBox="0 0 24 24" fill="var(--md-sys-color-primary)" aria-hidden="true"><rect x="3" y="3" width="8" height="8" rx="1.5"/><rect x="13" y="3" width="8" height="8" rx="1.5"/><rect x="3" y="13" width="8" height="8" rx="1.5"/><rect x="13" y="13" width="8" height="8" rx="1.5"/></svg>
@@ -120,7 +115,7 @@ export function RankingScreen({ onTakeTest }: RankingScreenProps) {
     if (completed.length === 0) return []
 
     return completed.slice(-4).reverse().map((key) => {
-      const name = titleMap[key] || key.replace('lesson-', 'Lesson ')
+      const name = resolveTitle(key)
       const isToday = studyDatesArr.includes(today)
       const isYesterday = !isToday && studyDatesArr.includes(yesterday)
       const dateLabel = isToday ? t('rankingScreen.today') : isYesterday ? t('rankingScreen.yesterday') : ''

--- a/src/screens/RoadmapScreenV3.tsx
+++ b/src/screens/RoadmapScreenV3.tsx
@@ -29,7 +29,7 @@ import type { LessonData } from '../lessonData'
 import { getCompletedLessons } from '../stats'
 import { getCoursesByCategory, getCoursesByGroup, COURSES, COURSE_GROUPS, type Course } from '../courseData'
 import { loadPersonalCourse, axisLabel } from '../placementData'
-import { t } from '../i18n'
+import { t, getLocale } from '../i18n'
 
 // レベル文字列（データ値）→ 表示用の翻訳キー
 function levelLabel(level: string): string {
@@ -189,7 +189,11 @@ function saveSearchHistory(q: string) {
   const cur = loadSearchHistory().filter(x => x !== t)
   localStorage.setItem(SEARCH_HISTORY_KEY, JSON.stringify([t, ...cur].slice(0, 5)))
 }
-const SUGGESTED_KEYWORDS = ['MECE', '仮説思考', 'VRIO', '5フォース', 'ブルーオーシャン', 'デザインシンキング']
+const SUGGESTED_KEYWORDS_JA = ['MECE', '仮説思考', 'VRIO', '5フォース', 'ブルーオーシャン', 'デザインシンキング']
+const SUGGESTED_KEYWORDS_EN = ['MECE', 'Hypothesis Thinking', 'VRIO', '5 Forces', 'Blue Ocean', 'Design Thinking']
+function getSuggestedKeywords(): string[] {
+  return getLocale() === 'en' ? SUGGESTED_KEYWORDS_EN : SUGGESTED_KEYWORDS_JA
+}
 
 type LevelFilter = '初級' | '中級' | '上級'
 type ProgressFilter = 'todo' | 'done'
@@ -580,7 +584,7 @@ function SearchPanel(p: {
         <div>
           <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)', marginBottom: 6 }}>{t('roadmap.suggestedKeywords')}</div>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-            {SUGGESTED_KEYWORDS.map(k => (
+            {getSuggestedKeywords().map(k => (
               <Pill key={k} active={false} onClick={() => p.onPickKeyword(k)} label={k} />
             ))}
           </div>


### PR DESCRIPTION
## Summary

「言語切り替えても切り替わってない」現象の調査 → 修正。`setLocale()` の仕組み自体は動いてたけど、`t()` を経由しないハードコードが多数残ってたのが原因。

### 主因（2大データファイルが完全に未対応）

- **`src/courseData.ts`** — 5グループ + 26コースの `label / title / description` が日本語固定 → ロードマップ画面が英語にしても全部日本語のまま
- **`src/fermiData.ts`** — 24問のフェルミ問題と参考統計が日本語固定 → ホーム/フェルミ画面が日本語のまま

両者に En 版を追加し、起動時の `getLocale()` で `COURSE_GROUPS` / `COURSES` / `FERMI_POOL` / `FERMI_STATS` を切り替える形に。

### 副因（重複ハードコード）

レッスン名が `lessonData.ts`（既に En 対応済み）に英訳あるのに、画面側で日本語マップを別途持っていた：
- `HomeScreenV3.tsx` `RECOMMENDED_LESSONS`
- `CompletedLessonsScreen.tsx` `LESSON_MAP.name`
- `RankingScreen.tsx` `titleMap`

→ ID 経由で `allLessons[id].title` を引く形にリファクタ。

### 細かい UI

- `Header.tsx` の `aria-label="戻る"` / 戻るラベル → `t('common.back')`
- `ConfirmDialog.tsx` のキャンセルデフォルト → `t('common.cancel')`
- `RoadmapScreenV3.tsx` の `SUGGESTED_KEYWORDS` → `getLocale()` で配列切り替え
- `i18n.ts` に `completed.cat.*` / `completed.specialName.*` の 8 キー追加（ja/en）

## Test plan

- [x] `tsc --noEmit` pass
- [x] `eslint` pass（既存 warning 1件のみ）
- [x] `npm run build` pass
- [x] バンドル grep: ja / en 両方の文字列が含まれることを確認
- [ ] **要確認: ローカル `npm run dev` で言語切り替え動作確認**
  - Settings → Language → English → ロードマップ画面のグループ名・コース名が英訳されるか
  - ホーム画面のフェルミ問題が英訳されるか
  - 完了レッスン画面のレッスン名・カテゴリが英訳されるか
- [ ] E2E: `e2e/locale-switch.spec.ts` 追加済み（環境制約で chromium DL できず未実行）

## Notes

- `category` キーと `level`（'初級'/'中級'/'上級'）は内部識別子として日本語のまま保持。表示時に `CATEGORY_LABEL_KEY` / `levelLabel()` 経由で翻訳。
- レッスンコンテンツ自体（`logicLessons.ts` 等）は既に En 対応済み（このPRは触ってない）。

https://claude.ai/code/session_016fN65toGFFTrxViXVpfkQg

---
_Generated by [Claude Code](https://claude.ai/code/session_016fN65toGFFTrxViXVpfkQg)_