### PR TITLE
style(journal): ストリークバッジ・AI ボタンを検索アイコンサイズに揃える

### DIFF
--- a/src/components/journal/StreakBadge.tsx
+++ b/src/components/journal/StreakBadge.tsx
@@ -7,7 +7,7 @@ interface StreakBadgeProps {
 
 export function StreakBadge({ streak, size = 'sm' }: StreakBadgeProps) {
   const dim = streak === 0
-  const fontSize = size === 'lg' ? 24 : 16
+  const fontSize = size === 'lg' ? 24 : 13
   return (
     <span
       className={`journal-streak-badge ${dim ? 'journal-streak-badge--dim' : ''} ${size === 'lg' ? 'journal-streak-badge--lg' : ''}`}

--- a/src/components/journal/journal.css
+++ b/src/components/journal/journal.css
@@ -1337,12 +1337,12 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 8px 12px;
+  padding: 6px 10px;
   background: linear-gradient(160deg, rgba(255,140,0,.18) 0%, rgba(255,61,0,.10) 100%);
   border: 1px solid color-mix(in srgb, var(--streak-flame, #FF6B00) 40%, transparent);
   border-radius: 99px;
   color: var(--streak-flame, #FF6B00);
-  font-size: 14px;
+  font-size: 12px;
   font-weight: 800;
   letter-spacing: -0.01em;
   flex-shrink: 0;
@@ -1365,7 +1365,7 @@
 
 .journal-streak-badge__count {
   font-family: 'Inter Tight', sans-serif;
-  font-size: 18px;
+  font-size: 14px;
   font-weight: 900;
 }
 
@@ -1602,9 +1602,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  /* 2026-05-16: HIG 推奨の 44px tap target を確保（外周）。SVG は 18px。 */
-  width: 44px;
-  height: 44px;
+  /* 2026-05-17: 検索ボタンと同サイズに統一（40px）。SVG は 18px のまま。 */
+  width: 40px;
+  height: 40px;
   padding: 0;
   border-radius: 50%;
   border: none;


### PR DESCRIPTION
## Summary
ジャーナル画面ヘッダーの「2日連続」ストリークバッジと AI 生成ボタンが検索アイコンより目立ちすぎてバランスが悪かったのを、検索アイコン（40px）に合わせて整える。

- AI ボタン: 44×44 → 40×40（検索ボタンと同サイズ、SVG 18px はそのまま）
- ストリークバッジ: `padding 8/12 → 6/10`、`font-size 14 → 12`、`count 18 → 14`、🔥 emoji `16 → 13`

## Test plan
- [ ] ジャーナル画面ヘッダーを開き、3 つのアイコン（ストリーク・AI・検索）が同じ縦サイズで並んでいる
- [ ] AI ボタンの pulse / sparkle アニメーションが 40px サイズでも違和感なく動く
- [ ] ストリーク 0 件 (`--dim` 状態) でもバッジが極端に小さく潰れない
- [ ] Android 実機で safe-area-inset-top と合わせて崩れないか確認

https://claude.ai/code/session_01NiGn1GkE3uoaxBEopZZAEr

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiGn1GkE3uoaxBEopZZAEr)_