### PR TITLE
feat(auth): メールログインを認証コード方式（OTP）に切替

### DIFF
--- a/docs/AUTH_EMAIL_TEMPLATE.md
+++ b/docs/AUTH_EMAIL_TEMPLATE.md
@@ -1,0 +1,54 @@
+# メール認証コード（OTP）テンプレ運用
+
+Logic のメールログインは **6桁の認証コードを入力する方式（Email OTP）**。Magic Link（メール内のリンクをクリックして Web に遷移する方式）は使わない。
+
+- クライアント側：`src/supabase.ts` の `sendEmailOtp` / `verifyEmailOtp`、UI は `src/screens/LoginScreen.tsx`
+- 既に `signInWithOtp` → `verifyOtp({ type: 'email' })` の OTP コード検証 API を呼んでいるので、**コード変更は不要**
+
+ただし Supabase の `signInWithOtp` は仕様上、**メールテンプレートの内容で Magic Link / OTP コードのどちらを送るかが決まる**。Logic では以下のテンプレ（`docs/auth-email-template-otp.html`）を Supabase ダッシュボードの「Magic Link」テンプレに適用することで、6桁コードを送る挙動にしている。
+
+> Reference: https://supabase.com/docs/guides/auth/auth-email-passwordless#with-otp
+
+## 1. ダッシュボードで手動適用（初回・誰でも可）
+
+1. https://supabase.com/dashboard/project/yctlelmlwjwlcpcxvmgx/auth/templates を開く
+2. テンプレ種別 **「Magic Link」** を選択
+3. **Subject heading** を `Logic 認証コード` に書き換え
+4. **Message body (HTML)** を `docs/auth-email-template-otp.html` の中身で全文上書き
+5. `Save changes`
+6. 自分のメールアドレスにテスト送信して、本文中の 6桁コードでログインできるか確認
+
+## 2. スクリプトで自動適用（CI / 環境再現用）
+
+Supabase Personal Access Token を発行して環境変数で渡す。
+
+```bash
+# Token 発行: https://supabase.com/dashboard/account/tokens
+export SUPABASE_ACCESS_TOKEN=sbp_xxxxxxxxxxxxxxxxxxxx
+
+# Logic 本番に適用
+./scripts/update-auth-email-template.sh
+
+# 別プロジェクト（例：staging）に適用したい場合
+SUPABASE_PROJECT_REF=xxxxxxxx ./scripts/update-auth-email-template.sh
+```
+
+スクリプトの中身は Supabase Management API の
+`PATCH /v1/projects/{ref}/config/auth` を叩いて、
+`mailer_subjects_magic_link` と `mailer_templates_magic_link_content`
+の 2 フィールドを更新するだけ。
+
+## 3. テンプレを編集したくなったら
+
+- HTML 本体は `docs/auth-email-template-otp.html` を直接編集
+- `{{ .Token }}` プレースホルダは **絶対残す**（Supabase 側で 6桁コードに置換される）
+- 編集後はもう一度 `./scripts/update-auth-email-template.sh` を流すか、ダッシュボードに貼り直す
+- 利用できる変数一覧は Supabase 公式ドキュメント参照：
+  https://supabase.com/docs/guides/auth/auth-email-templates
+
+## 4. やってはいけないこと
+
+- テンプレに `{{ .ConfirmationURL }}`（Magic Link 用 URL）を含めない
+  → 含めるとユーザーがリンクをクリックして Web に飛んでしまい、アプリ側の OTP 入力 UI を経由しない
+- Supabase Auth の `Enable email confirmations` は OFF にしない（パスワード認証ではなく OTP 専用にしているため）
+- `signInWithOtp` 呼び出し時に `emailRedirectTo` を渡さない（`src/supabase.ts` 参照、現状未指定で正しい）

--- a/docs/auth-email-template-otp.html
+++ b/docs/auth-email-template-otp.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Logic 認証コード / Verification Code</title>
+  </head>
+  <body style="margin:0;padding:24px;background:#F5F7FB;font-family:-apple-system,BlinkMacSystemFont,'Helvetica Neue',Arial,'Hiragino Kaku Gothic ProN','Hiragino Sans','Noto Sans JP',sans-serif;color:#1F2937;line-height:1.6;">
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width:480px;margin:0 auto;background:#FFFFFF;border-radius:12px;box-shadow:0 2px 8px rgba(0,0,0,0.04);">
+      <tr>
+        <td style="padding:32px 32px 24px;">
+          <div style="font-size:18px;font-weight:700;color:#3D5FC4;letter-spacing:0.04em;margin:0 0 24px;">Logic</div>
+
+          <p style="font-size:15px;margin:0 0 4px;color:#1F2937;">下記の認証コードをアプリに入力してください。</p>
+          <p style="font-size:13px;margin:0 0 20px;color:#6B7280;">Enter the verification code below in the app.</p>
+
+          <div style="background:#EEF2FE;border-radius:10px;padding:20px 16px;text-align:center;margin:0 0 20px;">
+            <div style="font-size:32px;font-weight:700;letter-spacing:0.32em;color:#3D5FC4;font-family:'SF Mono','Menlo','Consolas',monospace;">{{ .Token }}</div>
+          </div>
+
+          <p style="font-size:13px;margin:0 0 4px;color:#6B7280;">このコードは <strong style="color:#1F2937;">1時間</strong> 有効です。</p>
+          <p style="font-size:13px;margin:0 0 24px;color:#6B7280;">This code expires in <strong style="color:#1F2937;">1 hour</strong>.</p>
+
+          <hr style="border:0;border-top:1px solid #E5E7EB;margin:24px 0;" />
+
+          <p style="font-size:12px;margin:0;color:#9CA3AF;">
+            心当たりがない場合はこのメールを無視してください。<br />
+            If you didn&rsquo;t request this code, you can safely ignore this email.
+          </p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/scripts/update-auth-email-template.sh
+++ b/scripts/update-auth-email-template.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Update the Supabase Auth "Magic Link" email template so that the login email
+# delivers a 6-digit OTP code (rendered from {{ .Token }}) instead of a magic
+# link. The Logic app already calls `verifyOtp({ type: 'email' })`, so the only
+# missing piece is the email body.
+#
+# Usage:
+#   SUPABASE_ACCESS_TOKEN=sbp_xxx ./scripts/update-auth-email-template.sh
+#
+# Optional:
+#   SUPABASE_PROJECT_REF   default: yctlelmlwjwlcpcxvmgx (Logic prod)
+#   TEMPLATE_FILE          default: docs/auth-email-template-otp.html
+#   SUBJECT_JA             default: "Logic 認証コード"
+#
+# Issue a Personal Access Token from:
+#   https://supabase.com/dashboard/account/tokens
+
+set -euo pipefail
+
+: "${SUPABASE_ACCESS_TOKEN:?SUPABASE_ACCESS_TOKEN is required (see https://supabase.com/dashboard/account/tokens)}"
+
+PROJECT_REF="${SUPABASE_PROJECT_REF:-yctlelmlwjwlcpcxvmgx}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE_FILE="${TEMPLATE_FILE:-${SCRIPT_DIR}/../docs/auth-email-template-otp.html}"
+SUBJECT="${SUBJECT_JA:-Logic 認証コード}"
+
+if [[ ! -f "$TEMPLATE_FILE" ]]; then
+  echo "ERROR: template file not found: $TEMPLATE_FILE" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required (brew install jq / apt-get install jq)" >&2
+  exit 1
+fi
+
+CONTENT="$(cat "$TEMPLATE_FILE")"
+
+PAYLOAD="$(jq -n \
+  --arg subject "$SUBJECT" \
+  --arg content "$CONTENT" \
+  '{
+    mailer_subjects_magic_link: $subject,
+    mailer_templates_magic_link_content: $content
+  }')"
+
+echo "Updating Auth email template for project: ${PROJECT_REF}"
+echo "Template source: ${TEMPLATE_FILE}"
+
+HTTP_STATUS="$(curl -sS -o /tmp/supabase-auth-update.json -w '%{http_code}' \
+  -X PATCH \
+  -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data "$PAYLOAD" \
+  "https://api.supabase.com/v1/projects/${PROJECT_REF}/config/auth")"
+
+if [[ "$HTTP_STATUS" != "200" ]]; then
+  echo "ERROR: Supabase API returned ${HTTP_STATUS}" >&2
+  cat /tmp/supabase-auth-update.json >&2
+  echo >&2
+  exit 1
+fi
+
+echo "OK — Magic Link template now delivers the 6-digit OTP code ({{ .Token }})."
+echo "Verify in: https://supabase.com/dashboard/project/${PROJECT_REF}/auth/templates"


### PR DESCRIPTION
## Summary

メールログイン時に「メールにコードが書いてない／クリックすると Web に遷移してしまう」問題の修正。

Supabase の `signInWithOtp` は仕様上、**メールテンプレートの内容で Magic Link / 6桁OTPコードのどちらを送るかが決まる**（[公式ドキュメント](https://supabase.com/docs/guides/auth/auth-email-passwordless#with-otp)）。

クライアント側は既に `verifyOtp({ type: 'email' })` を呼び、`LoginScreen.tsx` も6桁コード入力 UI 完備。残るは Supabase 側の Magic Link テンプレに `{{ .Token }}` を含めるだけ。

## 変更内容

- `docs/auth-email-template-otp.html` — 6桁コード表示用のメール本文 HTML（日英併記・Logic ブランドカラー）
- `scripts/update-auth-email-template.sh` — Management API 経由で Magic Link テンプレを一括上書きする shell スクリプト（`SUPABASE_ACCESS_TOKEN` 必須）
- `docs/AUTH_EMAIL_TEMPLATE.md` — 手動 / 自動それぞれの適用手順

## 適用方法（どちらか一方でOK）

### A. ダッシュボードで手動（推奨・即時）
1. https://supabase.com/dashboard/project/yctlelmlwjwlcpcxvmgx/auth/templates
2. 「Magic Link」タブ
3. Subject heading: `Logic 認証コード`
4. Message body (HTML) を `docs/auth-email-template-otp.html` の中身で全文上書き
5. Save changes

### B. スクリプトで自動
```bash
export SUPABASE_ACCESS_TOKEN=sbp_xxx   # https://supabase.com/dashboard/account/tokens
./scripts/update-auth-email-template.sh
```

## Test plan
- [ ] Supabase ダッシュボード or スクリプトで Magic Link テンプレを上書き
- [ ] 自分のメールアドレスでログイン試行
- [ ] メール本文に **6桁の認証コード** が表示される（リンクではない）
- [ ] アプリの入力欄にコードを入れてログインできる
- [ ] 再送ボタン・別アドレスへの切替ボタンが従来通り動く

## 注意
- コード変更ゼロ（`src/supabase.ts` / `src/screens/LoginScreen.tsx` は既に OTP 完全対応済み）
- Supabase 側のテンプレ反映が **唯一の必須作業**。マージしただけではまだ動作変わらないので注意

https://claude.ai/code/session_01N2DRppgnWzRQeLFSBUytX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2DRppgnWzRQeLFSBUytX7)_