### PR TITLE
通知設定下部の「※通知はネイティブアプリのみ」注意書きを削除

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1104,7 +1104,6 @@ const STRINGS: Record<Locale, Strings> = {
     'notifSettings.journalHeading': 'ジャーナル',
     'notifSettings.journalReminder': 'ジャーナルリマインダー',
     'notifSettings.journalReminderSub': '指定時刻に今日のジャーナルを書く通知が届きます',
-    'notifSettings.note': '※ 通知はネイティブアプリ（iOS/Android）でのみ機能します。ブラウザ版では届きません。',
     'notifSettings.toggleAria': 'トグル',
 
     // Notification body messages (daily reminder, 20 variations)
@@ -2622,7 +2621,6 @@ const STRINGS: Record<Locale, Strings> = {
     'notifSettings.journalHeading': 'Journal',
     'notifSettings.journalReminder': 'Journal reminder',
     'notifSettings.journalReminderSub': 'Daily nudge to write your journal entry at the chosen time',
-    'notifSettings.note': '* Notifications work only on the native apps (iOS/Android). They are not delivered in the browser.',
     'notifSettings.toggleAria': 'Toggle',
 
     // Notification body messages (daily reminder, 20 variations)

--- a/src/screens/NotificationSettingsScreen.tsx
+++ b/src/screens/NotificationSettingsScreen.tsx
@@ -232,11 +232,6 @@ export function NotificationSettingsScreen({ onBack }: Props) {
             )}
           </div>
         </div>
-
-        {/* note */}
-        <div style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.7, padding: '0 4px' }}>
-          {t('notifSettings.note')}
-        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

通知設定画面下部に表示していた「※ 通知はネイティブアプリ（iOS/Android）でのみ機能します。ブラウザ版では届きません。」の注意書きを削除しました。

Logic はモバイルアプリ専用配信方針（[[project-logic-mobile-only]]）で Web 版を本番リリースしないため、この前置きは不要。

## Changes

- `src/i18n.ts`: ja / en 両方の `notifSettings.note` キーを削除（2行）
- `src/screens/NotificationSettingsScreen.tsx`: 末尾の note 表示ブロックを削除（5行）

合計 **7行削除のみ**、追加なし。

## Notes

- トグル直下にある `notifSettings.browserOnly`（「ブラウザ版では通知はアプリを開いている間のみ機能します」）は ※ マークのない別文言なので今回は残しています。同じ理由でこちらも消す方が筋が通るので、必要なら別 PR で対応します。

## Test plan

- [x] `tsc -b --noEmit` クリーン
- [ ] 通知設定画面を開き、トグル群の下に注意書きが表示されないことを目視確認
- [ ] ja / en どちらの locale でも文字残りがないこと


---
_Generated by [Claude Code](https://claude.ai/code/session_01RitKrY1xq1t5jfjNRmybiD)_