### PR TITLE
fix(pricing): remove redundant "有料" label above price

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,7 +405,14 @@ Logic アプリのコースサムネイルは **`public/images/v3/course-*.png`�
 - 新規コース追加・サムネ作り直しは **v4 Figma マスター（https://www.figma.com/design/2SJYbSyMbBlSOyd3DJzbUc）** から複製 → PNG 書き出しが標準パイプライン
 - ダーク背景・写実的シーン・人物シルエット中心の構図は採用しない
 - Pixa は使わない（[[feedback-no-pixa]]）
-- **レッスンサムネ（lesson-*.png/webp、49 枚）は 2026-05-19 に Gemini Nano Banana で v2 化完了**（commit `8b613a0`）。同じノートブック手書きトーンで、トピックごとに固有の図解（ロジックツリー / 2x2 grid / 因果ループ / イシュー分解 等）を中央に配置。マスターは `public/images/v3/lesson-*.png`、scripts は `scripts/generate-lesson-thumbnails-v2.ts` + `scripts/lessonPromptsV2.ts`。再生成は `npx tsx scripts/generate-lesson-thumbnails-v2.ts --only=lesson-XX`
+- **2026-05-19 に全 116 枚（27 コース + 89 レッスン）を Gemini Nano Banana で Caveat 風 v3 に統一**（commit `376f008`）。STYLE は「クリーム notebook + Caveat-style chunky Title Case marker title + flowing coral underline + 図解」。マスターは `public/images/v3/{course,lesson}-*.png`。再生成系スクリプト:
+  - `scripts/generate-course-thumbnails-v2.ts` — コース 27枚（16:9）
+  - `scripts/generate-lesson-thumbnails-v2.ts` — 既存レッスン 49枚（1:1）
+  - `scripts/generate-career-thumbnails.ts` — キャリア 5+35枚
+  - `scripts/{course,lesson,career}PromptsV2.ts` — 各 entry 定義
+  - `lessonPromptsV2.ts` の `titleCase()` ヘルパーで all-caps エントリを自動 Title Case 化（略語 whitelist 例外あり）
+  - 個別再生成: `npx tsx scripts/generate-lesson-thumbnails-v2.ts --only=lesson-XX`
+  - 旧 imagePrompts.ts (3D iso ダーク背景版、未使用) は方針外、参照しないこと
 - home/hero（4 枚）は未対応。Phase 3 で同じトーンに揃える検討余地あり
 - 関連 docs: `docs/HANDDRAWN_ROLLOUT_PLAN.md` / `docs/HANDDRAWN_STYLE_GUIDE.md`
 - サンプル1枚で承認を取ってから全体展開する（過去事故の再発防止）

--- a/src/screens/PricingScreen.tsx
+++ b/src/screens/PricingScreen.tsx
@@ -162,9 +162,6 @@ export function PricingScreen({ onBack }: PricingScreenProps) {
               {t('pricing.recommended')}
             </div>
           )}
-          <div style={{ fontSize: 12, fontWeight: 800, color: 'var(--brand)', letterSpacing: '.1em', textTransform: 'uppercase', marginBottom: 6 }}>
-            {t('pricing.planPaid')}
-          </div>
           <div style={{ display: 'flex', alignItems: 'flex-end', gap: 8, marginBottom: 14 }}>
             <span style={{ fontSize: 36, fontWeight: 900, color: 'var(--text-primary)', letterSpacing: '-0.03em', lineHeight: 1 }}>{priceMain}</span>
             <span style={{ fontSize: 13, color: 'var(--text-muted)', paddingBottom: 4 }}>{priceSub}</span>


### PR DESCRIPTION
## Summary

- `PricingScreen.tsx` の価格カード上部にあった小さな「有料」ラベル（`{t('pricing.planPaid')}`）を削除
- ページタイトル・月払い/年払いトグル・「有料プランを始める」CTA で十分に伝わるため redundant

## Before / After

スクショで「¥350」の真上に小さく表示されていた青字の「有料」が消えて、価格カードがスッキリ表示される。

## Test plan

- [ ] `node node_modules/.bin/tsc -b --noEmit` パス（確認済み）
- [ ] PricingScreen を月払い/年払い両方で目視確認、レイアウト崩れなし
- [ ] OnboardingScreen 側の「有料」ラベル（別画面・別構造）は意図的に保持

https://claude.ai/code/session_017Z3dgwemJuUzSWo2kCNcGG

---
_Generated by [Claude Code](https://claude.ai/code/session_017Z3dgwemJuUzSWo2kCNcGG)_