### PR TITLE
chore(ci): bump Actions to Node.js 24-ready majors + tracks migration

### DIFF
--- a/.github/workflows/android-deploy.yml
+++ b/.github/workflows/android-deploy.yml
@@ -13,25 +13,25 @@ jobs:
     steps:
       # ── 1. チェックアウト ──────────────────────────────────
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # ── 2. Node.js セットアップ ───────────────────────────
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
 
       # ── 3. Java (JDK 17) セットアップ ─────────────────────
       - name: Setup JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
 
       # ── 4. Android SDK セットアップ ───────────────────────
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       # ── 5. npm install ─────────────────────────────────────
       - name: Install dependencies
@@ -74,7 +74,7 @@ jobs:
 
       # ── 10. Gradle キャッシュ ─────────────────────────────
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -110,7 +110,7 @@ jobs:
 
       # ── 13. AAB を成果物として保存 ───────────────────────
       - name: Upload AAB artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: app-release-aab
           path: android/app/build/outputs/bundle/release/app-release.aab
@@ -120,12 +120,12 @@ jobs:
       #      Production 初回公開済みなので status: completed で
       #      内部テスターへ自動 rollout する。
       - name: Deploy to Play Console (Internal Test)
-        uses: r0adkll/upload-google-play@v1
+        uses: r0adkll/upload-google-play@v1.1.5
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
           packageName: com.logicalthinking.app
           releaseFiles: android/app/build/outputs/bundle/release/app-release.aab
-          track: internal
+          tracks: internal
           status: completed
           whatsNewDirectory: distribution/whatsnew
           inAppUpdatePriority: 2

--- a/.github/workflows/build-android-aab.yml
+++ b/.github/workflows/build-android-aab.yml
@@ -30,22 +30,22 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
 
       - name: Setup JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "17"
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Install dependencies
         run: npm ci
@@ -77,7 +77,7 @@ jobs:
           grep -E "versionCode|versionName" "$GRADLE"
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -131,7 +131,7 @@ jobs:
           sha256sum "$AAB"
 
       - name: Upload AAB artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: app-release-aab
           path: android/app/build/outputs/bundle/release/app-release.aab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -45,10 +45,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-a11y-report
           path: e2e/report

--- a/.github/workflows/daily-x-post.yml
+++ b/.github/workflows/daily-x-post.yml
@@ -9,9 +9,9 @@ jobs:
   post:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -27,9 +27,9 @@ jobs:
     needs: check-confirm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/generate-keystore.yml
+++ b/.github/workflows/generate-keystore.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
@@ -42,7 +42,7 @@ jobs:
           cat keystore.b64
 
       - name: Upload base64 as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: keystore-base64
           path: keystore.b64

--- a/.github/workflows/update-auth-email-template.yml
+++ b/.github/workflows/update-auth-email-template.yml
@@ -31,7 +31,7 @@ jobs:
     needs: check-confirm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq


### PR DESCRIPTION
## Summary
- 直近の Android deploy run（[#25963419482](https://github.com/keitaurano-del/logic/actions/runs/25963419482)）で出ていた 2件の deprecation 警告を解消
  - Node.js 20 系アクション（2026-06-02 で強制 Node 24 化、2026-09-16 で削除）
  - `r0adkll/upload-google-play` の `track` パラメータ（`tracks` へ移行）
- 各アクションを Node 24 対応の最新 major にバンプ
  - `actions/checkout` v4 → **v6**
  - `actions/setup-node` v4 → **v6**
  - `actions/setup-java` v4 → **v5**
  - `actions/cache` v4 → **v5**
  - `actions/upload-artifact` v4 → **v7**
  - `android-actions/setup-android` v3 → **v4**
  - `r0adkll/upload-google-play` v1 → **v1.1.5**（`track: internal` → `tracks: internal`）

## 影響範囲
- 7 workflow ファイル（android-deploy / build-android-aab / ci / daily-x-post / deploy-production / generate-keystore / update-auth-email-template）
- 単純な version bump + 1 パラメータ rename のみ、ロジック変更なし

## Test plan
- [ ] CI — Build & Lint がグリーン（このPRで起動）
- [ ] merge 後の main push で Android Deploy → Internal Test が成功し、deprecation 警告が消える
- [ ] Play Console の Internal Test トラックに新ビルドが届く

🤖 Generated with [Claude Code](https://claude.com/claude-code)