### PR TITLE
fix(billing): subscription を verify 後に acknowledge する

### DIFF
--- a/server/routes/billing.ts
+++ b/server/routes/billing.ts
@@ -81,6 +81,22 @@ export function createBillingRouter(deps: BillingDeps): express.Router {
           })
         }
         gpExpiryTimeMillis = expiryTimeMillis
+
+        // Acknowledgement — Play Billing 必須要件。3 日以内に ack しないと自動返金される。
+        // acknowledgementState: 0=未ack, 1=ack済。冪等性のため未ackのみ呼ぶ。
+        if (sub.acknowledgementState === 0) {
+          try {
+            await androidpublisher.purchases.subscriptions.acknowledge({
+              packageName: gpPackageName,
+              subscriptionId: productId,
+              token: purchaseToken,
+              requestBody: { developerPayload: '' },
+            })
+          } catch (ackErr) {
+            console.error('billing/verify acknowledge failed:', ackErr)
+            // ack 失敗は verify 自体は通すが、ログには残す。3日以内に再 ack できる余地を残す。
+          }
+        }
       }
 
       // productId からプランを特定（2026-05-15 単一有料プラン化）


### PR DESCRIPTION
## Summary
- Play Billing 必須要件である `acknowledgePurchase` をサーバー側 `/api/billing/verify` 内に追加
- `androidpublisher.purchases.subscriptions.acknowledge` を呼び、`acknowledgementState === 0` のときのみ実行（冪等）
- ack 失敗時は verify 結果は通すがエラーログを残す（3日以内に再 ack できる余地）

## Why
未 ack のサブスク購入は購入から 3 日後に **自動返金**される。本修正なしだと「ユーザーが買えるけど 3 日で課金がキャンセルされる」状態。

## Test plan
- [ ] License Tester アカウントで Internal Test 端末から購入フロー実行
- [ ] Supabase `subscriptions` テーブルに plan=paid_monthly の行が入る
- [ ] 5 分以上（License Tester は本番月単位 → 5 分間隔に短縮）放置してもキャンセルされない
- [ ] サーバーログに `acknowledge failed` が出ていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)