### PR TITLE
fix(fermi-ranking): switch ranking score to cumulative total

### DIFF
--- a/server/routes/fermi.ts
+++ b/server/routes/fermi.ts
@@ -440,17 +440,16 @@ Keep responses concise (2-4 sentences). Do not solve the problem for them.`
           .from('fermi_scores')
           .select('user_name, score, created_at')
           .gte('created_at', since.toISOString())
-          .order('score', { ascending: false })
-          .limit(50)
+          .order('created_at', { ascending: false })
+          .limit(500)
 
         if (!error && data && data.length > 0) {
-          // ユーザーごとに最高スコアを集計
+          // ユーザーごとにスコアを累積（合計）
           const byUser: Record<string, { name: string; score: number }> = {}
           for (const row of data) {
             const name = row.user_name || 'ゲスト'
-            if (!byUser[name] || byUser[name].score < row.score) {
-              byUser[name] = { name, score: row.score }
-            }
+            if (!byUser[name]) byUser[name] = { name, score: 0 }
+            byUser[name].score += row.score
           }
           realRanking = Object.values(byUser)
             .sort((a, b) => b.score - a.score)

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -852,14 +852,14 @@ const STRINGS: Record<Locale, Strings> = {
 
     // Fermi Ranking
     'fermiRank.heading': 'フェルミ ランキング',
-    'fermiRank.subtitle': '採点スコアのベスト記録で競おう',
+    'fermiRank.subtitle': '採点スコアの累計で競おう',
     'fermiRank.period.week': '今週',
     'fermiRank.period.month': '今月',
     'fermiRank.period.alltime': '累計',
     'fermiRank.rankUp': '順位アップ！ +{n}位',
     'fermiRank.yourRank': 'あなたの順位',
     'fermiRank.rankUnit': '位',
-    'fermiRank.bestScore': 'ベストスコア',
+    'fermiRank.bestScore': '累計スコア',
     'fermiRank.top3': 'TOP 3',
     'fermiRank.fourPlus': '4位以降',
     'fermiRank.empty.title': 'まだスコアがありません',
@@ -2218,14 +2218,14 @@ const STRINGS: Record<Locale, Strings> = {
 
     // Fermi Ranking
     'fermiRank.heading': 'Fermi Ranking',
-    'fermiRank.subtitle': "Compete with your best graded score",
+    'fermiRank.subtitle': "Compete with your total graded score",
     'fermiRank.period.week': 'This week',
     'fermiRank.period.month': 'This month',
     'fermiRank.period.alltime': 'All time',
     'fermiRank.rankUp': 'Rank up! +{n}',
     'fermiRank.yourRank': 'Your rank',
     'fermiRank.rankUnit': '',
-    'fermiRank.bestScore': 'Best score',
+    'fermiRank.bestScore': 'Total score',
     'fermiRank.top3': 'TOP 3',
     'fermiRank.fourPlus': 'Rank 4+',
     'fermiRank.empty.title': 'No scores yet',

--- a/src/screens/FermiRankingScreen.tsx
+++ b/src/screens/FermiRankingScreen.tsx
@@ -189,7 +189,7 @@ export function FermiRankingScreen() {
           </div>
           <div style={{ textAlign: 'right' }}>
             <div style={{ fontSize: 12, color: 'var(--text-secondary)', marginBottom: 4 }}>{t('fermiRank.bestScore')}</div>
-            <div style={{ fontSize: 24, fontWeight: 800 }}>{myEntry.score}<span style={{ fontSize: 11, color: 'var(--text-muted)', marginLeft: 2 }}>/100</span></div>
+            <div style={{ fontSize: 24, fontWeight: 800 }}>{myEntry.score}</div>
           </div>
         </div>
       )}
@@ -271,7 +271,6 @@ function RankCard({ entry, compact, highlight }: { entry: RankEntry; compact?: b
       {/* スコア */}
       <div style={{ flexShrink: 0, textAlign: 'right' }}>
         <span style={{ fontSize: compact ? 15 : 18, fontWeight: 800 }}>{entry.score}</span>
-        <span style={{ fontSize: 11, color: 'var(--text-muted)', marginLeft: 2 }}>/100</span>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- フェルミ ランキングのスコア集計を「ユーザーごとの最高スコア (max)」から「累積合計 (sum)」へ変更
- スコア表示の `/100` 分母を削除（自分の順位カード + 各ランクカード）
- ラベルを「ベストスコア / Best score」→「累計スコア / Total score」、サブタイトルも「ベスト記録で競おう」→「累計で競おう」に更新

## Why

Keita からの指摘 — ランキングは元々フェルミ問題のスコア累積を意図しており、`/100` 表記と "ベストスコア" ラベルは実態と乖離していた。

## Changes

- `server/routes/fermi.ts` — 集計ロジック `max` → `sum`、累積に十分なサンプルを取るため query を `order by created_at desc, limit 500` に変更
- `src/screens/FermiRankingScreen.tsx` — `/100` 表記を2箇所削除
- `src/i18n.ts` — ja/en 両方でラベル更新

## Test plan

- [ ] ローカルで `npm run dev` + `npm run server` を起動し、フェルミ ランキング画面でスコアが累積値として表示されることを確認
- [ ] 同一ユーザーが複数回フェルミ問題を採点した際、ランキングが合計スコアで並ぶことを確認
- [ ] ja / en 両ロケールでラベルが「累計スコア / Total score」に切り替わることを確認

https://claude.ai/code/session_01L86bJJwgwRfv3viPr2qozh

---
_Generated by [Claude Code](https://claude.ai/code/session_01L86bJJwgwRfv3viPr2qozh)_