### PR TITLE
feat(scripts): Supabase migration runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "pg": "^8.20.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1"
@@ -8729,6 +8730,113 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pgpass/node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8853,6 +8961,49 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prebuild-install": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "pg": "^8.20.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1"

--- a/scripts/run-migration.js
+++ b/scripts/run-migration.js
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * Supabase migration runner
+ *
+ * supabase/migrations/*.sql を sort 順に走査し、未適用のものを順番に apply する。
+ * 適用済みは `_migrations` テーブル（初回実行時に自動作成）で追跡するので、
+ * 何度実行しても同じ migration を 2 回走らせない。
+ *
+ * Usage:
+ *   SUPABASE_DB_URL=... node scripts/run-migration.js              # 未適用を全部 apply
+ *   SUPABASE_DB_URL=... node scripts/run-migration.js --dry-run    # 何を流すか表示するだけ
+ *   SUPABASE_DB_URL=... node scripts/run-migration.js --list       # 適用済み / 未適用の一覧
+ *   SUPABASE_DB_URL=... node scripts/run-migration.js --file 014_journal_goal_categories.sql
+ *
+ * 接続文字列の取り方:
+ *   Supabase Dashboard → Project Settings → Database → Connection string
+ *   "URI" タブの pooler URL (port 6543, mode=transaction) を推奨。
+ *   例: postgres://postgres.<ref>:<password>@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres
+ *
+ * 前提:
+ *   - `npm install --save-dev pg` 済み
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+let Client
+try {
+  ;({ Client } = await import('pg'))
+} catch {
+  console.error('ERROR: "pg" package is not installed.')
+  console.error('  Run: npm install --save-dev pg')
+  process.exit(1)
+}
+
+const MIGRATIONS_DIR = path.join(__dirname, '..', 'supabase', 'migrations')
+const TRACKING_TABLE = '_migrations'
+
+function parseArgs(argv) {
+  const out = { dryRun: false, list: false, file: null }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--dry-run') out.dryRun = true
+    else if (a === '--list') out.list = true
+    else if (a === '--file') out.file = argv[++i]
+    else if (a === '--help' || a === '-h') {
+      const lines = fs.readFileSync(__filename, 'utf8').split('\n').slice(2, 22)
+      console.log(lines.join('\n'))
+      process.exit(0)
+    } else {
+      console.error(`Unknown argument: ${a}`)
+      process.exit(1)
+    }
+  }
+  return out
+}
+
+function readSqlFiles() {
+  if (!fs.existsSync(MIGRATIONS_DIR)) {
+    console.error(`ERROR: migrations dir not found: ${MIGRATIONS_DIR}`)
+    process.exit(1)
+  }
+  return fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .sort()
+}
+
+function checksum(text) {
+  return crypto.createHash('sha256').update(text).digest('hex').slice(0, 16)
+}
+
+async function ensureTrackingTable(client) {
+  await client.query(`
+    create table if not exists ${TRACKING_TABLE} (
+      filename text primary key,
+      applied_at timestamptz not null default now(),
+      checksum text
+    );
+  `)
+}
+
+async function getAppliedMap(client) {
+  const { rows } = await client.query(
+    `select filename, checksum from ${TRACKING_TABLE} order by filename`,
+  )
+  const map = new Map()
+  for (const r of rows) map.set(r.filename, r.checksum)
+  return map
+}
+
+async function applyOne(client, filename) {
+  const sqlPath = path.join(MIGRATIONS_DIR, filename)
+  const sql = fs.readFileSync(sqlPath, 'utf8')
+  const sum = checksum(sql)
+  console.log(`\n→ applying ${filename}  (${sql.length} bytes, sha=${sum})`)
+  await client.query('begin')
+  try {
+    await client.query(sql)
+    await client.query(
+      `insert into ${TRACKING_TABLE} (filename, checksum) values ($1, $2)
+       on conflict (filename) do update set checksum = excluded.checksum, applied_at = now()`,
+      [filename, sum],
+    )
+    await client.query('commit')
+    console.log(`  ✓ ok`)
+  } catch (err) {
+    await client.query('rollback')
+    console.error(`  ✗ failed: ${err.message}`)
+    throw err
+  }
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2))
+
+  const dbUrl = process.env.SUPABASE_DB_URL || process.env.DATABASE_URL
+  if (!dbUrl) {
+    console.error('ERROR: SUPABASE_DB_URL (or DATABASE_URL) not set.')
+    console.error(
+      '  Supabase Dashboard → Project Settings → Database → Connection string (URI tab) で取得。',
+    )
+    console.error('  Pooler URL (port 6543, mode=transaction) 推奨。')
+    process.exit(1)
+  }
+
+  const client = new Client({
+    connectionString: dbUrl,
+    ssl: { rejectUnauthorized: false },
+  })
+
+  try {
+    await client.connect()
+  } catch (err) {
+    console.error(`ERROR: failed to connect to database: ${err.message}`)
+    process.exit(1)
+  }
+
+  await ensureTrackingTable(client)
+
+  const all = readSqlFiles()
+  const applied = await getAppliedMap(client)
+  const pending = all.filter((f) => !applied.has(f))
+
+  if (opts.list) {
+    console.log('Applied:')
+    for (const f of all.filter((f) => applied.has(f))) {
+      const stored = applied.get(f)
+      const current = checksum(fs.readFileSync(path.join(MIGRATIONS_DIR, f), 'utf8'))
+      const drift = stored && stored !== current ? '  ⚠ file changed since apply' : ''
+      console.log(`  ✓ ${f}${drift}`)
+    }
+    console.log('Pending:')
+    if (pending.length === 0) console.log('  (none)')
+    for (const f of pending) console.log(`  ○ ${f}`)
+    await client.end()
+    return
+  }
+
+  let target
+  if (opts.file) {
+    if (!all.includes(opts.file)) {
+      console.error(`ERROR: file not found in ${MIGRATIONS_DIR}: ${opts.file}`)
+      console.error(`Available:\n  ${all.join('\n  ')}`)
+      await client.end()
+      process.exit(1)
+    }
+    target = [opts.file]
+  } else {
+    target = pending
+  }
+
+  if (target.length === 0) {
+    console.log('Nothing to apply. All migrations are up to date.')
+    await client.end()
+    return
+  }
+
+  console.log(opts.dryRun ? 'DRY RUN — would apply:' : 'Will apply:')
+  for (const f of target) {
+    const note = applied.has(f) ? '  (re-apply, already tracked)' : ''
+    console.log(`  - ${f}${note}`)
+  }
+
+  if (opts.dryRun) {
+    await client.end()
+    return
+  }
+
+  for (const f of target) {
+    await applyOne(client, f)
+  }
+
+  await client.end()
+  console.log('\nDone.')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

クラウドターミナルから走らせる用の Supabase migration runner を新設。Supabase Dashboard / CLI を使わず、`SUPABASE_DB_URL` を渡せば未適用の `supabase/migrations/*.sql` を順番に流せる。

## Changes

| Path | 内容 |
|---|---|
| `scripts/run-migration.js` | 新規。`_migrations` テーブルで適用済みファイルを tracking し、未適用を順番に apply |
| `package.json` / `package-lock.json` | `pg ^8.20.0` を devDependencies に追加 |

main 起点でクリーンに作り直したので、competing journal 改修（PR #172/#173/#175）との競合はなし。**追加行 +359 / 削除 0 / 既存ファイル変更なし**。

## 仕様

- `_migrations` テーブル（初回自動作成）に filename + sha + applied_at を記録
- `supabase/migrations/*.sql` を **ファイル名 sort 順** に走査
- 各 migration を `begin/commit/rollback` で囲む。失敗時は完全 rollback
- `--list` で適用済みファイルのチェックサム drift を検出
- SSL 接続（Supabase 必須）

## 使い方

```bash
# 1. 接続文字列セット（Supabase Dashboard → Project Settings → Database → Connection string URI tab、pooler 6543 推奨）
export SUPABASE_DB_URL='postgres://postgres.<ref>:<password>@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres'

# 2. 現状確認
node scripts/run-migration.js --list

# 3. dry-run
node scripts/run-migration.js --dry-run

# 4. 未適用を全部 apply
node scripts/run-migration.js

# 特定ファイルだけ
node scripts/run-migration.js --file 014_journal_goal_categories.sql
```

## なぜ今これが必要か

PR #172（journal 目標 3 階層化）が main にマージ済みで、`014_journal_goal_categories.sql` が新規追加されている。これを Supabase 本番に適用しないと本番ビルドで journal 関連が落ちる。

## Test plan

- [ ] `SUPABASE_DB_URL=... node scripts/run-migration.js --list` で `_migrations` テーブル作成＋既存 migrations を表示
- [ ] `--dry-run` が DB に影響しない
- [ ] migration 014 を実際に apply して `list_tables` で `goal_categories` カラム確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPMWiHUB7T4Lg3zh4kMVEn)_