### PR TITLE
feat(pricing): AI problem gen and AI roleplay are paid-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,7 +405,14 @@ Logic アプリのコースサムネイルは **`public/images/v3/course-*.png`�
 - 新規コース追加・サムネ作り直しは **v4 Figma マスター（https://www.figma.com/design/2SJYbSyMbBlSOyd3DJzbUc）** から複製 → PNG 書き出しが標準パイプライン
 - ダーク背景・写実的シーン・人物シルエット中心の構図は採用しない
 - Pixa は使わない（[[feedback-no-pixa]]）
-- **レッスンサムネ（lesson-*.png/webp、49 枚）は 2026-05-19 に Gemini Nano Banana で v2 化完了**（commit `8b613a0`）。同じノートブック手書きトーンで、トピックごとに固有の図解（ロジックツリー / 2x2 grid / 因果ループ / イシュー分解 等）を中央に配置。マスターは `public/images/v3/lesson-*.png`、scripts は `scripts/generate-lesson-thumbnails-v2.ts` + `scripts/lessonPromptsV2.ts`。再生成は `npx tsx scripts/generate-lesson-thumbnails-v2.ts --only=lesson-XX`
+- **2026-05-19 に全 116 枚（27 コース + 89 レッスン）を Gemini Nano Banana で Caveat 風 v3 に統一**（commit `376f008`）。STYLE は「クリーム notebook + Caveat-style chunky Title Case marker title + flowing coral underline + 図解」。マスターは `public/images/v3/{course,lesson}-*.png`。再生成系スクリプト:
+  - `scripts/generate-course-thumbnails-v2.ts` — コース 27枚（16:9）
+  - `scripts/generate-lesson-thumbnails-v2.ts` — 既存レッスン 49枚（1:1）
+  - `scripts/generate-career-thumbnails.ts` — キャリア 5+35枚
+  - `scripts/{course,lesson,career}PromptsV2.ts` — 各 entry 定義
+  - `lessonPromptsV2.ts` の `titleCase()` ヘルパーで all-caps エントリを自動 Title Case 化（略語 whitelist 例外あり）
+  - 個別再生成: `npx tsx scripts/generate-lesson-thumbnails-v2.ts --only=lesson-XX`
+  - 旧 imagePrompts.ts (3D iso ダーク背景版、未使用) は方針外、参照しないこと
 - home/hero（4 枚）は未対応。Phase 3 で同じトーンに揃える検討余地あり
 - 関連 docs: `docs/HANDDRAWN_ROLLOUT_PLAN.md` / `docs/HANDDRAWN_STYLE_GUIDE.md`
 - サンプル1枚で承認を取ってから全体展開する（過去事故の再発防止）

--- a/src/AppV3.tsx
+++ b/src/AppV3.tsx
@@ -583,18 +583,32 @@ function AppV3() {
       )}
 
       {screen.type === 'roleplay' && (
-        <RoleplaySelectScreen
-          onBack={() => navigate({ type: 'lessons' }, true)}
-          onStart={(characterId) => navigate({ type: 'roleplay-chat', characterId })}
-          onUpgrade={() => navigate({ type: 'pricing' })}
-        />
+        isPaid() ? (
+          <RoleplaySelectScreen
+            onBack={() => navigate({ type: 'lessons' }, true)}
+            onStart={(characterId) => navigate({ type: 'roleplay-chat', characterId })}
+            onUpgrade={() => navigate({ type: 'pricing' })}
+          />
+        ) : (
+          <RoleplayPaywall
+            onBack={() => navigate({ type: 'lessons' }, true)}
+            onUpgrade={() => navigate({ type: 'pricing' })}
+          />
+        )
       )}
 
       {screen.type === 'roleplay-chat' && (
-        <RoleplayChatScreen
-          characterId={screen.characterId}
-          onBack={() => navigate({ type: 'roleplay' })}
-        />
+        isPaid() ? (
+          <RoleplayChatScreen
+            characterId={screen.characterId}
+            onBack={() => navigate({ type: 'roleplay' })}
+          />
+        ) : (
+          <RoleplayPaywall
+            onBack={() => navigate({ type: 'lessons' }, true)}
+            onUpgrade={() => navigate({ type: 'pricing' })}
+          />
+        )
       )}
 
       {screen.type === 'profile' && (
@@ -969,6 +983,67 @@ function ReviewPaywall({ onBack, onUpgrade }: { onBack: () => void; onUpgrade: (
             }}
           >
             {t('reviewHub.viewPlansCta')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function RoleplayPaywall({ onBack, onUpgrade }: { onBack: () => void; onUpgrade: () => void }) {
+  return (
+    <div style={{ minHeight: '100vh', background: 'var(--bg-primary)', display: 'flex', flexDirection: 'column' }}>
+      <Header title={t('roleplay.title')} onBack={onBack} />
+      <div style={{ flex: 1, padding: '32px 20px 120px', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'flex-start', gap: 20 }}>
+        <div style={{
+          background: 'var(--bg-card)',
+          borderRadius: 16,
+          padding: 24,
+          maxWidth: 380,
+          width: '100%',
+          textAlign: 'center',
+          boxShadow: 'var(--shadow-v3-card-inset)',
+          border: '1px solid rgba(255,255,255,.06)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 14,
+        }}>
+          <div style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            alignSelf: 'center',
+            width: 56, height: 56, borderRadius: '50%',
+            background: 'linear-gradient(135deg, var(--brand), var(--brand-light, #8B5CF6))',
+            fontSize: 28,
+            marginBottom: 4,
+          }}>
+            <span aria-hidden="true">💬</span>
+          </div>
+          <div style={{ fontSize: 16, fontWeight: 800, color: 'var(--text-primary)' }}>
+            {t('roleplay.paywallTitle')}
+          </div>
+          <div style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.7 }}>
+            {t('roleplay.paywallDesc')}
+          </div>
+          <button
+            type="button"
+            onClick={onUpgrade}
+            style={{
+              marginTop: 8,
+              padding: '14px 24px',
+              background: 'var(--brand)',
+              color: 'var(--accent-fg, #fff)',
+              border: 'none',
+              borderRadius: 12,
+              font: 'inherit',
+              fontSize: 15,
+              fontWeight: 700,
+              cursor: 'pointer',
+              minHeight: 48,
+            }}
+          >
+            {t('roleplay.viewPlansCta')}
           </button>
         </div>
       </div>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -433,7 +433,7 @@ const STRINGS: Record<Locale, Strings> = {
     'pricing.title': '料金プラン',
     'pricing.heroEyebrow': 'AI 問題生成を解放しよう',
     'pricing.heroHeadline': '面接塾やビジネス書で何万円もかける前に、\n月 ¥350 で AI が毎日あなた専用の問題を作る。',
-    'pricing.heroSub': '無料プランでもレッスン・ロールプレイは使い放題、今日の一問も毎日 1 問解けます。',
+    'pricing.heroSub': '無料プランでもレッスンは使い放題、今日の一問も毎日 1 問解けます。',
     'pricing.featLessons': 'レッスン',
     'pricing.featRoleplay': 'AI ロールプレイ',
     'pricing.featReview': '復習',
@@ -545,6 +545,9 @@ const STRINGS: Record<Locale, Strings> = {
     'roleplay.live2dNote': '※キャラクターアニメーションは今後 Live2D に進化予定です',
     'roleplay.beta': 'BETA',
     'roleplay.backToOther': '別のシナリオに戻る',
+    'roleplay.paywallTitle': 'AI ロールプレイは有料プラン機能です',
+    'roleplay.paywallDesc': '哲学者キャラクター達と論理思考を実践できる AI ロールプレイは、有料プランで利用できます。',
+    'roleplay.viewPlansCta': 'プランを見る',
 
     // Coffee Break
     'coffeebreak.title': 'コーヒーブレイク',
@@ -2062,7 +2065,7 @@ const STRINGS: Record<Locale, Strings> = {
     'pricing.title': 'Pricing',
     'pricing.heroEyebrow': 'Unlock AI problem generation',
     'pricing.heroHeadline': 'Before you spend tens of thousands of yen on interview prep or business books,\nlet AI craft your own practice problems for ¥350/month.',
-    'pricing.heroSub': 'Lessons and roleplay are free and unlimited, plus one daily problem every day.',
+    'pricing.heroSub': 'Lessons are free and unlimited, plus one daily problem every day.',
     'pricing.featLessons': 'Lessons',
     'pricing.featRoleplay': 'AI roleplay',
     'pricing.featReview': 'Review',
@@ -2174,6 +2177,9 @@ const STRINGS: Record<Locale, Strings> = {
     'roleplay.live2dNote': '* Character animation will evolve to Live2D in a future update.',
     'roleplay.beta': 'BETA',
     'roleplay.backToOther': 'Back to another scenario',
+    'roleplay.paywallTitle': 'AI roleplay is a paid feature',
+    'roleplay.paywallDesc': 'Practice logical thinking with philosopher characters. AI roleplay is available on the paid plan.',
+    'roleplay.viewPlansCta': 'View plans',
 
     // Coffee Break
     'coffeebreak.title': 'Coffee Break',

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -40,10 +40,10 @@ type OBFeature = { label: string; free: string | boolean; paid: string | boolean
 function getOBFeatures(): OBFeature[] {
   return [
     { label: t('pricing.featLessons'),    free: t('pricing.featAllLessons'), paid: t('pricing.featAllLessons') },
-    { label: t('pricing.featRoleplay'),   free: t('pricing.featUnlimited'),  paid: t('pricing.featUnlimited') },
-    { label: t('pricing.featReview'),     free: true,                         paid: true },
+    { label: t('pricing.featRoleplay'),   free: false,                        paid: true },
+    { label: t('pricing.featReview'),     free: false,                        paid: true },
     { label: t('pricing.featFermi'),      free: t('pricing.featDaily1'),     paid: t('pricing.featDaily10') },
-    { label: t('pricing.featAiGen'),      free: t('pricing.featAiGenFree'),  paid: t('pricing.featAiGenPaid') },
+    { label: t('pricing.featAiGen'),      free: false,                        paid: true },
     { label: t('pricing.featRecord'),     free: true,                         paid: true },
   ]
 }

--- a/src/screens/PricingScreen.tsx
+++ b/src/screens/PricingScreen.tsx
@@ -28,8 +28,8 @@ function getFeatures(): FeatureRow[] {
     { label: t('pricing.featLessons'), free: t('pricing.featAllLessons'), paid: t('pricing.featAllLessons') },
     { label: t('pricing.featFermi'), free: t('pricing.featDaily1'), paid: t('pricing.featDaily10') },
     { label: t('pricing.featReview'), free: false, paid: true },
-    { label: t('pricing.featAiGen'), free: t('pricing.featAiGenFree'), paid: t('pricing.featAiGenPaid') },
-    { label: t('pricing.featRoleplay'), free: t('pricing.featUnlimited'), paid: t('pricing.featUnlimited') },
+    { label: t('pricing.featAiGen'), free: false, paid: true },
+    { label: t('pricing.featRoleplay'), free: false, paid: true },
     { label: t('pricing.featJournal'), free: false, paid: true },
   ]
 }


### PR DESCRIPTION
## Summary

料金比較表で AI 問題生成と AI ロールプレイを「有料プランのみ」表示に統一し、ロールプレイの機能側も `isPaid()` でゲートした。

- `PricingScreen` / `OnboardingScreen` の比較表で `AI 問題生成` と `AI ロールプレイ` を `×` / ✅ 表示に変更（他の有料機能と統一）。
- `AppV3.tsx` の `roleplay` / `roleplay-chat` スクリーンを `isPaid()` でゲート。無料ユーザーには新規 `RoleplayPaywall` を表示してプラン画面へ誘導。
- `pricing.heroSub` の「ロールプレイは無料無制限」表現を削除（ja / en 両方）。
- `roleplay.paywallTitle` / `paywallDesc` / `viewPlansCta` を i18n に追加。

AI 問題生成は元々 `getAIGenerationLimit()` で `isPaid() ? -1 : 0` と無料は不可になっていたので、表示と実装の食い違いを修正した形。

## Test plan

- [ ] 無料アカウントで `/roleplay` を開くと `RoleplayPaywall` が表示される
- [ ] 無料アカウントで `roleplay-chat` URL を直接踏んでも paywall に飛ぶ
- [ ] 有料アカウントでは従来通りロールプレイが使える
- [ ] `PricingScreen` の比較表で AI 問題生成 / AI ロールプレイの行が `×` / ✅ で表示される
- [ ] `OnboardingScreen` の比較表も同様
- [ ] ja / en の両言語で文言が破綻していない

https://claude.ai/code/session_01XsvmdRAPbkx6dPYHzyaZKq

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsvmdRAPbkx6dPYHzyaZKq)_