### PR TITLE
feat(journal): 朝夜 phase 再構成 + カレンダーフル編集 + 整理ボタン + マイクデバッグ強化

### DIFF
--- a/server/routes/journal.ts
+++ b/server/routes/journal.ts
@@ -215,5 +215,65 @@ ${journalContext}`
     }
   })
 
+  // =============================================
+  // ジャーナル — テキスト整形 (cleanup)
+  //   入力テキストの誤字脱字 / 句読点 / 改行を整えるだけ。
+  //   内容の追加・要約・意見・解釈は禁止。
+  // =============================================
+  router.post('/cleanup', journalLimiter, async (req: Request, res: Response) => {
+    try {
+      const { text, locale } = req.body || {}
+      const isEn = locale === 'en'
+      if (typeof text !== 'string' || !text.trim()) {
+        return res.status(400).json({ error: isEn ? 'text required' : 'text が必要です' })
+      }
+      const trimmed = text.slice(0, 5000) // 暴走防御
+
+      const systemPrompt = isEn
+        ? `You are a text cleanup tool. The user gives you a raw text (often dictated by voice and full of fillers, missing punctuation, or typos). Your ONLY job is to clean it up:
+
+- Fix typos and obvious spelling errors
+- Add appropriate punctuation and paragraph breaks
+- Remove filler words ("um", "uh", "like", "you know", repetitions)
+- Normalize whitespace
+- Keep the EXACT meaning, tone, and information
+
+DO NOT:
+- Summarize or shorten
+- Add new content, opinions, or interpretation
+- Change the writer's voice or style
+- Translate
+
+Output ONLY the cleaned text. No preamble, no explanation, no quotes around it.`
+        : `あなたはテキスト整形ツールです。ユーザーは未整形のテキスト（多くは音声入力で、フィラー・句読点抜け・誤字を含む）を渡してきます。あなたの仕事は **整形のみ**:
+
+- 誤字脱字を直す
+- 適切な句読点と段落分けを入れる
+- フィラー（「えーと」「あの」「まあ」「なんていうか」、繰り返し）を除去
+- 余分な空白・改行を正規化
+- 意味・トーン・情報は **完全に保つ**
+
+禁止事項:
+- 要約・短縮
+- 内容の追加・意見・解釈
+- 書き手の口調・スタイルの変更
+- 翻訳
+
+出力は **整形済みテキストのみ**。前置き・説明・引用符は付けない。`
+
+      const response = await client.messages.create({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 1200,
+        system: systemPrompt,
+        messages: [{ role: 'user', content: trimmed }],
+      })
+      const cleaned = response.content[0].type === 'text' ? response.content[0].text.trim() : ''
+      res.json({ cleaned })
+    } catch (e: unknown) {
+      console.error('journal cleanup error:', e)
+      res.status(500).json({ error: e instanceof Error ? e.message : String(e) })
+    }
+  })
+
   return router
 }

--- a/src/components/journal/JournalDetailSheet.tsx
+++ b/src/components/journal/JournalDetailSheet.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
 import type { DailyJournal, Mood, Weather } from './types'
-import { MoodIcon, WeatherIcon } from './MoodWeatherIcons'
+import { MoodSelector, WeatherSelector } from './MoodWeatherSelector'
 import { VoiceTextarea } from './VoiceTextarea'
+import { TagInput } from './TagInput'
+import { SparkleIcon } from './MoodWeatherIcons'
 import { fetchJournalByDate, upsertJournal } from './journalDb'
 import { t } from '../../i18n'
 
@@ -13,31 +15,38 @@ interface JournalDetailSheetProps {
   onSaved?: (j: DailyJournal) => void
 }
 
-const MOOD_LABEL_KEY: Record<Mood, string> = {
-  1: 'journal.moodVeryBad',
-  2: 'journal.moodBad',
-  3: 'journal.moodNeutral',
-  4: 'journal.moodGood',
-  5: 'journal.moodGreat',
-}
-
-const WEATHER_LABEL_KEY: Record<Weather, string> = {
-  sunny:  'journal.weatherSunny',
-  cloudy: 'journal.weatherCloudy',
-  rainy:  'journal.weatherRainy',
-  snowy:  'journal.weatherSnowy',
+function emptyJournal(userId: string, date: string): DailyJournal {
+  return {
+    user_id: userId,
+    date,
+    mood: null,
+    weather: null,
+    morning_memo: null,
+    schedule_notes: null,
+    evening_reflection: null,
+    ai_summary: null,
+    tags: [],
+  }
 }
 
 export function JournalDetailSheet({ userId, date, initialJournal, onClose, onSaved }: JournalDetailSheetProps) {
-  const [journal, setJournal] = useState<DailyJournal | null>(initialJournal ?? null)
-  const [reflection, setReflection] = useState(initialJournal?.evening_reflection ?? '')
+  // フル編集モード: 開いている間は state にバッファし、保存で確定
+  const [mood, setMood] = useState<Mood | null>((initialJournal?.mood as Mood | null) ?? null)
+  const [weather, setWeather] = useState<Weather | null>((initialJournal?.weather as Weather | null) ?? null)
+  const [scheduleNotes, setScheduleNotes] = useState<string>(initialJournal?.schedule_notes ?? '')
+  const [reflection, setReflection] = useState<string>(initialJournal?.evening_reflection ?? '')
+  const [tags, setTags] = useState<string[]>(initialJournal?.tags ?? [])
+  const [aiSummary] = useState<string>(initialJournal?.ai_summary ?? '') // read-only 表示用
+
+  const [loading, setLoading] = useState(!initialJournal)
   const [saving, setSaving] = useState(false)
   const [savedToast, setSavedToast] = useState(false)
-  const [loading, setLoading] = useState(!initialJournal)
+
   const modalRef = useRef<HTMLDivElement>(null)
   const closeBtnRef = useRef<HTMLButtonElement>(null)
   const previouslyFocusedRef = useRef<HTMLElement | null>(null)
 
+  // 初期データが渡されない場合は fetch
   useEffect(() => {
     if (initialJournal !== undefined && initialJournal !== null) return
     let cancelled = false
@@ -45,14 +54,19 @@ export function JournalDetailSheet({ userId, date, initialJournal, onClose, onSa
       setLoading(true)
       const j = await fetchJournalByDate(userId, date)
       if (cancelled) return
-      setJournal(j)
-      setReflection(j?.evening_reflection ?? '')
+      if (j) {
+        setMood((j.mood as Mood | null) ?? null)
+        setWeather((j.weather as Weather | null) ?? null)
+        setScheduleNotes(j.schedule_notes ?? '')
+        setReflection(j.evening_reflection ?? '')
+        setTags(j.tags ?? [])
+      }
       setLoading(false)
     })()
     return () => { cancelled = true }
   }, [userId, date, initialJournal])
 
-  // モーダルが開いている間: ESC で閉じる、初期 focus を閉じるボタン、body スクロール抑制
+  // モーダル a11y: ESC で閉じる、focus trap、body scroll lock
   useEffect(() => {
     previouslyFocusedRef.current = document.activeElement as HTMLElement | null
     const prevOverflow = document.body.style.overflow
@@ -65,7 +79,6 @@ export function JournalDetailSheet({ userId, date, initialJournal, onClose, onSa
         return
       }
       if (e.key === 'Tab') {
-        // 簡易フォーカストラップ：内部の interactive 要素を巡回
         const root = modalRef.current
         if (!root) return
         const focusables = root.querySelectorAll<HTMLElement>(
@@ -84,7 +97,6 @@ export function JournalDetailSheet({ userId, date, initialJournal, onClose, onSa
       }
     }
     document.addEventListener('keydown', handleKey)
-    // 開いた直後は閉じるボタンに focus
     closeBtnRef.current?.focus()
 
     return () => {
@@ -97,23 +109,20 @@ export function JournalDetailSheet({ userId, date, initialJournal, onClose, onSa
   const handleSave = async () => {
     setSaving(true)
     const updated: DailyJournal = {
-      user_id: userId,
-      date,
-      mood: (journal?.mood as Mood | null) ?? null,
-      weather: (journal?.weather as Weather | null) ?? null,
-      morning_memo: journal?.morning_memo ?? null,
-      schedule_notes: journal?.schedule_notes ?? null,
-      ai_summary: journal?.ai_summary ?? null,
+      ...emptyJournal(userId, date),
+      mood,
+      weather,
+      schedule_notes: scheduleNotes.trim() || null,
       evening_reflection: reflection.trim() || null,
-      tags: journal?.tags ?? [],
+      ai_summary: aiSummary.trim() || null,
+      tags,
     }
     const { error } = await upsertJournal(updated)
     setSaving(false)
     if (!error) {
-      setJournal(updated)
       setSavedToast(true)
       onSaved?.(updated)
-      setTimeout(() => setSavedToast(false), 2000)
+      setTimeout(() => setSavedToast(false), 1500)
     }
   }
 
@@ -128,58 +137,67 @@ export function JournalDetailSheet({ userId, date, initialJournal, onClose, onSa
       />
       <div ref={modalRef} className="journal-modal" style={{ position: 'relative' }}>
         <div className="journal-modal__bar" />
-        <div>
-          <div className="journal-modal__title">{date}</div>
-          {(journal?.mood || journal?.weather) && (
-            <div className="journal-modal__meta" style={{ marginTop: 6 }}>
-              {journal.mood && (
-                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: 'var(--brand)' }}>
-                  <MoodIcon mood={journal.mood as Mood} size={18} />
-                  <span>{t(MOOD_LABEL_KEY[journal.mood as Mood])}</span>
-                </span>
-              )}
-              {journal.weather && (
-                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: 'var(--text-secondary)' }}>
-                  <WeatherIcon weather={journal.weather as Weather} size={18} />
-                  <span>{t(WEATHER_LABEL_KEY[journal.weather as Weather])}</span>
-                </span>
-              )}
-            </div>
-          )}
-        </div>
+        <div className="journal-modal__title">{date}</div>
 
-        {loading && <div className="journal-modal__empty">{t('common.loading')}</div>}
-
-        {!loading && !journal && (
-          <div className="journal-modal__empty">{t('journal.noEntryThisDay')}</div>
-        )}
-
-        {!loading && journal && (
+        {loading ? (
+          <div className="journal-modal__empty">{t('common.loading')}</div>
+        ) : (
           <>
-            {journal.schedule_notes && (
-              <div>
-                <div className="journal-modal__section-label">{t('journal.scheduleLabel')}</div>
-                <div className="journal-modal__body">{journal.schedule_notes}</div>
+            {aiSummary && (
+              <div className="journal-summary-card journal-summary-card--compact" role="region">
+                <div className="journal-summary-card__title">
+                  <SparkleIcon size={14} />
+                  <span>{t('journal.aiSummary')}</span>
+                </div>
+                <div className="journal-summary-card__body">{aiSummary}</div>
               </div>
             )}
 
-            {journal.ai_summary && (
-              <div>
-                <div className="journal-modal__section-label">{t('journal.aiSummary')}</div>
-                <div className="journal-modal__body">{journal.ai_summary}</div>
-              </div>
-            )}
-
+            {/* mood */}
             <div>
-              <div className="journal-modal__section-label">{t('journal.eveningReflection')}</div>
-              <div style={{ marginTop: 6 }}>
-                <VoiceTextarea
-                  value={reflection}
-                  onChange={setReflection}
-                  placeholder={t('journal.eveningPlaceholder')}
-                  ariaLabel={t('journal.eveningReflection')}
-                />
-              </div>
+              <div className="journal-section__label" style={{ marginBottom: 8 }}>{t('journal.moodLabel')}</div>
+              <MoodSelector value={mood} onChange={setMood} disabled={saving} />
+            </div>
+
+            {/* weather */}
+            <div>
+              <div className="journal-section__label" style={{ marginBottom: 8 }}>{t('journal.weatherLabel')}</div>
+              <WeatherSelector value={weather} onChange={setWeather} disabled={saving} />
+            </div>
+
+            {/* schedule_notes (朝の意図) */}
+            <div>
+              <div className="journal-section__label" style={{ marginBottom: 8 }}>{t('journal.intentLabel')}</div>
+              <VoiceTextarea
+                value={scheduleNotes}
+                onChange={setScheduleNotes}
+                placeholder={t('journal.intentPlaceholder')}
+                ariaLabel={t('journal.intentLabel')}
+                enableCleanup
+              />
+            </div>
+
+            {/* tags */}
+            <div>
+              <div className="journal-section__label" style={{ marginBottom: 8 }}>{t('journal.tagsLabel')}</div>
+              <TagInput
+                value={tags}
+                onChange={setTags}
+                placeholder={t('journal.tagsPlaceholder')}
+              />
+            </div>
+
+            {/* evening_reflection */}
+            <div>
+              <div className="journal-section__label" style={{ marginBottom: 8 }}>{t('journal.eveningReflection')}</div>
+              <VoiceTextarea
+                value={reflection}
+                onChange={setReflection}
+                placeholder={t('journal.eveningPlaceholder')}
+                ariaLabel={t('journal.eveningReflection')}
+                minHeight={120}
+                enableCleanup
+              />
             </div>
 
             <button
@@ -187,7 +205,7 @@ export function JournalDetailSheet({ userId, date, initialJournal, onClose, onSa
               className="journal-summarize-btn"
               onClick={handleSave}
               disabled={saving}
-              style={{ marginTop: 8 }}
+              style={{ marginTop: 4 }}
             >
               {saving ? t('common.loading') : t('common.save')}
             </button>

--- a/src/components/journal/JournalToday.tsx
+++ b/src/components/journal/JournalToday.tsx
@@ -27,16 +27,16 @@ export function JournalToday({ userId, assistantName }: JournalTodayProps) {
   const [loaded, setLoaded] = useState(false)
   const [phase, setPhase] = useState<Phase>(decideInitialPhase)
 
-  // 朝セクション
-  const [mood, setMood] = useState<Mood | null>(null)
-  const [weather, setWeather] = useState<Weather | null>(null)
+  // 朝セクション（意図・予定・タグ）
   const [scheduleNotes, setScheduleNotes] = useState('')
   const [tags, setTags] = useState<string[]>([])
   const [summary, setSummary] = useState('')
   const [followUp, setFollowUp] = useState('')
   const [isGenerating, setIsGenerating] = useState(false)
 
-  // 夜セクション
+  // 夜セクション（気分・天気・振り返り）
+  const [mood, setMood] = useState<Mood | null>(null)
+  const [weather, setWeather] = useState<Weather | null>(null)
   const [reflection, setReflection] = useState('')
   const [saving, setSaving] = useState(false)
   const [savedToast, setSavedToast] = useState(false)
@@ -76,7 +76,10 @@ export function JournalToday({ userId, assistantName }: JournalTodayProps) {
     return () => { cancelled = true }
   }, [userId])
 
-  const canGenerate = !!(mood !== null || weather !== null || scheduleNotes.trim() || tags.length > 0)
+  // 朝の要約 CTA は schedule_notes / tags があれば有効
+  const canGenerate = !!(scheduleNotes.trim() || tags.length > 0)
+  // 夜の保存 CTA は気分・天気・振り返り のどれかが入ってれば有効
+  const canSaveEvening = !!(mood !== null || weather !== null || reflection.trim())
 
   const refreshAfterSave = async () => {
     if (!userId) return
@@ -107,14 +110,15 @@ export function JournalToday({ userId, assistantName }: JournalTodayProps) {
     await refreshAfterSave()
   }
 
+  // 朝のサマリー: scheduleNotes + tags を中心に。mood/weather は朝時点で未入力なので渡さない
   const handleSummarize = async () => {
     if (!canGenerate || isGenerating) return
     setError(null)
     setIsGenerating(true)
     try {
       const { summary: newSummary, followUpQuestion, error: apiErr } = await summarizeJournal({
-        mood,
-        weather,
+        mood: null,
+        weather: null,
         scheduleNotes: scheduleNotes.trim() || null,
         assistantName,
       })
@@ -192,22 +196,13 @@ export function JournalToday({ userId, assistantName }: JournalTodayProps) {
       {phase === 'morning' ? (
         <div className="journal-today__phase">
           <div>
-            <div className="journal-section__label" style={{ marginBottom: 8 }}>{t('journal.moodLabel')}</div>
-            <MoodSelector value={mood} onChange={setMood} disabled={isGenerating} />
-          </div>
-
-          <div>
-            <div className="journal-section__label" style={{ marginBottom: 8 }}>{t('journal.weatherLabel')}</div>
-            <WeatherSelector value={weather} onChange={setWeather} disabled={isGenerating} />
-          </div>
-
-          <div>
             <div className="journal-section__label" style={{ marginBottom: 8 }}>{t('journal.intentLabel')}</div>
             <VoiceTextarea
               value={scheduleNotes}
               onChange={setScheduleNotes}
               placeholder={t('journal.intentPlaceholder')}
               ariaLabel={t('journal.intentLabel')}
+              enableCleanup
             />
           </div>
 
@@ -263,6 +258,7 @@ export function JournalToday({ userId, assistantName }: JournalTodayProps) {
         </div>
       ) : (
         <div className="journal-today__phase">
+          {/* 朝のリキャップ (任意・存在時のみ) */}
           {summary && (
             <div className="journal-summary-card journal-summary-card--compact" role="region">
               <div className="journal-summary-card__title">
@@ -279,6 +275,19 @@ export function JournalToday({ userId, assistantName }: JournalTodayProps) {
             </div>
           )}
 
+          {/* 今日の気分（1 日を振り返って） */}
+          <div>
+            <div className="journal-section__label" style={{ marginBottom: 8 }}>{t('journal.moodLabel')}</div>
+            <MoodSelector value={mood} onChange={setMood} disabled={saving} />
+          </div>
+
+          {/* 今日の天気 */}
+          <div>
+            <div className="journal-section__label" style={{ marginBottom: 8 }}>{t('journal.weatherLabel')}</div>
+            <WeatherSelector value={weather} onChange={setWeather} disabled={saving} />
+          </div>
+
+          {/* 振り返り */}
           <div>
             <div className="journal-section__label" style={{ marginBottom: 8 }}>{t('journal.eveningReflection')}</div>
             <VoiceTextarea
@@ -287,6 +296,7 @@ export function JournalToday({ userId, assistantName }: JournalTodayProps) {
               placeholder={t('journal.eveningPlaceholder')}
               ariaLabel={t('journal.eveningReflection')}
               minHeight={140}
+              enableCleanup
             />
           </div>
 
@@ -294,7 +304,7 @@ export function JournalToday({ userId, assistantName }: JournalTodayProps) {
             type="button"
             className="journal-summarize-btn"
             onClick={handleSaveEvening}
-            disabled={saving}
+            disabled={!canSaveEvening || saving}
           >
             {saving ? t('common.loading') : t('journal.saveEvening')}
           </button>

--- a/src/components/journal/VoiceTextarea.tsx
+++ b/src/components/journal/VoiceTextarea.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useVoiceInput, type VoiceErrorCode } from '../../hooks/useVoiceInput'
 import { MicIcon } from './MoodWeatherIcons'
+import { cleanupText } from './journalApi'
 import { t } from '../../i18n'
 
 interface VoiceTextareaProps {
@@ -9,6 +10,8 @@ interface VoiceTextareaProps {
   placeholder?: string
   minHeight?: number
   ariaLabel?: string
+  /** 「整理する」ボタンを表示。入力テキストを整形 API でクリーンアップする */
+  enableCleanup?: boolean
 }
 
 const ERROR_KEY: Record<VoiceErrorCode, string> = {
@@ -22,9 +25,11 @@ const ERROR_KEY: Record<VoiceErrorCode, string> = {
   'unknown':           'journal.voiceErrUnknown',
 }
 
-export function VoiceTextarea({ value, onChange, placeholder, minHeight, ariaLabel }: VoiceTextareaProps) {
+export function VoiceTextarea({ value, onChange, placeholder, minHeight, ariaLabel, enableCleanup }: VoiceTextareaProps) {
   // 録音開始時のテキスト末尾位置を覚えて、認識結果を以降に追記する
   const baseRef = useRef<string>(value)
+  const [cleaning, setCleaning] = useState(false)
+  const [cleanupError, setCleanupError] = useState<string | null>(null)
 
   const handleTranscript = (transcript: string) => {
     const sep = baseRef.current && !/[\s\n]$/.test(baseRef.current) ? ' ' : ''
@@ -41,6 +46,26 @@ export function VoiceTextarea({ value, onChange, placeholder, minHeight, ariaLab
   const handleStart = () => {
     if (!isListening) baseRef.current = value
     void toggleListening()
+  }
+
+  const handleCleanup = async () => {
+    if (!value.trim() || cleaning) return
+    setCleanupError(null)
+    setCleaning(true)
+    try {
+      const { cleaned, error: apiErr } = await cleanupText(value)
+      if (apiErr) { setCleanupError(t('journal.cleanupError')); return }
+      const final = (cleaned || '').trim()
+      if (final) {
+        baseRef.current = final
+        onChange(final)
+      }
+    } catch (e) {
+      console.warn('cleanup error:', e)
+      setCleanupError(t('journal.cleanupError'))
+    } finally {
+      setCleaning(false)
+    }
   }
 
   return (
@@ -72,9 +97,37 @@ export function VoiceTextarea({ value, onChange, placeholder, minHeight, ariaLab
           {t('journal.voiceRecording')}
         </span>
       )}
+      {enableCleanup && (
+        <button
+          type="button"
+          className="journal-cleanup-btn"
+          onClick={handleCleanup}
+          disabled={!value.trim() || cleaning}
+          aria-label={t('journal.cleanupAria')}
+        >
+          {cleaning ? (
+            <>
+              <span className="journal-spinner journal-spinner--brand" aria-hidden="true" />
+              <span>{t('journal.cleanupRunning')}</span>
+            </>
+          ) : (
+            <>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M3 6h18M3 12h18M3 18h12" />
+              </svg>
+              <span>{t('journal.cleanupCta')}</span>
+            </>
+          )}
+        </button>
+      )}
       {error && (
         <div className="journal-voice-error" role="alert">
           {t(ERROR_KEY[error])}
+        </div>
+      )}
+      {cleanupError && (
+        <div className="journal-voice-error" role="alert">
+          {cleanupError}
         </div>
       )}
     </div>

--- a/src/components/journal/journal.css
+++ b/src/components/journal/journal.css
@@ -839,3 +839,35 @@
   color: var(--text-secondary);
   line-height: 1.6;
 }
+
+/* Cleanup button (テキスト整形) */
+.journal-cleanup-btn {
+  position: absolute;
+  right: 56px;
+  bottom: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  border-radius: 99px;
+  border: 1px solid var(--border, rgba(255,255,255,.12));
+  background: var(--bg-tertiary, rgba(255,255,255,.08));
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  min-height: 28px;
+}
+
+.journal-cleanup-btn:hover:not(:disabled) {
+  background: var(--accent-soft);
+  color: var(--brand);
+  border-color: color-mix(in srgb, var(--brand) 40%, transparent);
+}
+
+.journal-cleanup-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/src/components/journal/journalApi.ts
+++ b/src/components/journal/journalApi.ts
@@ -36,6 +36,24 @@ interface GoalFeedbackRequest {
   assistantName: string
 }
 
+export async function cleanupText(text: string): Promise<{ cleaned?: string; error?: string }> {
+  try {
+    const res = await fetch(`${API_BASE}/api/journal/cleanup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, locale: getLocale() }),
+    })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      return { error: data?.error || `HTTP ${res.status}` }
+    }
+    const data = await res.json()
+    return { cleaned: data?.cleaned ?? '' }
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : String(e) }
+  }
+}
+
 export async function goalFeedback(req: GoalFeedbackRequest): Promise<{ feedback?: string; error?: string }> {
   try {
     const res = await fetch(`${API_BASE}/api/journal/goal-feedback`, {

--- a/src/hooks/useVoiceInput.ts
+++ b/src/hooks/useVoiceInput.ts
@@ -166,6 +166,8 @@ export function useVoiceInput(onTranscript: (text: string) => void): UseVoiceInp
       }
       recognition.onend = () => { setIsListening(false); recognitionRef.current = null }
       recognition.onerror = (e) => {
+        // Keita デバッグ用にフル詳細を出力
+        console.warn('[useVoiceInput] onerror', { error: e.error, message: e.message, raw: e })
         const code = mapWebError(e)
         // ユーザーが止めた場合（aborted）は無視
         if (code !== 'aborted') setError(code)
@@ -176,8 +178,12 @@ export function useVoiceInput(onTranscript: (text: string) => void): UseVoiceInp
       recognitionRef.current = recognition
       setIsListening(true)
     } catch (e) {
-      console.warn('useVoiceInput web start:', e)
-      setError('unknown')
+      console.warn('[useVoiceInput] web start failed', e)
+      // SecurityError: not HTTPS / not allowed by Permissions Policy
+      const msg = e instanceof Error ? e.message.toLowerCase() : ''
+      if (msg.includes('not allowed') || msg.includes('permission')) setError('permission-denied')
+      else if (msg.includes('not supported')) setError('not-supported')
+      else setError('unknown')
       setIsListening(false)
     }
   }, [])

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -132,6 +132,12 @@ const STRINGS: Record<Locale, Strings> = {
     'journal.voiceErrUnsupported': 'このブラウザは音声入力に対応してないみたい',
     'journal.voiceErrAborted': '',
     'journal.voiceErrUnknown': '音声入力でエラーが起きたわ。もう一度試して',
+
+    // Text cleanup
+    'journal.cleanupCta': '整理する',
+    'journal.cleanupRunning': '整理中...',
+    'journal.cleanupAria': '入力テキストを整形',
+    'journal.cleanupError': '整理に失敗したわ。もう一度試して',
     'journal.assistantNameDefault': 'パーソナルアシスタント',
     'journal.errorGeneric': 'エラーが発生しました。しばらく待ってからもう一度お試しください。',
     'journal.prevMonth': '前の月',
@@ -1584,6 +1590,12 @@ const STRINGS: Record<Locale, Strings> = {
     'journal.voiceErrUnsupported': "This browser doesn't support voice input.",
     'journal.voiceErrAborted': '',
     'journal.voiceErrUnknown': 'Voice input failed. Please try again.',
+
+    // Text cleanup
+    'journal.cleanupCta': 'Clean up',
+    'journal.cleanupRunning': 'Cleaning...',
+    'journal.cleanupAria': 'Clean up the typed text',
+    'journal.cleanupError': 'Cleanup failed. Please try again.',
     'journal.assistantNameDefault': 'Personal assistant',
     'journal.errorGeneric': 'Something went wrong. Please try again in a moment.',
     'journal.prevMonth': 'Previous month',


### PR DESCRIPTION
## Summary

Keita からの 4 つの要望に対応：

1. **「気分」「天気」を夜に移動** — 朝は予定・タグ・意図だけ、1 日を振り返ってから気分・天気を記録する自然な配置
2. **カレンダーから当日（過去日）のジャーナルも残せる** — 詳細モーダルを read-only からフル編集モードに
3. **AI アシスタントとは別に「整理する」ボタン** — 書かれた（音声入力された）内容のクリーンアップのみ（内容追加・要約・意見の付与なし）
4. **マイクエラーの調査用デバッグログ強化** — Console で原因特定できるように

## 主な変更

### Phase 再構成（`JournalToday.tsx`）

| Phase | 含まれる項目 |
|---|---|
| 朝（意図）| 予定メモ + タグ + `{name}に整理してもらう` (AI 要約 + フォローアップ問い) |
| 夜（振り返り）| 朝のリキャップ（任意） + **気分** + **天気** + 振り返り入力 + 保存 |

夜の保存 CTA は気分・天気・振り返りのどれか 1 つ以上で有効。

### カレンダーフル編集（`JournalDetailSheet.tsx`）

- 日付セルをタップ → モーダルで mood / weather / 予定 / タグ / 振り返り を全て編集可能
- AI 要約は read-only 表示（生成は「今日」のタブで）
- ESC + focus trap + body scroll lock の a11y は維持

### 整理ボタン（`VoiceTextarea` + 新 endpoint）

- `VoiceTextarea` に `enableCleanup` prop 追加 → マイクの隣に小さい「整理する」ボタン
- `POST /api/journal/cleanup` を新設（claude-haiku-4-5-20251001）
- プロンプトで **「要約・短縮・内容追加・意見・解釈・翻訳を禁止」** を厳格に指示
- 整形対象：誤字脱字 / 句読点 / フィラー除去 / 段落分け / 空白正規化のみ
- 朝の予定 textarea / 夜の振り返り textarea / カレンダー詳細の各 textarea で有効

### マイクデバッグ強化（`useVoiceInput.ts`）

- `onerror` で `event.error` + `event.message` + raw event を `console.warn` で全部出力
- web start の catch で SecurityError / permission / not-supported を細かく分類

**マイクエラーが出たら**:
1. ブラウザの開発者ツールを開く（F12 or Cmd+Option+I）
2. Console タブを見る
3. `[useVoiceInput]` で始まるログを確認して、`error` フィールドを共有してね

考えられる主な原因：
- `not-allowed` / `service-not-allowed` → マイク許可拒否、または HTTPS でない
- `network` → Chrome の音声サーバー（Google）への接続失敗。社内 LAN / プロキシで起きやすい
- `audio-capture` → 物理マイクなし or OS でミュート
- `no-speech` → 何も話さなかった or マイク入力が小さすぎる

## チェック結果

- `tsc -b --noEmit` ✅ エラー 0
- `eslint` v3 ファイル ✅ エラー 0
- `vite build` ✅
- 既存テーブル変更なし（migration 追加なし）

## Test plan

- [ ] 朝の phase: 気分・天気のセレクターが**無い**、予定・タグ・要約 CTA のみ
- [ ] 夜の phase: 朝のリキャップ（あれば表示） + 気分 + 天気 + 振り返り
- [ ] 朝で AI 要約生成 → 夜の phase に切り替えるとリキャップが見える
- [ ] カレンダー → 任意の日付タップ → モーダルで mood / weather / 予定 / タグ / 振り返り 全部編集 → 保存
- [ ] 予定 / 振り返り textarea の「整理する」ボタン押下 → テキストが整形される（内容追加されないことを確認）
- [ ] マイクボタン押下 → エラー時 Console に `[useVoiceInput]` ログが出る

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQfqPCpqQg2FZZqCX2V7HU)_