### PR TITLE
feat(roleplay): Gemini character art pipeline + image fallback

### DIFF
--- a/scripts/characterPortraitsV2.ts
+++ b/scripts/characterPortraitsV2.ts
@@ -1,0 +1,91 @@
+/**
+ * Character portrait prompts (Gemini Nano Banana 生成用).
+ *
+ * 哲学者 3 体 × 表情 3 種 = 9 枚。立ち絵としてロールプレイ画面の上半分に表示。
+ * 既存レッスンサムネと世界観を揃える（クリーム notebook 紙、Caveat 風の手書きトーン）。
+ *
+ * 使い方:
+ *   npx tsx scripts/generate-character-portraits.ts
+ *   npx tsx scripts/generate-character-portraits.ts --only=socrates_neutral,nietzsche_smile
+ *
+ * 出力: public/characters/{slug}.png
+ */
+
+export const PORTRAIT_STYLE = `
+Hand-drawn ink portrait on warm cream notebook paper (1:1 square).
+The portrait shows a head-and-shoulders view, centered, taking up about 70% of the frame.
+
+LINE WORK — clean confident black marker pen lines with slight natural ink variation. Cross-hatching for shading. NO photorealism, NO 3D rendering, NO digital painting polish.
+
+PAPER — warm beige cream paper with very subtle texture, optional faint horizontal ruled lines in light coral pink at the very top and bottom only (not crossing the portrait). NO decorative borders, NO sparkles, NO floating doodles.
+
+COLOR — primarily black line drawing with very light watercolor wash accents (sage green, mustard yellow, dusty blue, or muted coral) used only for clothing shadows and background tinting. NEVER fill the face with bright color. The character's skin remains paper-tone.
+
+NAMEPLATE — a single short name in chunky relaxed marker handwriting (Caveat-like) placed at the lower edge, with one flowing coral red underline beneath. The underline is a single quick brush stroke with natural taper, never ruler-straight.
+
+CRITICAL TEXT RULES:
+- Do NOT write any hex color codes, RGB values, color names, instruction labels, or technical text anywhere in the image
+- The ONLY visible text must be the philosopher's name at the bottom
+- Spelling must be perfectly correct — re-check every letter
+- The name uses Title Case (e.g. "Socrates", not "SOCRATES" all caps)
+
+NO: photo realism, 3D, isometric perspective, cinematic lighting, dark moody backgrounds, gradients filling whole image, glow effects, computer-graphics polish, multiple figures, hand gestures dominating the frame, decorative borders, ornamental marks.
+`.trim()
+
+export type CharacterPortraitEntry = {
+  /** Output filename without extension, e.g. "socrates_neutral" */
+  slug: string
+  /** The character */
+  characterId: 'socrates' | 'descartes' | 'nietzsche'
+  /** Expression */
+  expression: 'neutral' | 'smile' | 'troubled'
+  /** Subject description (head, hair, beard, clothing, era cues) */
+  subject: string
+  /** Expression detail (eyes, mouth, brow) */
+  expressionDetail: string
+  /** Nameplate text shown at the bottom */
+  nameplate: string
+  /** Critical words whose spelling MUST be preserved */
+  spell: string[]
+}
+
+const SOCRATES_SUBJECT = 'An elderly philosopher with a full curly white beard, a bald shiny round head, a wide flat nose, and a draped ancient Greek tunic (chiton) over one shoulder. Ancient Greek style, 5th century BC.'
+const DESCARTES_SUBJECT = 'A 17th-century French gentleman with shoulder-length wavy dark hair, a thin mustache, a small goatee, a long straight nose, and a wide white lace collar over a dark doublet. Calm and analytical bearing.'
+const NIETZSCHE_SUBJECT = 'A 19th-century European philosopher with an enormous bushy walrus mustache covering the upper lip and drooping past the mouth, intense piercing eyes under heavy brows, dark hair combed back, and a high-collared dark Victorian-era coat. Imposing and intense.'
+
+const EXPR_NEUTRAL = 'Calm composed expression. Steady level gaze. Mouth closed in a relaxed neutral line. Eyebrows level.'
+const EXPR_SMILE = 'Warm slightly amused expression. Subtle upturn at the corners of the mouth, faint crinkle near the eyes. Eyebrows slightly raised in friendly curiosity. Not a wide grin — a knowing gentle smile.'
+const EXPR_TROUBLED = 'Concerned thoughtful expression. Slight furrow between the eyebrows. Mouth pressed into a flat line or very slightly downturned. Eyes narrowed in critical consideration.'
+
+export const CHARACTER_PORTRAITS: CharacterPortraitEntry[] = [
+  // Socrates
+  { slug: 'socrates_neutral', characterId: 'socrates', expression: 'neutral', subject: SOCRATES_SUBJECT, expressionDetail: EXPR_NEUTRAL, nameplate: 'Socrates', spell: ['Socrates'] },
+  { slug: 'socrates_smile', characterId: 'socrates', expression: 'smile', subject: SOCRATES_SUBJECT, expressionDetail: EXPR_SMILE, nameplate: 'Socrates', spell: ['Socrates'] },
+  { slug: 'socrates_troubled', characterId: 'socrates', expression: 'troubled', subject: SOCRATES_SUBJECT, expressionDetail: EXPR_TROUBLED, nameplate: 'Socrates', spell: ['Socrates'] },
+  // Descartes
+  { slug: 'descartes_neutral', characterId: 'descartes', expression: 'neutral', subject: DESCARTES_SUBJECT, expressionDetail: EXPR_NEUTRAL, nameplate: 'Descartes', spell: ['Descartes'] },
+  { slug: 'descartes_smile', characterId: 'descartes', expression: 'smile', subject: DESCARTES_SUBJECT, expressionDetail: EXPR_SMILE, nameplate: 'Descartes', spell: ['Descartes'] },
+  { slug: 'descartes_troubled', characterId: 'descartes', expression: 'troubled', subject: DESCARTES_SUBJECT, expressionDetail: EXPR_TROUBLED, nameplate: 'Descartes', spell: ['Descartes'] },
+  // Nietzsche
+  { slug: 'nietzsche_neutral', characterId: 'nietzsche', expression: 'neutral', subject: NIETZSCHE_SUBJECT, expressionDetail: EXPR_NEUTRAL, nameplate: 'Nietzsche', spell: ['Nietzsche'] },
+  { slug: 'nietzsche_smile', characterId: 'nietzsche', expression: 'smile', subject: NIETZSCHE_SUBJECT, expressionDetail: EXPR_SMILE, nameplate: 'Nietzsche', spell: ['Nietzsche'] },
+  { slug: 'nietzsche_troubled', characterId: 'nietzsche', expression: 'troubled', subject: NIETZSCHE_SUBJECT, expressionDetail: EXPR_TROUBLED, nameplate: 'Nietzsche', spell: ['Nietzsche'] },
+]
+
+export function buildPortraitPrompt(entry: CharacterPortraitEntry): string {
+  return `${PORTRAIT_STYLE}
+
+SUBJECT:
+${entry.subject}
+
+EXPRESSION:
+${entry.expressionDetail}
+
+NAMEPLATE (the only visible text in the image):
+"${entry.nameplate}" — in chunky relaxed marker handwriting (Caveat-like), with one flowing coral red underline beneath it as a single brush stroke.
+
+CRITICAL SPELLING ENFORCEMENT — these strings MUST appear exactly as written, letter-by-letter, no substitutions, no extra letters, no missing letters:
+${entry.spell.map((s) => `  - "${s}"`).join('\n')}
+
+If you cannot render the nameplate text correctly, omit the nameplate entirely rather than misspelling it. NO other words may appear in the image.`
+}

--- a/scripts/generate-character-portraits.ts
+++ b/scripts/generate-character-portraits.ts
@@ -1,0 +1,183 @@
+/**
+ * 哲学者キャラクター立ち絵 9 枚を Gemini Nano Banana で一括生成する。
+ *
+ * Usage:
+ *   npx tsx scripts/generate-character-portraits.ts                    # 全 9 枚
+ *   npx tsx scripts/generate-character-portraits.ts --only=socrates_neutral
+ *   npx tsx scripts/generate-character-portraits.ts --skip-existing
+ *   npx tsx scripts/generate-character-portraits.ts --concurrency=3
+ *
+ * Default output: public/characters/{slug}.png
+ * Default model:  gemini-2.5-flash-image (Nano Banana, $0.039/枚)
+ */
+
+import { writeFile, mkdir, access, readFile } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { CHARACTER_PORTRAITS, buildPortraitPrompt, type CharacterPortraitEntry } from './characterPortraitsV2.ts'
+
+type Args = {
+  only: string[] | null
+  skipExisting: boolean
+  model: string
+  concurrency: number
+  out: string
+}
+
+function parseArgs(argv: string[]): Args {
+  const get = (k: string) => argv.find((a) => a.startsWith(`--${k}=`))?.slice(`--${k}=`.length)
+  const has = (k: string) => argv.includes(`--${k}`)
+  const only = get('only')?.split(',').map((s) => s.trim()).filter(Boolean) ?? null
+  return {
+    only,
+    skipExisting: has('skip-existing'),
+    model: get('model') ?? 'gemini-2.5-flash-image',
+    concurrency: Number(get('concurrency') ?? 2),
+    out: get('out') ?? 'public/characters',
+  }
+}
+
+async function loadEnv(): Promise<Record<string, string>> {
+  const envPath = resolve(process.cwd(), '.env')
+  try {
+    const text = await readFile(envPath, 'utf-8')
+    const env: Record<string, string> = {}
+    for (const line of text.split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const eq = trimmed.indexOf('=')
+      if (eq < 0) continue
+      env[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim()
+    }
+    return env
+  } catch {
+    return {}
+  }
+}
+
+type GenResult = { ok: true; bytes: Buffer } | { ok: false; error: string }
+
+async function generate(prompt: string, apiKey: string, model: string): Promise<GenResult> {
+  const isImagen = model.startsWith('imagen-')
+  const url = isImagen
+    ? `https://generativelanguage.googleapis.com/v1beta/models/${model}:predict?key=${apiKey}`
+    : `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`
+
+  const body = isImagen
+    ? {
+        instances: [{ prompt }],
+        parameters: { sampleCount: 1, aspectRatio: '1:1', safetyFilterLevel: 'block_only_high' },
+      }
+    : {
+        contents: [{ parts: [{ text: prompt }] }],
+        generationConfig: { responseModalities: ['IMAGE', 'TEXT'] },
+      }
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => '')
+    return { ok: false, error: `HTTP ${res.status}: ${errText.slice(0, 400)}` }
+  }
+
+  const json = (await res.json()) as Record<string, unknown>
+
+  if (isImagen) {
+    const preds = (json as { predictions?: { bytesBase64Encoded?: string }[] }).predictions
+    const b64 = preds?.[0]?.bytesBase64Encoded
+    if (!b64) return { ok: false, error: `no image: ${JSON.stringify(json).slice(0, 400)}` }
+    return { ok: true, bytes: Buffer.from(b64, 'base64') }
+  }
+  const cands = (json as { candidates?: { content?: { parts?: { inlineData?: { data?: string } }[] } }[] }).candidates
+  const inline = cands?.[0]?.content?.parts?.find((p) => p.inlineData?.data)?.inlineData
+  if (!inline?.data) return { ok: false, error: `no image: ${JSON.stringify(json).slice(0, 400)}` }
+  return { ok: true, bytes: Buffer.from(inline.data, 'base64') }
+}
+
+async function runConcurrent<T>(tasks: (() => Promise<T>)[], n: number): Promise<T[]> {
+  const results: T[] = new Array(tasks.length)
+  let next = 0
+  async function worker() {
+    while (next < tasks.length) {
+      const i = next++
+      results[i] = await tasks[i]()
+    }
+  }
+  await Promise.all(Array.from({ length: Math.max(1, n) }, () => worker()))
+  return results
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const env = await loadEnv()
+  const apiKey = env.GEMINI_API_KEY || process.env.GEMINI_API_KEY
+  if (!apiKey) {
+    console.error('GEMINI_API_KEY not found in .env or environment')
+    process.exit(1)
+  }
+
+  const __filename = fileURLToPath(import.meta.url)
+  const __dirname = dirname(__filename)
+  const repoRoot = resolve(__dirname, '..')
+  const outDir = resolve(repoRoot, args.out)
+  await mkdir(outDir, { recursive: true })
+
+  const allJobs = CHARACTER_PORTRAITS.filter((e: CharacterPortraitEntry) => !args.only || args.only.includes(e.slug))
+  if (allJobs.length === 0) {
+    console.error('no jobs matched --only filter')
+    process.exit(1)
+  }
+
+  console.log(`[gen] model=${args.model} concurrency=${args.concurrency} jobs=${allJobs.length} out=${outDir}`)
+
+  let done = 0
+  let skipped = 0
+  let failed = 0
+  const failures: string[] = []
+
+  const tasks = allJobs.map((entry) => async () => {
+    const outFile = resolve(outDir, `${entry.slug}.png`)
+    if (args.skipExisting && (await fileExists(outFile))) {
+      skipped++
+      console.log(`[skip] ${entry.slug} (exists)`)
+      return
+    }
+    const prompt = buildPortraitPrompt(entry)
+    const r = await generate(prompt, apiKey, args.model)
+    if (!r.ok) {
+      failed++
+      failures.push(entry.slug)
+      console.error(`[fail] ${entry.slug}: ${r.error}`)
+      return
+    }
+    await writeFile(outFile, r.bytes)
+    done++
+    console.log(`[ok]   ${entry.slug} → ${entry.slug}.png (${r.bytes.length} bytes)`)
+  })
+
+  await runConcurrent(tasks, args.concurrency)
+
+  console.log(`\n[done] ok=${done} skipped=${skipped} failed=${failed}`)
+  if (failures.length) {
+    console.log(`failed slugs: ${failures.join(',')}`)
+    console.log(`re-run failed: npx tsx scripts/generate-character-portraits.ts --only=${failures.join(',')}`)
+  }
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/src/components/CharacterPortrait.tsx
+++ b/src/components/CharacterPortrait.tsx
@@ -1,0 +1,95 @@
+// キャラ立ち絵共通コンポーネント
+// public/characters/{id}_{expression}.png があればそれを表示、
+// 無ければアクセントカラーのグラデ + イニシャル文字（CSS placeholder）にフォールバック。
+//
+// blinking=true でまばたきアニメ、bouncing=true で軽くバウンド。
+
+import { useEffect, useState } from 'react'
+import type { Character, CharacterExpression } from '../roleplayCharacters'
+
+interface Props {
+  character: Character
+  size?: number
+  expression?: CharacterExpression
+  /** まばたきアニメを有効化（4-6 秒間隔） */
+  blinking?: boolean
+  /** 一時的にバウンドさせる（true → translateY(-4px)、false → 元位置） */
+  bouncing?: boolean
+}
+
+export function CharacterPortrait({
+  character,
+  size = 96,
+  expression = 'neutral',
+  blinking = false,
+  bouncing = false,
+}: Props) {
+  const [imgFailed, setImgFailed] = useState(false)
+  const [blink, setBlink] = useState(false)
+
+  useEffect(() => {
+    if (!blinking) return
+    let cancelled = false
+    const loop = () => {
+      if (cancelled) return
+      const delay = 4000 + Math.random() * 2000
+      setTimeout(() => {
+        if (cancelled) return
+        setBlink(true)
+        setTimeout(() => {
+          if (cancelled) return
+          setBlink(false)
+          loop()
+        }, 120)
+      }, delay)
+    }
+    loop()
+    return () => { cancelled = true }
+  }, [blinking])
+
+  const transform = bouncing ? 'translateY(-4px)' : 'translateY(0)'
+  const opacity = blink ? 0.3 : 1
+  const containerStyle: React.CSSProperties = {
+    width: size, height: size, borderRadius: '50%',
+    position: 'relative',
+    overflow: 'hidden',
+    flexShrink: 0,
+    background: `radial-gradient(circle at 30% 30%, color-mix(in srgb, ${character.accentColor} 65%, white) 0%, ${character.accentColor} 100%)`,
+    boxShadow: `0 ${size * 0.06}px ${size * 0.18}px color-mix(in srgb, ${character.accentColor} 35%, transparent)`,
+    transform,
+    transition: 'transform 180ms ease, opacity 100ms ease',
+    opacity,
+    userSelect: 'none',
+  }
+
+  return (
+    <div style={containerStyle} aria-hidden="true">
+      {/* 背景レイヤー: イニシャル文字（画像が無い／読み込み失敗時のフォールバック） */}
+      <div style={{
+        position: 'absolute', inset: 0,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontFamily: 'Caveat, "Noto Serif JP", serif',
+        fontSize: size * 0.55,
+        fontWeight: 700,
+        color: 'rgba(255,255,255,0.92)',
+        letterSpacing: '0.02em',
+      }}>
+        {character.initial}
+      </div>
+      {/* 画像レイヤー: あれば background を覆い隠す */}
+      {!imgFailed && (
+        <img
+          src={character.images[expression]}
+          alt=""
+          onError={() => setImgFailed(true)}
+          style={{
+            position: 'absolute', inset: 0,
+            width: '100%', height: '100%',
+            objectFit: 'cover',
+            display: 'block',
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/screens/RoleplayChatScreen.tsx
+++ b/src/screens/RoleplayChatScreen.tsx
@@ -9,7 +9,8 @@ import { Header } from '../components/platform/Header'
 import { haptic } from '../platform/haptics'
 import { recordActivity } from '../activityLog'
 import { API_BASE } from './apiBase'
-import { getCharacter, buildCharacterSetup, localized, type Character } from '../roleplayCharacters'
+import { getCharacter, buildCharacterSetup, localized } from '../roleplayCharacters'
+import { CharacterPortrait } from '../components/CharacterPortrait'
 
 interface RoleplayChatScreenProps {
   characterId: string
@@ -27,50 +28,6 @@ type SummaryResult = {
 }
 
 const MAX_TURNS = 5
-
-// キャラ立ち絵 placeholder（画像が無い間表示）— 画像が出来たら img タグに差し替え
-function CharacterPortrait({ character, bouncing }: { character: Character; bouncing: boolean }) {
-  const [blink, setBlink] = useState(false)
-  useEffect(() => {
-    let cancelled = false
-    const loop = () => {
-      if (cancelled) return
-      // 4〜6 秒間隔のまばたき
-      const delay = 4000 + Math.random() * 2000
-      setTimeout(() => {
-        if (cancelled) return
-        setBlink(true)
-        setTimeout(() => {
-          if (cancelled) return
-          setBlink(false)
-          loop()
-        }, 120)
-      }, delay)
-    }
-    loop()
-    return () => { cancelled = true }
-  }, [])
-
-  return (
-    <div style={{
-      width: 120, height: 120, borderRadius: '50%',
-      background: `radial-gradient(circle at 30% 30%, color-mix(in srgb, ${character.accentColor} 65%, white) 0%, ${character.accentColor} 100%)`,
-      display: 'flex', alignItems: 'center', justifyContent: 'center',
-      fontFamily: 'Caveat, "Noto Serif JP", serif',
-      fontSize: 64,
-      fontWeight: 700,
-      color: 'rgba(255,255,255,0.92)',
-      boxShadow: `0 10px 26px color-mix(in srgb, ${character.accentColor} 35%, transparent)`,
-      letterSpacing: '0.02em',
-      userSelect: 'none',
-      transform: bouncing ? 'translateY(-4px)' : 'translateY(0)',
-      transition: 'transform 180ms ease, opacity 100ms ease',
-      opacity: blink ? 0.3 : 1,
-    }} aria-hidden="true">
-      {character.initial}
-    </div>
-  )
-}
 
 export function RoleplayChatScreen({ characterId, onBack }: RoleplayChatScreenProps) {
   const character = getCharacter(characterId)
@@ -256,7 +213,13 @@ export function RoleplayChatScreen({ characterId, onBack }: RoleplayChatScreenPr
             display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8,
             padding: '8px 16px 4px',
           }}>
-            <CharacterPortrait character={character} bouncing={bouncing} />
+            <CharacterPortrait
+              character={character}
+              size={120}
+              expression={loading ? 'troubled' : finished ? 'smile' : 'neutral'}
+              blinking
+              bouncing={bouncing}
+            />
             <div style={{ fontSize: 13, fontWeight: 700, color: character.accentColor, marginTop: 4 }}>
               {localized(character.role)}
             </div>

--- a/src/screens/RoleplaySelectScreen.tsx
+++ b/src/screens/RoleplaySelectScreen.tsx
@@ -9,33 +9,13 @@ import { isSaved, toggleSaved } from '../savedItemsStore'
 import { haptic } from '../platform/haptics'
 import { t } from '../i18n'
 import { CHARACTERS, localized, type Character } from '../roleplayCharacters'
+import { CharacterPortrait } from '../components/CharacterPortrait'
 
 interface RoleplaySelectScreenProps {
   onBack: () => void
   onStart: (characterId: string) => void
   /** 旧シグネチャ互換用。ロールプレイは全プラン無制限。 */
   onUpgrade?: () => void
-}
-
-// 画像が無いときの placeholder。アクセントカラーのグラデ + 大きなイニシャル文字。
-function CharacterPortraitPlaceholder({ character, size = 96 }: { character: Character; size?: number }) {
-  return (
-    <div style={{
-      width: size, height: size, borderRadius: '50%',
-      flexShrink: 0,
-      background: `radial-gradient(circle at 30% 30%, color-mix(in srgb, ${character.accentColor} 65%, white) 0%, ${character.accentColor} 100%)`,
-      display: 'flex', alignItems: 'center', justifyContent: 'center',
-      fontFamily: 'Caveat, "Noto Serif JP", serif',
-      fontSize: size * 0.5,
-      fontWeight: 700,
-      color: 'rgba(255,255,255,0.9)',
-      boxShadow: `0 6px 18px color-mix(in srgb, ${character.accentColor} 35%, transparent)`,
-      letterSpacing: '0.02em',
-      userSelect: 'none',
-    }} aria-hidden="true">
-      {character.initial}
-    </div>
-  )
 }
 
 function CharacterCard({
@@ -79,7 +59,7 @@ function CharacterCard({
       >
         {/* ヘッダー：立ち絵 + 名前 / 役柄 / 時代 */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
-          <CharacterPortraitPlaceholder character={character} size={84} />
+          <CharacterPortrait character={character} size={84} expression="neutral" />
           <div style={{ flex: 1, minWidth: 0 }}>
             <div style={{ fontSize: 20, fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-.01em', lineHeight: 1.2 }}>
               {localized(character.name)}


### PR DESCRIPTION
## Summary

哲学者キャラの立ち絵を Gemini Nano Banana で生成する pipeline と、画像が無い間の CSS placeholder フォールバック構造を追加。PR #206（ロールプレイの哲学者軸リプレース）の続き。

### 新規スクリプト
- `scripts/characterPortraitsV2.ts` … `PORTRAIT_STYLE` + 9 エントリ（Socrates / Descartes / Nietzsche × neutral / smile / troubled）。Caveat 風ノートブック紙トーンで既存レッスンサムネと世界観統一
- `scripts/generate-character-portraits.ts` … 一括生成ランナー（既存 lesson-thumbnails 系と同パターン）

### 新規コンポーネント
- `src/components/CharacterPortrait.tsx` … 画像レイヤー + イニシャル文字フォールバック。`blinking` でまばたき、`bouncing` で軽くバウンド

### 画面側
- `RoleplaySelectScreen` … 内部 placeholder を共通コンポーネントに置換（size=84）
- `RoleplayChatScreen` … 同上（size=120、blinking 有効、応答中は `troubled`、終了後は `smile` に表情切替）

### 実行手順（API キー必要）
```bash
npx tsx scripts/generate-character-portraits.ts
# → public/characters/ に 9 枚生成
# → 約 ¥55、所要 1-2 分
# 失敗 slug があれば --only=<slug> で個別再生成
```

### 注意点
- 画像未生成でも UI は CSS placeholder で動く（onError でフォールバック）
- Gemini の長英単語スペル崩し対策（`feedback_gemini_prompt_tricks`）として、表示テキストは哲学者名のみ（短くて崩れにくい綴り）
- 概念チェック必須：生成後に各画像が哲学者の identity（髭・襟・口髭等）を保ってるか目視確認

## Test plan
- [x] 型チェック（`tsc -b --noEmit`）パス
- [x] Vite build 成功
- [x] ESLint 0 errors
- [ ] `npx tsx scripts/generate-character-portraits.ts` で 9 枚生成 → 各画像を目視確認 → 承認後 commit
- [ ] Android 実機で立ち絵が `<img>` 表示になっていることを確認

https://claude.ai/code/session_01Bo1RfD9XrkV4hNCdFPSxMB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bo1RfD9XrkV4hNCdFPSxMB)_