### PR TITLE
ci: Supabase Auth メールテンプレ反映 workflow を追加

### DIFF
--- a/.github/workflows/update-auth-email-template.yml
+++ b/.github/workflows/update-auth-email-template.yml
@@ -1,0 +1,50 @@
+name: 📧 Update Auth Email Template (Supabase)
+
+on:
+  # 手動トリガーのみ
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Supabase Auth Magic Link テンプレを上書きしますか？ (yes と入力)'
+        required: true
+        default: 'no'
+      project_ref:
+        description: 'Supabase project ref (空欄なら Logic 本番 yctlelmlwjwlcpcxvmgx)'
+        required: false
+        default: ''
+
+jobs:
+  # ── ガード: "yes" 以外は即終了 ─────────────────────────
+  check-confirm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm input
+        run: |
+          if [ "${{ github.event.inputs.confirm }}" != "yes" ]; then
+            echo "❌ 'yes' と入力されなかったため中止します"
+            exit 1
+          fi
+          echo "✅ 承認確認OK"
+
+  # ── テンプレ反映 ───────────────────────────────────────
+  update-template:
+    needs: check-confirm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Apply email template via Supabase Management API
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF: ${{ github.event.inputs.project_ref }}
+        run: |
+          if [ -z "$SUPABASE_ACCESS_TOKEN" ]; then
+            echo "❌ secrets.SUPABASE_ACCESS_TOKEN が未設定です"
+            echo "https://supabase.com/dashboard/account/tokens でトークンを発行し、"
+            echo "リポジトリ Settings → Secrets and variables → Actions に登録してください"
+            exit 1
+          fi
+          bash scripts/update-auth-email-template.sh


### PR DESCRIPTION
## Summary

PR #180 のフォローアップ。Claude Code on the web のクラウドセッションから `api.supabase.com` への直接アクセスが network policy でブロックされたので、GitHub Actions（GitHub の IP は Supabase 側で許可される）経由で `scripts/update-auth-email-template.sh` を流せるようにする。

## 使い方

1. **secret 登録（初回のみ）**: Repo Settings → Secrets and variables → Actions → `New repository secret`
   - Name: `SUPABASE_ACCESS_TOKEN`
   - Value: `sbp_xxx`（https://supabase.com/dashboard/account/tokens で発行）
2. **実行**: Actions タブ → 「📧 Update Auth Email Template (Supabase)」→ `Run workflow`
   - `confirm`: `yes` と入力
   - `project_ref`: 空欄（Logic 本番 `yctlelmlwjwlcpcxvmgx` がデフォルト）

`deploy-production.yml` と同じ「confirm=yes 必須ガード」パターン採用。

## Test plan
- [ ] マージ
- [ ] `SUPABASE_ACCESS_TOKEN` を repo secret に登録
- [ ] Workflow を `confirm=yes` で実行 → 成功ログ確認
- [ ] 自分のメアドでログインしてみてメール本文に 6桁コードが届くか確認
- [ ] 動作確認後、Supabase 側でトークン revoke 推奨

https://claude.ai/code/session_01N2DRppgnWzRQeLFSBUytX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2DRppgnWzRQeLFSBUytX7)_