### PR TITLE
feat: Device Sync Phase 1 - Supabase 同期テーブル + sync orchestration (feature flag OFF)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,13 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 SUPABASE_URL=https://yctlelmlwjwlcpcxvmgx.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key_here
 
+# --- Feature flags ---
+# Device Sync Phase 1 (フラッシュカード / 誤答 / saved items / notebook / roadmap /
+# カテゴリ別 progress を Supabase に同期して別端末で引き継ぐ)
+# デフォルト false。内部テスター環境のみ true で dry-run する。
+# Phase 2 以降でサーバー配信 API (/api/feature-flags) に拡張予定。
+VITE_ENABLE_DEVICE_SYNC=false
+
 # --- Stripe (テストモード) ---
 STRIPE_SECRET_KEY=sk_test_...
 STRIPE_PUBLISHABLE_KEY=pk_test_...

--- a/src/analogyThinkingLessonsEn.ts
+++ b/src/analogyThinkingLessonsEn.ts
@@ -94,6 +94,9 @@ const analogyDeepDive: LessonData = {
       title: 'Abstract and instantiate — the core skill',
       content:
         'In practice, the most important skills in analogical reasoning are abstraction and instantiation.\n\n(1) Abstract a concrete case.\n\nCase: "Netflix\'s recommendation system"\n↓ abstract\nStructure: "Predict individual preferences from past behavior data and offer suggestions."\n\n(2) Instantiate the abstract structure in a different domain.\n\n↓ instantiated for hiring\n"Recruiting AI that predicts a candidate\'s likelihood of success from past hiring data."\n\n↓ instantiated for education\n"Adaptive learning that predicts a student\'s weak spots from past data and serves the optimal next problem."\n\n↓ instantiated for healthcare\n"Preventive-care AI that predicts disease risk from past case data and proposes interventions."\n\nThe same abstract structure can spawn ideas across completely different fields.',
+      visual: 'AbstractionLadderDiagram',
+      outro:
+        'The core of analogical reasoning is climbing and descending a three-rung ladder: concrete, abstract, then concrete again in another domain. Once you abstract a case in passing, you open a channel for ideas from a totally different industry to flow back into your own field.',
     },
     {
       type: 'quiz',

--- a/src/catchupLessonsEn.ts
+++ b/src/catchupLessonsEn.ts
@@ -22,6 +22,9 @@ const catchupLesson330: LessonData = {
       type: 'explain',
       title: 'Think of catchup in three layers',
       content: 'Gathering information randomly doesn\'t stick. Catchup happens in three layers.\n\nLayer 1: Surface (1-2 days)\n- Industry terms, key players, market size\n- "I can follow what\'s being talked about"\n- Example: "What is reinsurance?" "Who are the three carriers?"\n\nLayer 2: Structure (3-4 days)\n- Business model, revenue structure, KPIs\n- "I understand why money is or isn\'t made"\n- Example: For a telco — relationship of ARPU, churn, capex\n\nLayer 3: Dynamics (Day 5+)\n- Competitive rules, regulation, trends, each player\'s strategy\n- "I can speak to what happens next"\n- Example: "How will MVNOs move over the next 3 years?"\n\nThe order matters. Going to Layer 3 with Layer 1 fuzzy means you sound plausible but the client sees through it.',
+      visual: 'ThreePillarsDiagram',
+      outro:
+        'Stacking surface, structure, and dynamics in order is the basic move for catching up on an unfamiliar industry. Jumping into the deeper layers with Layer 1 still fuzzy makes you sound plausible while the client sees right through it. The patience to refuse shortcuts on the sequence is what produces the actual fastest path.',
     },
     {
       type: 'quiz',

--- a/src/clientWorkLessonsEn.ts
+++ b/src/clientWorkLessonsEn.ts
@@ -58,6 +58,9 @@ const clientLesson89: LessonData = {
       type: 'explain',
       title: 'Estimate market size',
       content: 'Market size estimates like "5 million people × 3,000 yen = ?" come up constantly.\n\nCalculation:\n1. 5 million × 3,000\n2. = 5 million × 0.3 × 10K\n3. = 5M × 0.3 × 10K\n4. = 0.3 × 5M × 10K\n5. = 0.3 × 50 billion\n6. = 15 billion yen\n\nTip: Memorizing "10K × 10K = 100M" makes calculations fast.\n\nExample: Japan\'s coffee market\n- Coffee drinkers: ~60 million people\n- Annual spend: ~5,000 yen / person\n- Market size: 60M × 5,000 yen\n\nCalculation:\n1. 60M × 5,000\n2. = 60M × 0.5 × 10K\n3. = 30M × 10K\n4. = 300 billion yen\n5. ≈ 300 billion yen',
+      visual: 'FermiFormulaDiagram',
+      outro:
+        'Market size sizing is fundamentally "headcount × spend" — a single multiplication that frames the whole picture. Burn unit-conversion anchors like "10K × 10K = 100M" into muscle memory and digit-sanity checks become instant, so you can put numbers on the table with confidence.',
     },
     {
       type: 'quiz',
@@ -88,6 +91,9 @@ const clientLesson90: LessonData = {
       type: 'explain',
       title: 'Use So what? / Why so? to dig deep',
       content: 'To frame the issue correctly, use two questions.\n\nSo what? (so therefore?)\n→ Extract implications from facts\nExample: "Sales fell 10%" → So what? → "At this rate we hit losses in 3 months"\n\nWhy so? (why is that?)\n→ Drill into the cause of facts\nExample: "Sales fell 10%" → Why so? → "New customer acquisition is flat, but churn of existing customers has increased"\n\nRepeating these two takes you from surface symptom to essential issue.',
+      visual: 'SoWhatDiagram',
+      outro:
+        'So what? pulls out implications, Why so? pulls out causes. A report that just lists facts tends to invite "so what?" from your audience, so alternate these two questions like a pair of tools and ride them down to the real issue. That alternation is the move that separates analysts from list-makers.',
     },
     {
       type: 'quiz',
@@ -180,6 +186,9 @@ const clientLesson92: LessonData = {
       type: 'explain',
       title: 'Read by separating claim, reason, and example',
       content: 'When organizing information, splitting it into three elements clears the head.\n\nClaim: what the author wants to convey\nExample: "This service has high implementation impact"\n\nReason: why the claim holds\nExample: "90% of adopting companies cut work hours by 20%"\n\nExample: evidence backing the reason\nExample: "Company A achieved 40 hours/month of effort reduction"\n\nReading split this way also surfaces problems like "claim with no reason" or "weak reason."',
+      visual: 'ClaimReasonAssumptionDiagram',
+      outro:
+        'Splitting writing into claim, reason, and example makes "claims without reasons" and "examples without claims" obvious at a glance. Use the same three-layer lens whether you are reading or writing, and the quality of your arguments climbs a clear notch.',
     },
     {
       type: 'quiz',
@@ -267,6 +276,9 @@ const clientLesson94: LessonData = {
       type: 'explain',
       title: 'Lead with the conclusion',
       content: 'In business writing, "conclusion first" is the foundation.\n\nPREP method:\n- P (Point): conclusion / claim\n- R (Reason): rationale\n- E (Example): specific examples / data\n- P (Point): restate the conclusion\n\nBad:\n"We did market research. Competitor A lowered prices. Competitor B added new features. Customer feedback shows price dissatisfaction. Therefore, a pricing strategy review is needed."\n\nGood:\n"We propose a pricing strategy review. Three reasons: (1) competitors cut prices, (2) customer satisfaction surveys show price dissatisfaction, (3) at this rate, next quarter\'s revenue target is at risk."',
+      visual: 'PrepDiagram',
+      outro:
+        'PREP is Point → Reason → Example → Point — a four-beat rhythm. Wrapping the conclusion at the start and end minimizes load on a busy reader. The same pattern works for the opening line of an email, a chat reply, or a one-minute briefing, making it one of the most reusable templates you can carry.',
     },
     {
       type: 'explain',
@@ -334,6 +346,9 @@ const clientLesson95: LessonData = {
       type: 'explain',
       title: 'Use the pyramid structure',
       content: 'A tool to organize storyline visually is the pyramid structure.\n\n```\n       [Conclusion / claim]\n      /        |        \\\n [Reason 1] [Reason 2] [Reason 3]\n   |          |           |\n[Fact]      [Fact]      [Fact]\n```\n\nUsage:\n- Top: the conclusion you want to convey (just one)\n- Middle: reasons supporting the conclusion (2-4)\n- Bottom: facts and data backing each reason\n\nOrganizing this way before slide-making naturally surfaces logical leaps and gaps.',
+      visual: 'PyramidDiagram',
+      outro:
+        'A conclusion at the top, supported by two to four reasons, each backed by facts — this three-tier pyramid is the standard shape of an argument. Sketch it on paper before opening a slide tool, and you catch composition wobble and lopsided reasoning early, while editing is still cheap.',
     },
     {
       type: 'quiz',
@@ -359,6 +374,9 @@ const clientLesson96: LessonData = {
       type: 'explain',
       title: 'Hold to the three elements of a report',
       content: 'Effective reports need three elements.\n\n(1) Fact: what happened\nExample: "New inquiries this month dropped 30% MoM"\n\n(2) Insight: what it means\nExample: "Not seasonal; we estimate the impact comes from last month\'s ad pause"\n\n(3) Next Action: what to do, by when\nExample: "We\'ll restart ads next week and check next month\'s numbers for impact"\n\nReports without all three trigger "so what should I do?" responses.',
+      visual: 'ThreePillarsDiagram',
+      outro:
+        'A report that carries fact, insight, and next action as a complete set never invites "so what now?" Spending an extra moment to self-check "are all three present?" before you send is the small habit that compounds into real trust over time.',
     },
     {
       type: 'explain',

--- a/src/easternPhilosophyLessonsEn.ts
+++ b/src/easternPhilosophyLessonsEn.ts
@@ -161,6 +161,9 @@ export const easternPhilosophyLessonMapEn: Record<number, LessonData> = {
         title: 'Innate goodness vs. innate self-interest — which to adopt',
         content:
           'In management, the question is not "which is correct" but "which to adopt in which situation."\n\n- Areas demanding creativity and self-direction → innate goodness (trust-based, broad autonomy)\n- Areas with large or irreversible risk → innate self-interest (system-based, verification-heavy)\n\nExample: an engineer\'s coding can run on innate goodness, but production deployment runs on innate self-interest with an approval flow. This is the modern division.\n\nFor 2,300 years, Mencius and Xunzi have left us the foundational question: "what assumption do you make about human nature?"',
+        outro:
+          'Innate goodness and innate self-interest are not opposing ideologies but tools to deploy by domain. Lean on innate goodness where creativity is needed and on innate self-interest where risk is high — this is the modern answer that protects an organization from going rigid.',
+        visual: 'Two2MatrixDiagram',
       },
       {
         type: 'quiz',
@@ -211,6 +214,9 @@ export const easternPhilosophyLessonMapEn: Record<number, LessonData> = {
         title: 'Connection to modern stakeholder thinking',
         content:
           'Universal love connects to modern "stakeholder thinking" and "ESG management."\n\n- Caring only about your own company\'s profit → short-term wins but long-term backlash from society.\n- Considering the interests of customers, partners, employees, and society as a whole "inclusively" → builds durable trust.\n\nExamples: thinking about labor conditions across the supply chain, accounting for environmental impact, cooperating with competitors on standards — these are modern echoes of "universal love."\n\nMohism is less mainstream than Confucianism or Daoism, but in the modern era it has been re-evaluated as a "rational, egalitarian, pragmatic" school of thought.',
+        outro:
+          'Twenty-four hundred years later, the impulse behind universal love is being re-evaluated as stakeholder capitalism and ESG management. The shift from short-term self-interest to long-term optimization that also weighs customers, partners, and society is one of the places where ancient thought still lives at the heart of modern management.',
+        visual: 'ThreePillarsDiagram',
       },
       {
         type: 'quiz',
@@ -405,6 +411,9 @@ export const easternPhilosophyLessonMapEn: Record<number, LessonData> = {
         title: 'The three elements of governance — law, technique, position',
         content:
           'Han Feizi organized governance into three elements:\n\nLaw (法) — published, clear rules\nA standard anyone can see; rewards and punishments must be predictable.\n→ In modern terms: HR systems, compliance, KPI design.\n\nTechnique (術) — the ruler\'s arts of personnel and operation\nThe craft of seeing through people, placing them in the right roles, and quietly supervising.\n→ In modern terms: management techniques, organizational design.\n\nPosition (勢) — the authority and power that come with one\'s rank\nNot personal popularity, but the power that attaches to a position.\n→ In modern terms: delegation of authority and the dynamics of organizational structure.\n\nOnly when all three are present does an organization function stably.',
+        outro:
+          'Law, technique, and position map straight onto modern HR systems, management, and authority design. As a principle for running an organization without relying on personal charisma, codifying evaluation standards and structuring authority remain the two pillars even today.',
+        visual: 'TriadDiagram',
       },
       {
         type: 'explain',

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -1,0 +1,47 @@
+/**
+ * src/featureFlags.ts
+ *
+ * Phase 1 では Vite ビルド時の環境変数だけで判定する単純実装。
+ * Phase 2 以降でサーバー配信 API (/api/feature-flags) に拡張する予定。
+ *
+ * 環境変数:
+ *   VITE_ENABLE_DEVICE_SYNC=true|false
+ *     - 未設定 or 'false' のとき OFF (デフォルト OFF)
+ *     - 'true' のとき Phase 1 同期処理を起動
+ *
+ * 注意:
+ *   Vite の import.meta.env は文字列で入る。boolean 化は明示的に判定する。
+ */
+
+function readEnvFlag(key: string, defaultValue: boolean): boolean {
+  try {
+    const raw = (import.meta.env as Record<string, string | undefined>)[key]
+    if (raw == null) return defaultValue
+    const v = String(raw).trim().toLowerCase()
+    if (v === 'true' || v === '1' || v === 'on' || v === 'yes') return true
+    if (v === 'false' || v === '0' || v === 'off' || v === 'no') return false
+    return defaultValue
+  } catch {
+    return defaultValue
+  }
+}
+
+/**
+ * Phase 1 デバイス間同期 (flashcards / wrong_answers / saved_items / notebook /
+ * roadmap / category_progress) を有効にするか。
+ *
+ * Phase 1 ではデフォルト OFF。内部テスター環境 (.env で VITE_ENABLE_DEVICE_SYNC=true)
+ * だけ ON にして dry-run する。
+ */
+export function isDeviceSyncEnabled(): boolean {
+  return readEnvFlag('VITE_ENABLE_DEVICE_SYNC', false)
+}
+
+/**
+ * ヘビーユーザー閾値 (移行時のトレースログ用)。
+ * 設計書 Section 5.2 と確認事項 4 で flashcards 200 / notebook 30 維持と確定済。
+ */
+export const HEAVY_USER_THRESHOLDS = {
+  flashcards: 200,
+  notebook: 30,
+} as const

--- a/src/feedbackCaseLessonsEn.ts
+++ b/src/feedbackCaseLessonsEn.ts
@@ -25,6 +25,9 @@ const feedbackPerspectives: LessonData = {
       type: 'explain',
       title: '9 fundamental business perspectives',
       content: 'If your thinking tends to come out shallow, build a habit of cycling through these 9 lenses. A minimum of 3 per topic is a good baseline.\n\n① Time: Since when / until when / short-term vs long-term impact?\n② Space: Where / company / industry / macro / by region?\n③ Stakeholder: For whom (customers / employees / shareholders / partners)?\n④ Abstract–Concrete: Strategy or tactics / whole or part?\n⑤ Quantitative–Qualitative: Measurable in numbers / qualitative signals?\n⑥ Opportunity–Risk: Have you looked at both upside and downside?\n⑦ Static–Dynamic: Current structure / drivers of change?\n⑧ Insider–Outsider: From within / a step removed?\n⑨ Comparison: Compared to what (past / competitor / industry average)?\n\nWhen a manager says "go one level deeper," they usually mean: "add the perspective you\'re missing from this list."',
+      visual: 'LogicTreeDiagram',
+      outro:
+        'You do not need all nine perspectives every time — combining at least three per topic is the trick. When you hear "go one level deeper," adding just one missing perspective is usually enough to make the discussion three-dimensional.',
     },
     {
       type: 'explain',
@@ -98,6 +101,9 @@ const feedbackShallow: LessonData = {
       type: 'explain',
       title: 'Three principles for in-the-moment response',
       content: 'When told "your thinking is shallow," apply these three principles immediately.\n\n① Specificity questions, not apologies\nNG: "Sorry, I\'ll think harder."\nOK: "Specifically, which claim feels shallow — the conclusion, or the reasoning behind it?"\n\n② Pinpoint the location of the issue\n"Generally shallow" gives you nothing to fix. Narrow to "is it especially XX?"\n\n③ Confirm the target depth\n"How deep is deep enough?" / "Down to which layer of hypotheses do you want?"\n→ Confirming the manager\'s mental model of "deep enough" prevents wasted drilling.\n\nThese three alone roughly double the quality of your re-submission.',
+      visual: 'ThreePillarsDiagram',
+      outro:
+        'Specificity questions, location pinpoints, and goal confirmation — running these three principles cuts the wasted swings on your re-submission dramatically. Narrowing down what is actually shallow is far more valuable to your manager than another apology.',
     },
     {
       type: 'case',
@@ -166,6 +172,9 @@ const feedbackWeakAnalysis: LessonData = {
       type: 'explain',
       title: 'Three diagnostic questions for the moment',
       content: 'When told "your analysis is loose," diagnose with three questions.\n\n① "Is it a structure issue or a numbers issue?"\n→ The fix differs whether the framing (MECE) is bad or whether the source / premise of the numbers is weak.\n\n② "Which element\'s precision falls short most?"\n→ Fixing everything is unrealistic. Identify the highest-priority element first.\n\n③ "What level of granularity do you expect on resubmission?"\n→ Confirm how far the numbers must be pinned down (sources required? ranges acceptable? sensitivity analysis needed?).\n\nThese three almost fully define the direction and depth of your fix.',
+      visual: 'ThreePillarsDiagram',
+      outro:
+        'Structure-vs-numbers, element identification, and granularity confirmation — running these three questions almost fully fixes the direction and required depth of the "looseness." Instead of redoing everything, raising precision only on the highest-priority element is the optimal play under time pressure.',
     },
     {
       type: 'case',
@@ -234,6 +243,9 @@ const feedbackWeakInsight: LessonData = {
       type: 'explain',
       title: 'Three diagnostic questions for the moment',
       content: 'When told "your insights are weak," concretize with three questions.\n\n① "Which part feels especially weak?"\n→ Rare for everything to be weak. Identify the highest-priority section and concentrate there.\n\n② "How far should I push?"\n→ "Far enough that the client can make a decision" is one good standard.\n\n③ "Which action should the insight feed into?"\n→ Insights exist for action. Reverse-engineer from the exit (the decision).\n\nThese three define the "exit" of the insight, which in turn defines how far to push.',
+      visual: 'ThreePillarsDiagram',
+      outro:
+        'Insights exist "for action." Where, how far, and for what — these three questions define the exit, and the required depth of your push appears naturally. The point is to aim for a line that informs a decision, not just a paraphrase of the facts.',
     },
     {
       type: 'case',

--- a/src/flashcardData.ts
+++ b/src/flashcardData.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getSupabaseClient } from './db/index'
+
 const STORAGE_KEY = 'logic-flashcards'
 
 export type Flashcard = {
@@ -102,6 +105,184 @@ export function getCardStats() {
   const weak = cards.filter((c) => c.wrongCount > 0).length
   const mastered = cards.filter((c) => c.correctCount >= 3 && c.interval >= 7).length
   return { total: cards.length, due, weak, mastered }
+}
+
+// =============================================
+// Supabase 同期 (Phase 1: Device Sync)
+// =============================================
+
+type FlashcardRow = {
+  card_key: string
+  source: string
+  category: string
+  front: string
+  back: string
+  interval_days: number
+  ease: number
+  next_review: string
+  correct_count: number
+  wrong_count: number
+  created_at: string
+  updated_at: string
+}
+
+function rowToCard(row: FlashcardRow): Flashcard {
+  return {
+    id: row.card_key,
+    front: row.front,
+    back: row.back,
+    category: row.category,
+    source: row.source,
+    createdAt: row.created_at ? row.created_at.slice(0, 10) : new Date().toISOString().slice(0, 10),
+    interval: row.interval_days ?? 0,
+    ease: row.ease ?? 2.5,
+    nextReview: row.next_review,
+    correctCount: row.correct_count ?? 0,
+    wrongCount: row.wrong_count ?? 0,
+  }
+}
+
+function cardToRow(userId: string, card: Flashcard, updatedAt?: string): Record<string, unknown> {
+  return {
+    user_id: userId,
+    card_key: card.id,
+    source: card.source,
+    category: card.category,
+    front: card.front,
+    back: card.back,
+    interval_days: card.interval,
+    ease: card.ease,
+    next_review: card.nextReview,
+    correct_count: card.correctCount,
+    wrong_count: card.wrongCount,
+    updated_at: updatedAt ?? new Date().toISOString(),
+  }
+}
+
+async function fetchCardsFromDB(userId: string): Promise<Flashcard[] | null> {
+  const db = getSupabaseClient()
+  if (!db) return null
+  try {
+    const { data, error } = await (db as any)
+      .from('user_flashcards')
+      .select('card_key, source, category, front, back, interval_days, ease, next_review, correct_count, wrong_count, created_at, updated_at')
+      .eq('user_id', userId)
+    if (error) {
+      console.warn('[flashcardData] fetchCardsFromDB error:', error.message)
+      return null
+    }
+    return (data || []).map((r: FlashcardRow) => rowToCard(r))
+  } catch (e) {
+    console.warn('[flashcardData] fetchCardsFromDB exception:', e)
+    return null
+  }
+}
+
+/** 1 枚を DB に upsert (書き込みフック用) */
+export async function pushCardToDB(userId: string, card: Flashcard): Promise<void> {
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const { error } = await (db as any)
+      .from('user_flashcards')
+      .upsert([cardToRow(userId, card)], { onConflict: 'user_id,card_key' })
+    if (error) console.warn('[flashcardData] pushCardToDB error:', error.message)
+  } catch (e) {
+    console.warn('[flashcardData] pushCardToDB exception:', e)
+  }
+}
+
+async function pushCardsToDB(userId: string, cards: Flashcard[]): Promise<void> {
+  if (cards.length === 0) return
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const now = new Date().toISOString()
+    const rows = cards.map((c) => cardToRow(userId, c, now))
+    const CHUNK = 500
+    for (let i = 0; i < rows.length; i += CHUNK) {
+      const chunk = rows.slice(i, i + CHUNK)
+      const { error } = await (db as any)
+        .from('user_flashcards')
+        .upsert(chunk, { onConflict: 'user_id,card_key' })
+      if (error) {
+        console.warn('[flashcardData] pushCardsToDB error:', error.message)
+        return
+      }
+    }
+  } catch (e) {
+    console.warn('[flashcardData] pushCardsToDB exception:', e)
+  }
+}
+
+/** ローカル削除 + DB 削除 */
+export async function deleteCardForUser(userId: string, cardKey: string): Promise<void> {
+  const cards = loadCards().filter((c) => c.id !== cardKey)
+  saveCards(cards)
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const { error } = await (db as any)
+      .from('user_flashcards')
+      .delete()
+      .eq('user_id', userId)
+      .eq('card_key', cardKey)
+    if (error) console.warn('[flashcardData] deleteCardForUser error:', error.message)
+  } catch (e) {
+    console.warn('[flashcardData] deleteCardForUser exception:', e)
+  }
+}
+
+/**
+ * ログイン時の同期。
+ * 戦略: Last-write-wins by 進捗指標 (correctCount + interval)。
+ * - 両方にある場合: 進捗が大きい方を採用 (SRS の古い値で復習結果を上書きしない)
+ * - 片方だけ: そのまま使う
+ */
+export async function syncFlashcards(userId: string): Promise<void> {
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const remote = await fetchCardsFromDB(userId)
+    if (remote == null) return
+    const local = loadCards()
+
+    const remoteByKey = new Map(remote.map((r) => [r.id, r]))
+    const merged = new Map<string, Flashcard>()
+    for (const r of remote) merged.set(r.id, r)
+
+    const toPush: Flashcard[] = []
+    for (const l of local) {
+      const r = remoteByKey.get(l.id)
+      if (!r) {
+        merged.set(l.id, l)
+        toPush.push(l)
+        continue
+      }
+      const localProgress = l.correctCount + l.interval
+      const remoteProgress = r.correctCount + r.interval
+      if (localProgress > remoteProgress) {
+        merged.set(l.id, l)
+        toPush.push(l)
+      }
+    }
+
+    const mergedArr = [...merged.values()]
+    saveCards(mergedArr)
+    await pushCardsToDB(userId, toPush)
+
+    if (import.meta.env.DEV) {
+      console.log(
+        '[flashcardData] syncFlashcards complete:',
+        `remote=${remote.length}`,
+        `local=${local.length}`,
+        `merged=${mergedArr.length}`,
+        `pushed=${toPush.length}`,
+      )
+    }
+  } catch (e) {
+    console.warn('[flashcardData] syncFlashcards failed:', e)
+  }
 }
 
 // Generate flashcards from lesson quiz results

--- a/src/issueLessonsEn.ts
+++ b/src/issueLessonsEn.ts
@@ -84,6 +84,9 @@ const issueExhaustive: LessonData = {
       title: 'MECE: no gaps, no overlaps',
       content:
         'The first rule when surfacing issues is MECE — Mutually Exclusive, Collectively Exhaustive.\n\nExample: "E-commerce revenue is dropping."\n\n[By revenue structure]\nRevenue = Visits × Conversion × Average ticket\n-> Issues on visits / conversion / average ticket.\n\n[By customer phase]\nNew / Repeat / Reactivated\n-> Which phase is dropping?\n\n[By product category]\nFlagship A / Adjacent B / Long tail\n-> Where is the impact concentrated?\n\nWhat matters is checking that any single cut is MECE on its own dimension. Mixing three dimensions in the same list silently creates both gaps and overlaps.',
+      visual: 'MeceVennDiagram',
+      outro:
+        'The iron rule of MECE is "stay inside one cut." Mix three dimensions and you create gaps and overlaps simultaneously. Taking a moment to ask "what dimension am I cutting on right now?" before listing issues is exactly the small habit that lifts the quality of your thinking.',
     },
     {
       type: 'quiz',
@@ -155,6 +158,9 @@ const issueStructure: LessonData = {
       title: 'Layer issues into main and sub-issues',
       content:
         'A flat list of 10-20 issues still signals shallow thinking.\nReorganizing them into main issues -> sub-issues -> validation questions makes the logic legible.\n\nExample: Risk of missing next year\'s profit target (top question)\n+- Main A: Could revenue come in below plan?\n|  +- Sub A1: Will repeat rates among existing customers drop?\n|  +- Sub A2: Will new acquisition slow?\n|  +- Sub A3: Will the price change cool demand?\n+- Main B: Could the cost base balloon?\n   +- Sub B1: Wage inflation?\n   +- Sub B2: Material and logistics cost increases?\n\nThis is an "issue tree."\nIf parent-child relationships can be explained both ways via "Why so / How so," the structure is sound.',
+      visual: 'LogicTreeDiagram',
+      outro:
+        'The quality test for an issue tree is whether each parent-child link survives both "Why so" and "How so." Simply layering a flat list into main, sub, and validation issues automatically settles your priority order and the sequence in which you should verify them.',
     },
     {
       type: 'quiz',
@@ -262,6 +268,9 @@ const issueHypothesis: LessonData = {
       title: 'Use "So What" in three layers to reach the essence',
       content:
         'Data alone is not yet an answer.\nApply "So what?" three times to ladder from surface to essence — this is the heart of the course.\n\nExample: "New signups +30% last month, free-to-paid conversion 7%."\n\nSo What level 1 (surface):\n-> New is strong, but the conversion bottleneck is large.\n\nSo What level 2 (middle):\n-> Closing the gap to industry average (15%) would roughly double paid members from the same acquisition.\n\nSo What level 3 (essence):\n-> Investment priority shifts from "more acquisition" to "better free-to-paid experience design."\n-> Competitive advantage concentrates in the first 14 days of onboarding.\n\nOnly with three layers does an issue turn into a "decision in motion."\nThe gap between people who stop at level 1 and those who push to level 3 is exactly what "depth of thinking" means.',
+      visual: 'SoWhatDiagram',
+      outro:
+        'Stack three layers of "So What" and data transforms into a "decision in motion." The gap between people who stop at the surface and people who push to essence is what "depth of thinking" really means. Getting in the habit of asking "so what?" three times in a row every time you look at data is the first step.',
     },
     {
       type: 'quiz',

--- a/src/notebookStore.ts
+++ b/src/notebookStore.ts
@@ -197,3 +197,61 @@ export async function migrateLocalStorageToSupabase(userId: string): Promise<voi
     console.warn('[notebookStore] migration failed:', e)
   }
 }
+
+// =============================================
+// Supabase 同期 (Phase 1: Device Sync)
+// =============================================
+
+/**
+ * ログイン時の同期。
+ * 戦略: per-date last-write-wins。
+ * - DB と localStorage を date 単位でマージ
+ * - 両方に同 date がある場合は aiSummary + userMemo の合計文字数が多い方を採用
+ *   (情報落としを最小化する保守マージ)
+ *
+ * 改修済 notebooks スキーマ (025_notebooks_journal_columns.sql) を前提とする。
+ */
+export async function syncNotebook(userId: string): Promise<void> {
+  try {
+    const remote = (await getNotebook(userId)) ?? []
+    const local = load()
+
+    const byDate = new Map<string, NotebookEntry>()
+    for (const r of remote) byDate.set(r.date, r)
+
+    const toPush: NotebookEntry[] = []
+    for (const l of local) {
+      const r = byDate.get(l.date)
+      if (!r) {
+        byDate.set(l.date, l)
+        toPush.push(l)
+        continue
+      }
+      const localScore = (l.aiSummary?.length ?? 0) + (l.userMemo?.length ?? 0)
+      const remoteScore = (r.aiSummary?.length ?? 0) + (r.userMemo?.length ?? 0)
+      if (localScore > remoteScore) {
+        byDate.set(l.date, l)
+        toPush.push(l)
+      }
+    }
+
+    const merged = [...byDate.values()]
+    save(merged)
+
+    for (const entry of toPush) {
+      await saveNotebook(userId, entry)
+    }
+
+    if (import.meta.env.DEV) {
+      console.log(
+        '[notebookStore] syncNotebook complete:',
+        `remote=${remote.length}`,
+        `local=${local.length}`,
+        `merged=${merged.length}`,
+        `pushed=${toPush.length}`,
+      )
+    }
+  } catch (e) {
+    console.warn('[notebookStore] syncNotebook failed:', e)
+  }
+}

--- a/src/numeracyLessonsEn.ts
+++ b/src/numeracyLessonsEn.ts
@@ -60,6 +60,9 @@ const numeracyLesson400: LessonData = {
       type: 'explain',
       title: 'A pattern-selection cheat sheet to remove hesitation',
       content: 'Order of checks for selecting techniques live.\n\nA. 2-digit × 2-digit multiplication (check from the top):\n1. Same tens + ones summing to 10? → Trick — instant\n2. Symmetric around a clean number? → Difference of squares\n3. One side near a clean number? → Round and adjust\n4. Otherwise → Distribution / cross multiplication\n\nB. Multiplication by special numbers:\n- ×11 → Add the digits, place between\n- ×25 → ×100 ÷ 4\n- ×50 → ×100 ÷ 2\n- ×125 → ×1,000 ÷ 8\n- ×9 → ×10 − ×1\n- ×5 → ×10 ÷ 2\n\nC. Percentages:\n- Combine anchors of 10%, 25%, 50%, 1%\n- "Almost ×1" cases like ×0.99 → use subtraction\n\nTip: No need to memorize every rule. Aim for the state where "something fires the moment you see the numbers." Decision time will start at slow and tighten to half a second with practice.',
+      visual: 'MentalMathDecisionTreeDiagram',
+      outro:
+        'The endgame for mental math is "first move fires the moment you see the numbers." Keep three decision tracks ready — multiplication, percentages, special numbers — and hesitation drops away while speed climbs.',
     },
     {
       type: 'quiz',
@@ -128,6 +131,9 @@ const numeracyLesson401: LessonData = {
       type: 'explain',
       title: 'Use absolute and relative values appropriately',
       content: 'For the same fact, the impression varies dramatically depending on whether you state an absolute value or a ratio.\n\nExample 1: $30 discount\n- $100 product → "30% off" lands hard\n- $10,000 product → "$30 off" feels weak; "$10,000 → $9,970" is unmoving\n\nExample 2: Sales up by $1B\n- Base of $10B → "10% growth" feels meaningful\n- Base of $1T → must say "+$1B" (0.1% doesn\'t communicate)\n\nPrinciples for choosing:\n- Small base × big change → use ratios (high impact)\n- Large base × small change → use absolute (concrete)\n- State both → most honest (lets the reader judge)\n\nCaution: Phrases like "Click-through rate up 200%!" need a closer look. 0.1% → 0.3% is also "up 200%." A textbook case where pure ratio overstates the picture.',
+      visual: 'AbsoluteVsRelativeDiagram',
+      outro:
+        'Ratios deliver impact, absolutes deliver concreteness. Pick by the size of the base and the size of the change, and when in doubt list both. Leaving the judgement material in the audience\'s hands is the most honest framing.',
     },
     {
       type: 'explain',
@@ -204,6 +210,9 @@ const numeracyLesson402: LessonData = {
       type: 'explain',
       title: 'Chained percent changes — multiply, do not add',
       content: 'When percent changes occur in sequence, multiply the multipliers — don\'t add them.\n\nExample 1: 20% up, then 10% down\n- 1.20 × 0.90 = 1.08 → 8% up\n- ❌ Not "20% − 10% = 10% up"\n\nExample 2: 30% up, then 30% down\n- 1.30 × 0.70 = 0.91 → 9% down\n- ❌ Not "back to ±0%"\n\nExample 3: 10% growth for 3 years in a row\n- 1.10 × 1.10 × 1.10 = 1.331 → 33.1% up by year 4\n- ❌ Not "30% up"\n\nPoint: When dealing with percent changes, the rule is "don\'t add." Chain them as multiplications.',
+      visual: 'ExponentialCurveDiagram',
+      outro:
+        'Chained percent changes call for multiplication, not addition. Three years of 10% growth lands at 33%, never at 30%. Carrying a compounding mindset is enough to lift the accuracy of long-horizon estimates by a full level.',
     },
     {
       type: 'explain',
@@ -358,6 +367,9 @@ const numeracyLesson404: LessonData = {
       type: 'explain',
       title: 'Exponential growth violates intuition',
       content: 'The human brain handles linear growth fine but consistently underestimates exponential growth.\n\nFamous example: how much after 30 days?\n- A: "Get 1M yen each day" → 30 × 1M = 30M yen\n- B: "Start with 1 yen, double each day" → 1, 2, 4, 8, … day 30 = 2^29 ≈ 540M yen\n- Intuition says A wins; in fact B is 10×+ larger\n\nDoubling power:\n- Infections double every 3 days → 30 days = 2^10 = 1,024×\n- Linear thinking gets blindsided just before it\'s too late\n\nSpotting exponential growth:\n- Phenomena that "double on a regular schedule" are exponential\n- A graph with a log Y-axis indicates exponential growth\n- "Suddenly grew a lot recently" = late-stage exponential\n\nBusiness application:\n- Exponential user growth captures markets terrifyingly fast (network-effect startups)\n- Conversely, exponential cost growth (credit-card interest, subscription stacking) follows the same mechanic\n- "Compounding things" can be ally or enemy\n\nPoint: The essence of exponential growth is "current value × multiplier" determines next. Step one is leaving linear thinking behind.',
+      visual: 'ExponentialCurveDiagram',
+      outro:
+        'Human intuition is strong on linear curves and weak on exponential ones. When you see something "doubling on a regular cadence," resist being lulled by the small early numbers — work backwards from the late-stage surge to size it instead.',
     },
     {
       type: 'explain',
@@ -435,6 +447,9 @@ const numeracyLesson405: LessonData = {
       type: 'explain',
       title: 'For skewed distributions, the median rules',
       content: 'Real-world data is often not normal. With skew, the mean misleads.\n\nRight-skewed (long right tail):\n- Examples: income, stock returns, social-media follower counts\n- A small number of high values lifts the mean\n- Mean > median\n- → Use the median for reality\n\nLeft-skewed (long left tail):\n- Examples: lifespan, exam scores when most are near full marks\n- A small number of low values pulls the mean down\n- Mean < median\n- → Use the median for reality\n\nPower law (Pareto):\n- Extreme skew where the top 20% accounts for 80%\n- Examples: book sales (a few bestsellers dominate), website traffic\n- The mean is meaningless; describe with "top X%," "median," or "Gini coefficient"\n\nHow to detect:\n- Compare mean vs. median\n- Plot a histogram (symmetric or one-sided?)\n- A mean-to-median ratio of 1.5× or more suggests heavy skew\n\nCommon mistake in practice:\n- Reading "mean income 5M" and expecting "I should also be at 5M"\n- Reality: median is 4M, mean inflated by upper layer\n- Same data, different impression based on which measure you choose\n\nPoint: Receiving "the mean" without inspecting the distribution gives a sense of reality at odds with reality.',
+      visual: 'DistributionShapeDiagram',
+      outro:
+        'Most real-world data — income, stock returns, follower counts — is heavily skewed. Trusting only the mean warps your sense of reality, so always check the median alongside. The gap between mean and median is itself a story about how skewed the data is.',
     },
     {
       type: 'quiz',
@@ -512,6 +527,9 @@ const numeracyLesson406: LessonData = {
       type: 'explain',
       title: 'Maintain a "doubt list" for incoming numbers',
       content: 'When numbers arrive, mechanically check the following.\n\nSampling traps:\n- Are failures and dropouts included? (survivorship bias)\n- Is the sample skewed? (selection bias)\n- Is the time/region/segment cherry-picked?\n\nAggregation traps:\n- Do the whole and parts agree? (Simpson)\n- Same trend at the subgroup level?\n\nCausation traps:\n- Are you mistaking correlation for causation?\n- Any third factor (confounder)?\n- Is the direction of causation reversed?\n\nDenominator traps:\n- For "X×" or "X%," what is the base rate?\n- What is the sample size (n)?\n- Have you seen both ratios and counts?\n\nProbability traps:\n- For "X% accuracy," what is the base rate?\n- Have you considered the absolute numbers of false positives/negatives?\n\nMeta-questions:\n- What does the presenter want to claim?\n- Have you also looked for data that argues the opposite conclusion?\n\nPoint: Beyond "don\'t swallow whole," carry a checklist of "what to doubt" — that\'s how you read numbers critically.',
+      visual: 'GraphPitfallsDiagram',
+      outro:
+        'Sampling, aggregation, causation, denominator, and probability are the five main families of number traps. Keep a checklist of "what to doubt" in your back pocket and you stop swallowing numbers whole, reading them structurally instead.',
     },
     {
       type: 'quiz',

--- a/src/philosophyLessonsEn.ts
+++ b/src/philosophyLessonsEn.ts
@@ -17,6 +17,9 @@ export const philosophyLessonMapEn: Record<number, LessonData> = {
         title: 'The structure of the elenchus',
         content:
           'The Socratic method runs in three steps.\n\n1. Ask for a definition: get them to state "What is X?"\n2. Hunt for counterexamples: shake the definition with "How do you explain this case?"\n3. Force a redefinition: lead them to a more precise definition.\n\nExample: "Courage is feeling no fear."\n→ "So someone who acts despite feeling fear has no courage?"\n→ "Then is courage perhaps the power to control fear?"\n\nThis cycle of refinement deepens thought.',
+        outro:
+          'The three-step rhythm of definition, counterexample, and redefinition still drives modern strategy debates and hypothesis testing. Simply persisting with "is that really so?" and "is there a counterexample?" is enough to polish vague claims into precise definitions.',
+        visual: 'ThreePillarsDiagram',
       },
       {
         type: 'quiz',
@@ -93,6 +96,9 @@ export const philosophyLessonMapEn: Record<number, LessonData> = {
         title: 'Thinking through the trolley problem',
         content:
           'The "trolley problem" sharpens the contrast between the two views.\n\nA runaway trolley with broken brakes is heading toward five people. Pulling a lever switches it to a side track where one person stands; the five are saved, but the one is killed. Should you pull?\n\nUtilitarian answer: Pull. 5 > 1. Maximizing the outcome is right.\nDeontological answer: (Possibly) do not pull. Using the one person as a means violates that person\'s rights.\n\nBoth are logical. What matters is being aware of which value system you are judging from.',
+        outro:
+          'Utilitarianism and deontology are both logically sound, which tells us the root of disagreement lives in values. When a decision splits the room, just naming which side — outcomes-first or rules-first — you and the other person are standing on turns the argument into a constructive one.',
+        visual: 'TrolleyProblemDiagram',
       },
       {
         type: 'quiz',

--- a/src/problemSettingLessonsEn.ts
+++ b/src/problemSettingLessonsEn.ts
@@ -50,6 +50,9 @@ const problemSettingIntro: LessonData = {
       title: 'The Where -> Why -> How framework',
       content:
         'For problem setting, the order "Where -> Why -> How" works well.\n\n[Where] Where is the problem?\nRevenue = Customers x Average ticket x Purchase frequency\n-> "Customers" are dropping (locate the problem)\n\n[Why] Why is that problem happening?\n-> New customers are growing, but existing customers are repeating less\n-> Repeat decline is caused by dissatisfaction with delivery delays\n\n[How] How do we fix it?\n-> Re-evaluate delivery partners\n-> Real-time delivery status notifications\n-> Auto-issue coupons on delays\n\nIf you skip Where/Why and jump to How,\nyou waste time and money on solutions that miss the target.',
+      visual: 'WhereWhyHowDiagram',
+      outro:
+        'Holding to Where -> Why -> How in that order is the iron rule of problem setting. Skip the Where and rush to the How, and you watch time and budget melt into solutions that miss the mark. Pinning down where the problem actually lives before designing actions is what makes the whole exercise efficient.',
     },
     {
       type: 'quiz',
@@ -94,6 +97,9 @@ const problemSettingFramework: LessonData = {
       title: 'Prioritizing issues — a 2x2 matrix',
       content:
         'When there are many issues, working on all of them is inefficient.\nA 2x2 matrix to set priorities:\n\n           High Impact\n        ┌────────┬────────┐\n  Easy  │ Quick  │  Top   │\n        │  Win   │ Priority│\n        ├────────┼────────┤\n  Hard  │ Defer  │ Strategic│\n        │        │  Plan  │\n        └────────┴────────┘\n           Low Impact\n\n(1) Top priority (high impact x easy) -> do immediately\n(2) Quick win (low impact x easy) -> do if you have spare cycles\n(3) Strategic plan (high impact x hard) -> work on over the medium/long term\n(4) Defer (low impact x hard) -> don\'t do',
+      visual: 'Two2MatrixDiagram',
+      outro:
+        'An impact × feasibility 2×2 sorts issues into top priority, quick wins, strategic plan, and defer at a glance. "Do everything" amounts to "do nothing" in practice. Make the priority visible and concentrate resources on the quadrant with the highest payoff.',
     },
     {
       type: 'quiz',

--- a/src/progressStore.ts
+++ b/src/progressStore.ts
@@ -1,5 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { loadCards } from './flashcardData'
 import { getProgress, saveAllProgress, saveProgressCategory } from './db/progressDb'
+import { getSupabaseClient } from './db/index'
 
 const STORAGE_KEY = 'logic-progress'
 
@@ -222,5 +224,84 @@ export async function migrateLocalStorageToSupabase(userId: string): Promise<voi
     }
   } catch (e) {
     console.warn('[progressStore] migration failed:', e)
+  }
+}
+
+// =============================================
+// Supabase 同期 (Phase 1: Device Sync — user_progress.category_progress)
+// =============================================
+//
+// 設計書 Section 4.4 / 3.2 に従い、カテゴリ別マスタリーは user_progress テーブルに
+// 相乗りさせる。conflict resolution は Max value (完了数は単調増加なので安全)。
+
+/**
+ * user_progress.category_progress を pull → ローカルとマージ → push
+ */
+export async function syncCategoryProgress(userId: string): Promise<void> {
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const { data, error } = await (db as any)
+      .from('user_progress')
+      .select('category_progress')
+      .eq('user_id', userId)
+      .maybeSingle()
+    if (error) {
+      console.warn('[progressStore] syncCategoryProgress select error:', error.message)
+      return
+    }
+
+    const remoteRaw = (data?.category_progress ?? {}) as Record<string, Partial<CategoryProgress>>
+    const local = loadProgress()
+
+    const merged: Record<Category, CategoryProgress> = structuredClone(DEFAULT_PROGRESS)
+    for (const cat of Object.keys(DEFAULT_PROGRESS) as Category[]) {
+      const r = remoteRaw[cat] ?? {}
+      const l = local[cat] ?? { totalCards: 0, completedCards: 0 }
+      merged[cat] = {
+        totalCards: Math.max(r.totalCards ?? 0, l.totalCards),
+        completedCards: Math.max(r.completedCards ?? 0, l.completedCards),
+      }
+    }
+
+    saveProgress(merged)
+
+    const { error: upErr } = await (db as any).from('user_progress').upsert(
+      {
+        user_id: userId,
+        category_progress: merged,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id' },
+    )
+    if (upErr) console.warn('[progressStore] syncCategoryProgress upsert error:', upErr.message)
+
+    if (import.meta.env.DEV) {
+      console.log('[progressStore] syncCategoryProgress complete:', merged)
+    }
+  } catch (e) {
+    console.warn('[progressStore] syncCategoryProgress failed:', e)
+  }
+}
+
+/**
+ * カテゴリ別進捗を全件 push (書き込みフック用)
+ */
+export async function pushCategoryProgressToDB(userId: string): Promise<void> {
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const current = loadProgress()
+    const { error } = await (db as any).from('user_progress').upsert(
+      {
+        user_id: userId,
+        category_progress: current,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id' },
+    )
+    if (error) console.warn('[progressStore] pushCategoryProgressToDB error:', error.message)
+  } catch (e) {
+    console.warn('[progressStore] pushCategoryProgressToDB exception:', e)
   }
 }

--- a/src/proposalCourseLessonsEn.ts
+++ b/src/proposalCourseLessonsEn.ts
@@ -82,6 +82,9 @@ const proposalHypothesis: LessonData = {
       type: 'explain',
       title: 'Separating issue, cause, and action',
       content: 'Three things that often get confused:\n\nIssue: the problem to solve (e.g., 30% sales drop)\nCause: why the issue is happening (e.g., repeat customer churn)\nAction: a measure that resolves the cause (e.g., launch a loyalty program)\n\nThinking in this order — issue → cause → action — keeps you from picking off-target actions.',
+      visual: 'ThreePillarsDiagram',
+      outro:
+        'Issue, cause, and action are three different things. Skip the order and you end up racing toward an action while the issue is still fuzzy — a classic way to burn time on off-target work. Write each of the three down separately and check them for fit before you ever open the proposal deck.',
     },
     {
       type: 'quiz',
@@ -153,6 +156,9 @@ const proposalVerification: LessonData = {
       type: 'explain',
       title: 'Hypotheses are meant to be changed',
       content: 'Many people think "changing your hypothesis = losing." It\'s the opposite.\n\nRevising and updating hypotheses based on research findings IS the essence of hypothesis thinking.\n\nUpdate patterns:\nSupported → dig deeper as-is\nPartially modified → re-test the modified hypothesis\nRejected → switch to a different hypothesis',
+      visual: 'ThreePillarsDiagram',
+      outro:
+        'Anticipating all three outcomes — supported, partially modified, rejected — from the start stops you from being thrown by research findings. Changing a hypothesis is not losing; it is proof your verification actually worked. Updating quickly to match the facts is what raises the precision of your proposal.',
     },
     {
       type: 'quiz',
@@ -199,6 +205,9 @@ const proposalStructure: LessonData = {
       type: 'explain',
       title: 'Organize issues with a tree structure',
       content: 'When multiple issues are tangled, organize with a logic tree.\n\nIssue tree example:\nSales decline\n├── Decline in new customers\n│   ├── Lower brand awareness\n│   └── Switching to competitors\n└── Decline in repeat customers\n    ├── Quality dissatisfaction\n    └── Loss of price competitiveness\n\nA tree shows "where the highest-leverage solve point is."',
+      visual: 'LogicTreeDiagram',
+      outro:
+        'An issue tree is the map that shows "which branch your action will actually move." Solving every branch evenly is not realistic, so use the tree to survey the whole and then zero in on the branch with the biggest leverage. That is how seasoned teams build proposals.',
     },
     {
       type: 'quiz',
@@ -231,6 +240,9 @@ const proposalStructure: LessonData = {
       type: 'explain',
       title: 'Evaluate actions on feasibility and impact',
       content: 'When multiple actions emerge, evaluate them on two axes.\n\nImpact: how much it contributes to solving the issue\nFeasibility: can it be done given cost, time, and resources\n\nClassify on a 2×2 grid for clear priority:\n- High impact × Easy → execute immediately (Quick Win)\n- High impact × Hard → tackle medium-to-long term\n- Low impact × Easy → do if time permits\n- Low impact × Hard → drop',
+      visual: 'Two2MatrixDiagram',
+      outro:
+        'The impact × feasibility 2×2 makes it obvious to start from the Quick Win quadrant. "Do everything" usually collapses into "do nothing" in practice. When you can articulate the priority logic on a proposal page, the conviction it creates in decision-makers changes dramatically.',
     },
   ],
 }
@@ -245,6 +257,9 @@ const proposalOutline: LessonData = {
       type: 'explain',
       title: 'Design the storyline',
       content: 'In a proposal, the logical flow (storyline) is everything.\n\nBasic structure:\n1. Current state and issue (As-Is)\n2. Cause of the issue (Why)\n3. Target state (To-Be)\n4. Proposed action (How)\n5. Expected impact (So What)\n\nThis flow leads the reader through "understanding → conviction → action."',
+      visual: 'WhereWhyHowDiagram',
+      outro:
+        'As-Is → Why → To-Be → How → So What is the royal road of proposal storylines. Reorder these and the logic collapses, leaving the reader with a "conclusion-first manipulation" feeling. Build your skeleton in this order before you add any decoration — it is the safest sequence.',
     },
     {
       type: 'quiz',
@@ -261,6 +276,9 @@ const proposalOutline: LessonData = {
       type: 'explain',
       title: 'Apply the Pyramid Principle',
       content: 'The "lead with the conclusion" Pyramid Principle is the foundation of proposals.\n\nTop-Down (conclusion first): conclusion → reason 1, reason 2, reason 3\n→ Used in most business proposals\n\nBottom-Up (reasons first): reason 1, reason 2, reason 3 → conclusion\n→ Suited for data analysis reports\n\nProposals respect the reader\'s time by leading with the conclusion.',
+      visual: 'PyramidDiagram',
+      outro:
+        'A proposal is decided by its opening conclusion. Senior readers have the least time, so Top-Down conclusion-first is the principle. Bottom-Up is fine for analysis reports but should be avoided in proposals as a rule.',
     },
     {
       type: 'quiz',

--- a/src/proposalLessonsEn.ts
+++ b/src/proposalLessonsEn.ts
@@ -16,6 +16,9 @@ const proposalPurpose: LessonData = {
       title: 'A proposal is a tool for getting decisions',
       content:
         'Before you start writing a proposal, answer one question.\n\n"What do I want the reader to decide after reading this?"\n\nIf this is fuzzy when you start writing, you end up with a proposal that has lots of information but leaves the reader thinking "so what are you actually saying?"\n\nProposal purposes fall into three buckets:\n\n(1) Approval\n"Approve this budget" / "Give us permission to execute this initiative"\n→ Build around the information needed for the decision and the risk mitigations.\n\n(2) Alignment / Understanding\n"Get on the same page about the current state" / "Share a sense of urgency"\n→ Use data and examples to make the situation visible and create shared concern or empathy.\n\n(3) Action\n"Start moving today" / "Decide the next step"\n→ Clearly specify next actions, owners, and deadlines.\n\nOnce you pick one purpose, treat everything else as supporting context. This single decision changes the density of your proposal.',
+      visual: 'ThreePillarsDiagram',
+      outro:
+        'Approval, alignment, and action are the three proposal purposes — picking just one is where every proposal should start. Once the purpose is settled, the center of gravity of the structure falls into place on its own. The courage to drop "I want it all in there" is what produces a high-density proposal.',
     },
     {
       type: 'quiz',
@@ -61,6 +64,9 @@ const proposalStakeholder: LessonData = {
       title: 'Imagine the reader as a person',
       content:
         'A great proposal answers the question already in the reader\'s head — before they ask.\n\nStakeholder analysis basics:\n\n(1) Who reads it (decision-makers, influencers, hands-on operators)\n(2) What they care about (cost, quality, speed, risk, reputation)\n(3) What worries them (resistance to change, scope of responsibility, past failures)\n\nTypical reader concerns:\n\n[Finance / CFO]\n"What\'s the ROI? What\'s the payback period?"\n\n[Operations / front-line]\n"What\'s the actual workload? Impact on existing work? Who will do it?"\n\n[Marketing / business]\n"What\'s our competitive advantage? How will customers perceive it? What\'s the growth potential?"\n\nPeople interpret the same information through their own lens. Adjusting emphasis based on who you\'re showing the same proposal to is the mark of a pro.',
+      visual: 'ThreePillarsDiagram',
+      outro:
+        'Finance, operations, and business roles each carry a different center of gravity, so the move of swapping emphasis on the same proposal is the mark of a pro. Picture your reader as a person and answer the question they will silently ask first — that is what makes a proposal land.',
     },
     {
       type: 'quiz',
@@ -106,6 +112,9 @@ const proposalStoryline: LessonData = {
       title: 'Design with the SCR structure',
       content:
         'There\'s a template for the flow of a proposal. The most usable one is SCR.\n\n[S] Situation\nConfirm the current state — something the reader already knows or agrees with.\nExample: "Our customer acquisition cost (CAC) is currently 1.5× the industry average."\n\n[C] Complication\nShow the problem, contradiction, or change that situation creates.\nExample: "Left alone, this puts us at risk of losing price competitiveness within three years."\n\n[R] Resolution\nPresent the answer that solves the problem.\nExample: "Shifting to digital marketing channels can cut CAC by 30%."\n\nWhy this order matters:\nSharing the "problem" before the "solution" creates the feeling of "so that\'s why we need this." Leading with the solution invites resistance ("why do we need this?").',
+      visual: 'ScrStructureDiagram',
+      outro:
+        'Situation → Complication → Resolution builds the reader\'s conviction in steps. Because they meet the solution after they have already felt the problem, it lands as "so this is why we need this." Run the order backwards and you start from resistance, which costs you persuasive power.',
     },
     {
       type: 'quiz',

--- a/src/roadmapStore.ts
+++ b/src/roadmapStore.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { getRoadmap } from './roadmapData'
 import {
   getRoadmapProgress,
@@ -5,6 +6,7 @@ import {
   saveAllRoadmapGoals,
   deleteRoadmapGoal,
 } from './db/roadmapDb'
+import { getSupabaseClient } from './db/index'
 
 const STORAGE_KEY = 'logic-roadmap'
 
@@ -259,6 +261,183 @@ export async function setDailyMinutesForUser(
     }
   }
   return state
+}
+
+// =============================================
+// Supabase 同期 (Phase 1: Device Sync — user_roadmap_goals テーブル)
+// =============================================
+//
+// 旧 roadmap_progress テーブル (node_id + status) は実装と不整合のため、
+// 新テーブル user_roadmap_goals (026_user_roadmap_goals.sql) に向き直す。
+
+type RoadmapGoalRow = {
+  goal_id: string
+  target_date: string | null
+  daily_minutes: number
+  completed_steps: number[]
+  setup_done: boolean
+  created_at: string
+}
+
+function rowToGoalEntryV2(row: RoadmapGoalRow): GoalEntry {
+  return {
+    goalId: row.goal_id,
+    targetDate: row.target_date,
+    dailyMinutes: row.daily_minutes ?? 15,
+    completedSteps: row.completed_steps ?? [],
+    createdAt: row.created_at || new Date().toISOString(),
+  }
+}
+
+async function fetchRoadmapGoalsV2(userId: string): Promise<RoadmapState | null> {
+  const db = getSupabaseClient()
+  if (!db) return null
+  try {
+    const { data, error } = await (db as any)
+      .from('user_roadmap_goals')
+      .select('goal_id, target_date, daily_minutes, completed_steps, setup_done, created_at')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: true })
+
+    if (error) {
+      console.warn('[roadmapStore] fetchRoadmapGoalsV2 error:', error.message)
+      return null
+    }
+    if (!data || data.length === 0) return null
+    const goals = (data as RoadmapGoalRow[]).map(rowToGoalEntryV2)
+    const setupDone = (data[0] as RoadmapGoalRow).setup_done ?? true
+    return { goals, setupDone }
+  } catch (e) {
+    console.warn('[roadmapStore] fetchRoadmapGoalsV2 exception:', e)
+    return null
+  }
+}
+
+async function pushRoadmapGoalsV2(userId: string, state: RoadmapState): Promise<void> {
+  if (state.goals.length === 0) return
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const rows = state.goals.map((g) => ({
+      user_id: userId,
+      goal_id: g.goalId,
+      target_date: g.targetDate,
+      daily_minutes: g.dailyMinutes,
+      completed_steps: g.completedSteps,
+      setup_done: state.setupDone,
+      updated_at: new Date().toISOString(),
+    }))
+    const { error } = await (db as any)
+      .from('user_roadmap_goals')
+      .upsert(rows, { onConflict: 'user_id,goal_id' })
+    if (error) console.warn('[roadmapStore] pushRoadmapGoalsV2 error:', error.message)
+  } catch (e) {
+    console.warn('[roadmapStore] pushRoadmapGoalsV2 exception:', e)
+  }
+}
+
+/** 1 ゴールを v2 テーブルに upsert (書き込みフック用) */
+export async function pushRoadmapGoalForUserV2(
+  userId: string,
+  goal: GoalEntry,
+  setupDone: boolean,
+): Promise<void> {
+  await pushRoadmapGoalsV2(userId, { goals: [goal], setupDone })
+}
+
+/** v2 テーブルから 1 ゴール削除 */
+export async function deleteRoadmapGoalForUserV2(userId: string, goalId: string): Promise<void> {
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const { error } = await (db as any)
+      .from('user_roadmap_goals')
+      .delete()
+      .eq('user_id', userId)
+      .eq('goal_id', goalId)
+    if (error) console.warn('[roadmapStore] deleteRoadmapGoalForUserV2 error:', error.message)
+  } catch (e) {
+    console.warn('[roadmapStore] deleteRoadmapGoalForUserV2 exception:', e)
+  }
+}
+
+/**
+ * ログイン時の同期 (Phase 1)。
+ * 戦略: Union of completedSteps + last-write for metadata
+ * - goal_id 単位でマージ
+ * - completedSteps は union (両端の進捗を合算)
+ * - targetDate / dailyMinutes は createdAt が新しい方を採用
+ */
+export async function syncRoadmap(userId: string): Promise<void> {
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const remote = await fetchRoadmapGoalsV2(userId)
+    const local = load()
+
+    if (!remote && local.goals.length === 0) return
+
+    const remoteGoals = remote?.goals ?? []
+    const localGoals = local.goals
+    const remoteByGoal = new Map(remoteGoals.map((g) => [g.goalId, g]))
+    const merged: GoalEntry[] = []
+    const toPushIds = new Set<string>()
+
+    for (const r of remoteGoals) {
+      const l = localGoals.find((lg) => lg.goalId === r.goalId)
+      if (!l) {
+        merged.push(r)
+        continue
+      }
+      const completedSteps = Array.from(new Set([...r.completedSteps, ...l.completedSteps]))
+      const newer = l.createdAt > r.createdAt ? l : r
+      const mergedEntry: GoalEntry = {
+        goalId: r.goalId,
+        targetDate: newer.targetDate ?? r.targetDate ?? l.targetDate,
+        dailyMinutes: newer.dailyMinutes ?? r.dailyMinutes,
+        completedSteps,
+        createdAt: r.createdAt < l.createdAt ? r.createdAt : l.createdAt,
+      }
+      merged.push(mergedEntry)
+      if (
+        completedSteps.length !== r.completedSteps.length ||
+        mergedEntry.targetDate !== r.targetDate ||
+        mergedEntry.dailyMinutes !== r.dailyMinutes
+      ) {
+        toPushIds.add(r.goalId)
+      }
+    }
+
+    for (const l of localGoals) {
+      if (!remoteByGoal.has(l.goalId)) {
+        merged.push(l)
+        toPushIds.add(l.goalId)
+      }
+    }
+
+    const mergedState: RoadmapState = {
+      goals: merged,
+      setupDone: (remote?.setupDone ?? false) || local.setupDone || merged.length > 0,
+    }
+    save(mergedState)
+
+    const goalsToPush = merged.filter((g) => toPushIds.has(g.goalId))
+    if (goalsToPush.length > 0) {
+      await pushRoadmapGoalsV2(userId, { goals: goalsToPush, setupDone: mergedState.setupDone })
+    }
+
+    if (import.meta.env.DEV) {
+      console.log(
+        '[roadmapStore] syncRoadmap complete:',
+        `remote=${remoteGoals.length}`,
+        `local=${localGoals.length}`,
+        `merged=${merged.length}`,
+        `pushed=${goalsToPush.length}`,
+      )
+    }
+  } catch (e) {
+    console.warn('[roadmapStore] syncRoadmap failed:', e)
+  }
 }
 
 /**

--- a/src/savedItemsStore.ts
+++ b/src/savedItemsStore.ts
@@ -5,6 +5,9 @@
  * AI 生成問題・フェルミ問題を横断して保存し、後から復習画面で
  * 一覧できるようにする。誤答ストアと同じく localStorage で完結。
  */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getSupabaseClient } from './db/index'
+
 const STORAGE_KEY = 'logic-saved-items'
 
 export type SavedItemType =
@@ -130,4 +133,176 @@ export function getSavedItemStats(): SavedItemStats {
   }
   for (const it of items) byType[it.type] += 1
   return { total: items.length, byType }
+}
+
+// =============================================
+// Supabase 同期 (Phase 1: Device Sync)
+// =============================================
+
+type SavedItemRow = {
+  item_type: string
+  ref_id: string
+  title: string
+  subtitle: string | null
+  image: string | null
+  step_index: number | null
+  parent_lesson_id: number | null
+  saved_at: string
+}
+
+function rowToSavedItem(row: SavedItemRow): SavedItem | null {
+  const allowed: SavedItemType[] = ['lesson', 'course', 'lesson-step', 'ai-problem', 'fermi']
+  if (!allowed.includes(row.item_type as SavedItemType)) return null
+  const type = row.item_type as SavedItemType
+  return {
+    id: makeId(type, row.ref_id),
+    type,
+    refId: row.ref_id,
+    title: row.title,
+    subtitle: row.subtitle ?? undefined,
+    image: row.image ?? undefined,
+    stepIndex: row.step_index ?? undefined,
+    parentLessonId: row.parent_lesson_id ?? undefined,
+    savedAt: row.saved_at,
+  }
+}
+
+function savedItemToRow(userId: string, item: SavedItem): Record<string, unknown> {
+  return {
+    user_id: userId,
+    item_type: item.type,
+    ref_id: item.refId,
+    title: item.title,
+    subtitle: item.subtitle ?? null,
+    image: item.image ?? null,
+    step_index: item.stepIndex ?? null,
+    parent_lesson_id: item.parentLessonId ?? null,
+    saved_at: item.savedAt,
+    updated_at: new Date().toISOString(),
+  }
+}
+
+async function fetchSavedItemsFromDB(userId: string): Promise<SavedItem[] | null> {
+  const db = getSupabaseClient()
+  if (!db) return null
+  try {
+    const { data, error } = await (db as any)
+      .from('user_saved_items')
+      .select('item_type, ref_id, title, subtitle, image, step_index, parent_lesson_id, saved_at')
+      .eq('user_id', userId)
+    if (error) {
+      console.warn('[savedItemsStore] fetchSavedItemsFromDB error:', error.message)
+      return null
+    }
+    return (data || [])
+      .map((r: SavedItemRow) => rowToSavedItem(r))
+      .filter((i: SavedItem | null): i is SavedItem => i !== null)
+  } catch (e) {
+    console.warn('[savedItemsStore] fetchSavedItemsFromDB exception:', e)
+    return null
+  }
+}
+
+/** 1 件 push */
+export async function pushSavedItemToDB(userId: string, item: SavedItem): Promise<void> {
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const { error } = await (db as any)
+      .from('user_saved_items')
+      .upsert([savedItemToRow(userId, item)], { onConflict: 'user_id,item_type,ref_id' })
+    if (error) console.warn('[savedItemsStore] pushSavedItemToDB error:', error.message)
+  } catch (e) {
+    console.warn('[savedItemsStore] pushSavedItemToDB exception:', e)
+  }
+}
+
+async function pushSavedItemsToDB(userId: string, items: SavedItem[]): Promise<void> {
+  if (items.length === 0) return
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const rows = items.map((it) => savedItemToRow(userId, it))
+    const CHUNK = 500
+    for (let i = 0; i < rows.length; i += CHUNK) {
+      const chunk = rows.slice(i, i + CHUNK)
+      const { error } = await (db as any)
+        .from('user_saved_items')
+        .upsert(chunk, { onConflict: 'user_id,item_type,ref_id' })
+      if (error) {
+        console.warn('[savedItemsStore] pushSavedItemsToDB error:', error.message)
+        return
+      }
+    }
+  } catch (e) {
+    console.warn('[savedItemsStore] pushSavedItemsToDB exception:', e)
+  }
+}
+
+/** ローカル + DB から削除 */
+export async function unsaveItemForUser(
+  userId: string,
+  type: SavedItemType,
+  refId: string | number,
+): Promise<void> {
+  unsaveItem(type, refId)
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const { error } = await (db as any)
+      .from('user_saved_items')
+      .delete()
+      .eq('user_id', userId)
+      .eq('item_type', type)
+      .eq('ref_id', String(refId))
+    if (error) console.warn('[savedItemsStore] unsaveItemForUser error:', error.message)
+  } catch (e) {
+    console.warn('[savedItemsStore] unsaveItemForUser exception:', e)
+  }
+}
+
+/**
+ * ログイン時の同期。
+ * 戦略: Union (savedAt が新しい方を採用)。
+ */
+export async function syncSavedItems(userId: string): Promise<void> {
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const remote = await fetchSavedItemsFromDB(userId)
+    if (remote == null) return
+    const local = loadSavedItems()
+
+    const byId = new Map<string, SavedItem>()
+    for (const r of remote) byId.set(r.id, r)
+    const toPush: SavedItem[] = []
+    for (const l of local) {
+      const r = byId.get(l.id)
+      if (!r) {
+        byId.set(l.id, l)
+        toPush.push(l)
+      } else {
+        if (l.savedAt > r.savedAt) {
+          byId.set(l.id, l)
+          toPush.push(l)
+        }
+      }
+    }
+
+    const merged = [...byId.values()].sort((a, b) => (a.savedAt < b.savedAt ? 1 : -1))
+    persist(merged)
+    await pushSavedItemsToDB(userId, toPush)
+
+    if (import.meta.env.DEV) {
+      console.log(
+        '[savedItemsStore] syncSavedItems complete:',
+        `remote=${remote.length}`,
+        `local=${local.length}`,
+        `merged=${merged.length}`,
+        `pushed=${toPush.length}`,
+      )
+    }
+  } catch (e) {
+    console.warn('[savedItemsStore] syncSavedItems failed:', e)
+  }
 }

--- a/src/strategyLessonsEn.ts
+++ b/src/strategyLessonsEn.ts
@@ -59,6 +59,33 @@ export const strategyLessonMapEn: Record<number, LessonData> = {
         title: 'The first to systematize "strategy"',
         content:
           'In 1965, Igor Ansoff in "Corporate Strategy" presented strategy as a systematic framework for the first time. He defined strategy as "the decision about which direction the company will grow."\n\nFamous above all is the "Ansoff Matrix." With "products (existing / new)" on one axis and "markets (existing / new)" on the other, growth options are organized into four quadrants.\n\nThis simple 2×2 turned a vague "we want to grow" into the concrete question "in which direction?"',
+        outro:
+          'Translating "we want to grow" into "which of these four quadrants are we betting on" instantly makes the discussion concrete. Whether you choose market penetration, new product, new market, or diversification comes down to each company\'s resources and tolerance for risk.',
+        visual: 'Two2MatrixDiagram',
+        visualProps: {
+          sectionLabel: 'Ansoff Matrix — Product × Market',
+          xAxis: { low: 'Existing market', high: 'New market', label: 'Market' },
+          yAxis: { low: 'Existing product', high: 'New product', label: 'Product' },
+          cells: [
+            {
+              title: '② New product development',
+              items: ['New product to same customers', 'Leverage existing brand'],
+            },
+            {
+              title: '④ Diversification (high risk)',
+              items: ['Enter wholly new domains', 'Synergy design is the key'],
+            },
+            {
+              title: '① Market penetration (safest)',
+              items: ['Grow share', 'Promotion, pricing, LTV gains'],
+            },
+            {
+              title: '③ New market development',
+              items: ['Overseas or new segment', 'Channel build-out required'],
+            },
+          ],
+          hint: 'The further top-right you go, the more unknowns and risk pile up. Diversification lives or dies on whether the "2 + 2 = 5" synergy actually shows up.',
+        },
       },
       {
         type: 'explain',
@@ -109,6 +136,9 @@ export const strategyLessonMapEn: Record<number, LessonData> = {
         title: 'Meaning of the four quadrants and resource allocation',
         content:
           'Cash cow (high share × low growth): generates cash. Profitable without further investment.\nStar (high share × high growth): needs investment to maintain growth. The future cash cow.\nQuestion mark (low share × high growth): with share gain, becomes a star. Cut or commit.\nDog (low share × low growth): consider exit.\n\nThe basic logic: "earn from cash cows, invest in question marks to grow them into stars, and eventually turn them into cash cows." It is a tool to make the "money flow across businesses" visible.',
+        outro:
+          'PPM is the device that makes the cash flow across your whole portfolio visible. How much of the cash cow\'s profit should be routed into the up-and-coming question marks? Once you can argue the rationale through these four quadrants, board-room debates change in tone.',
+        visual: 'Two2MatrixDiagram',
       },
       {
         type: 'quiz',
@@ -147,6 +177,9 @@ export const strategyLessonMapEn: Record<number, LessonData> = {
         title: 'The structure that splits "profitable industries from unprofitable ones"',
         content:
           'In 1980, Michael Porter in "Competitive Strategy" argued that "industry profitability is determined by five forces." This is Five Forces analysis.\n\n① Rivalry within the industry — how fierce the price wars are among competitors.\n② Threat of new entrants — low entry barriers thin out profits.\n③ Threat of substitutes — products in adjacent categories that can satisfy customers instead.\n④ Bargaining power of buyers — strong customers can force price cuts.\n⑤ Bargaining power of suppliers — strong suppliers raise costs.\n\nThe essence of Five Forces is a lens that diagnoses "whether an industry is structurally profitable."',
+        outro:
+          'Five Forces is the lens that decides "is this an industry where effort can earn a profit, or one that is structurally unprofitable?" The same effort produces wildly different results depending on the industry, so it is the analysis you should run once both before entry and at any exit decision.',
+        visual: 'FiveForcesDiagram',
       },
       {
         type: 'explain',
@@ -191,6 +224,9 @@ export const strategyLessonMapEn: Record<number, LessonData> = {
         title: 'There are only three ways to win',
         content:
           'In a follow-up, Porter argued that "within an industry, only three generic strategies can win." ① Cost leadership, ② Differentiation, ③ Focus.\n\n① Cost leadership: produce at the lowest cost in the industry. You can sell the same product cheaper, or earn more on the same price. Scale, the experience curve, and efficient operations are the weapons.\n② Differentiation: provide unique value that customers will pay extra for. Build difference through brand, quality, technology, or experience.\n③ Focus: specialize in a particular segment and play either ① or ② within that narrow market.',
+        outro:
+          'Cost, differentiation, and focus are an either-or choice — mixing them half-heartedly lands you in the "stuck in the middle" zone where none of them wins. A clear call about which axis you will win on, grounded in your own strengths and the structure of the market, is the decisive move.',
+        visual: 'TriadDiagram',
       },
       {
         type: 'explain',
@@ -241,6 +277,9 @@ export const strategyLessonMapEn: Record<number, LessonData> = {
         title: 'VRIO — diagnosing resources with four questions',
         content:
           'Barney\'s framework checks whether a resource generates competitive advantage with four questions. This is VRIO.\n\nV (Valuable) — does the resource create customer value?\nR (Rare) — is it rare among competitors?\nI (Inimitable) — is it hard to imitate? (historical paths, social complexity, causal ambiguity)\nO (Organized) — is the organization set up to leverage it?\n\nIf all four are "yes," the resource yields "sustained competitive advantage." Miss even one, and the value won\'t last.\n\nExample: Starbucks\' barista service know-how is valuable, scarce among other chains, embedded in culture and hard to imitate, and organized around store operations → sustained advantage.',
+        outro:
+          'The four VRIO questions act as filters that get progressively stricter. V alone is something anyone can hold, R adds rarity, I means imitation is hard, and only when O is also satisfied do you have sustained advantage. Running your strengths through the four-step sieve is what surfaces the resources that actually win.',
+        visual: 'VrioDiagram',
       },
       {
         type: 'think',

--- a/src/syncService.ts
+++ b/src/syncService.ts
@@ -10,6 +10,13 @@
  */
 
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { isDeviceSyncEnabled, HEAVY_USER_THRESHOLDS } from './featureFlags'
+import { syncFlashcards, loadCards } from './flashcardData'
+import { syncWrongAnswers } from './wrongAnswerStore'
+import { syncSavedItems } from './savedItemsStore'
+import { syncNotebook, loadEntries } from './notebookStore'
+import { syncRoadmap } from './roadmapStore'
+import { syncCategoryProgress } from './progressStore'
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || ''
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || ''
@@ -280,6 +287,42 @@ export async function syncOnLogin(userId: string): Promise<void> {
 
     if (import.meta.env.DEV) {
       console.log('[sync] Login sync complete. Lessons:', merged.completedLessons.length)
+    }
+
+    // Phase 1 Device Sync: feature flag が ON のときだけ追加同期を走らせる
+    if (isDeviceSyncEnabled()) {
+      // ヘビーユーザー判定 (移行時のトレースログ用、UI は silent)
+      try {
+        const cardCount = loadCards().length
+        const notebookCount = loadEntries().length
+        if (
+          cardCount >= HEAVY_USER_THRESHOLDS.flashcards ||
+          notebookCount >= HEAVY_USER_THRESHOLDS.notebook
+        ) {
+          console.warn('[sync] heavy user detected', {
+            userId,
+            flashcards: cardCount,
+            notebook: notebookCount,
+          })
+        }
+      } catch { /* */ }
+
+      const t0 = Date.now()
+      const results = await Promise.allSettled([
+        syncFlashcards(userId),
+        syncWrongAnswers(userId),
+        syncSavedItems(userId),
+        syncNotebook(userId),
+        syncRoadmap(userId),
+        syncCategoryProgress(userId),
+      ])
+      const failures = results.filter((r) => r.status === 'rejected')
+      if (failures.length > 0) {
+        console.warn('[sync] Phase 1 device sync had failures:', failures.length)
+      }
+      if (import.meta.env.DEV) {
+        console.log(`[sync] device sync complete in ${Date.now() - t0}ms`)
+      }
     }
   } catch (e) {
     console.warn('[sync] syncOnLogin failed:', e)

--- a/src/systemsThinkingLessonsEn.ts
+++ b/src/systemsThinkingLessonsEn.ts
@@ -32,6 +32,9 @@ const systemsIntro: LessonData = {
       title: 'Feedback loops — Cycles of cause and effect',
       content:
         'The heart of a system is the feedback loop.\n\n[Reinforcing loop]\nThe output amplifies the input → snowballs.\n\nVirtuous example:\nGreat product → more word of mouth → more sales → more R&D investment → even better product.\n\nVicious example:\nQuality drops → more complaints → more handling cost → less R&D capacity → quality drops further.\n\n[Balancing loop]\nThe output suppresses the input → moves toward equilibrium.\n\nExamples:\nBody temperature rises → sweat → temperature drops.\nService gains popularity → crowds → wait times rise → popularity drops → it empties out.\n\nIn business:\nWhen you find a virtuous loop, push it as hard as you can.\nWhen you find a vicious loop, break the chain.',
+      visual: 'FeedbackLoopDiagram',
+      outro:
+        'Reinforcing loops amplify, balancing loops settle toward equilibrium. Push a virtuous loop with everything you have, and cut a vicious loop before it gathers momentum — just being able to tell the two apart changes how much your interventions move the system.',
     },
     {
       type: 'quiz',
@@ -50,6 +53,9 @@ const systemsIntro: LessonData = {
       title: 'The Iceberg Model — Look beneath the surface',
       content:
         'A core systems-thinking tool, the Iceberg Model:\n\nAbove water — Events\n"Sales dropped 10% last month."\n→ Reactive: "Pressure the sales team."\n\nJust below — Patterns\n"Sales drop every Q3."\n→ Adaptive: "Plan ahead for Q3."\n\nDeeper — Structures\n"Sales incentives are skewed toward Q4, so Q3 activity dies."\n→ Generative: "Redesign the incentive scheme to be even across quarters."\n\nDeepest — Mental Models\n"We can always make it up in Q4." (an organizational belief)\n→ Transformative: "Shift the culture toward steady year-round revenue."\n\nReacting only to events does not solve the problem at the root.\nUnless you change structure and mental models, the same issue keeps recurring.',
+      visual: 'IcebergModelDiagram',
+      outro:
+        'The four layers of the Iceberg Model — events, patterns, structures, mental models — gain leverage as you go deeper. Reacting only at the surface guarantees the issue returns, so the perspective that descends all the way to structure and mental models is what cracks recurring problems open.',
     },
     {
       type: 'quiz',
@@ -76,6 +82,9 @@ const systemsLoops: LessonData = {
       title: 'System archetypes',
       content:
         'Knowing the recurring system archetypes lets you diagnose business problems quickly.\n\n[Archetype 1: Fixes that Fail]\nTreat the symptom → improve briefly → side effects → problem worsens.\n\nExample:\nUse overtime to clear a project delay.\n→ Hit the deadline short term.\n→ Staff burn out, attrition rises.\n→ Next project is even more delayed by understaffing.\n\nLesson: A fix only postpones the problem. Address the root cause.\n\n[Archetype 2: Success to the Successful]\nThe successful unit gets more resources → succeeds even more → other units decline.\n\nExample:\nBudget increases for high-performing division A → A grows further.\nB\'s budget shrinks → B underperforms → "B has weak capabilities."\n→ But it is really resource allocation, not capability.',
+      visual: 'SystemArchetypeDiagram',
+      outro:
+        'Problems that recur inside organizations almost always map to a known archetype. Carrying patterns like "Fixes that Fail" and "Success to the Successful" in your toolkit lets you diagnose the structure quickly and side-step common traps before they bite.',
     },
     {
       type: 'quiz',
@@ -138,6 +147,9 @@ const systemsPractice: LessonData = {
       title: 'Drawing causal loop diagrams',
       content:
         'A causal loop diagram is a practical systems-thinking tool.\n\nHow to draw one:\n1. List the variables (use nouns whose levels can rise or fall).\n2. Connect them with arrows showing causation.\n3. Mark each arrow with "+" (same direction) or "-" (opposite direction).\n4. Find loops and label them R (reinforcing) or B (balancing).\n\nExample: software development quality\n\n[Dev speed] -→(-) [Test time]\n[Test time] -→(+) [Quality]\n[Quality] -→(-) [Bug-fix time]\n[Bug-fix time] -→(-) [Dev speed]\n\n→ A vicious cycle emerges: "Dev speed up → less test time → quality drops → more bugs → dev speed drops."\n\nCountermeasure: How can we keep test time while raising dev speed?\n→ Automated tests, CI/CD, better code review.',
+      visual: 'CausalLoopDiagram',
+      outro:
+        'A causal loop diagram is the device that pulls the fuzzy web of relationships out of your head and onto a shared screen. Listing variables, marking each arrow with plus or minus, and surfacing the loops — that act itself is what reveals the vicious cycles and points to the countermeasures.',
     },
     {
       type: 'quiz',

--- a/src/visuals/AbsoluteVsRelativeVisual.tsx
+++ b/src/visuals/AbsoluteVsRelativeVisual.tsx
@@ -5,6 +5,12 @@ import './visuals-phase3c.css'
  * lesson-42 step.2 / lesson-401 visual='AbsoluteVsRelativeDiagram'
  *
  * 構図: 共通の事実カード上に、2 つの見せ方カード（絶対値 / 相対値）を並べる
+ *
+ * A 案 Phase 3 適用済 (2026-05-24, §3.1 §2.4 準拠):
+ *   - inline hint 11→13, padding/lineHeight 拡大
+ *   - CSS: avr-fact-label 11→12, fact-text 15→16, card-tag 11→12, card-impression 13→14
+ *   - warm accent: hint ボックスを terracotta soft 背景に
+ *     (relative の rose は §2.3 例外として意味色を維持、ヒント 1 箇所のみ温度感色)
  */
 
 export function AbsoluteVsRelativeVisual() {
@@ -41,14 +47,15 @@ export function AbsoluteVsRelativeVisual() {
       </div>
 
       <div style={{
-        marginTop: 12,
-        padding: '8px 10px',
-        background: 'var(--warning-soft)',
+        marginTop: 14,
+        padding: '10px 12px',
+        background: 'var(--visual-warm-primary-soft)',
         borderRadius: 8,
-        fontSize: 11,
+        fontSize: 13,
         fontWeight: 600,
-        color: '#92400E',
+        color: 'var(--visual-warm-primary-deep)',
         textAlign: 'center',
+        lineHeight: 1.45,
       }}>
         ⚠ 「% 増」だけ語る相手は要注意。元の数を必ず確認する
       </div>

--- a/src/visuals/DistributionShapeVisual.tsx
+++ b/src/visuals/DistributionShapeVisual.tsx
@@ -6,6 +6,12 @@ import './visuals-phase3c.css'
  *
  * 構図: 横並び 2 カード (左: 正規分布 / 右: 右に裾長い歪み分布)
  * 各カードに分布曲線 + 平均ライン (brand) + 中央値ライン (success)
+ *
+ * A 案 Phase 3 適用済 (2026-05-24, §3.1 §2.4 準拠):
+ *   - inline hint 11→13, padding/lineHeight 拡大、warning 意味色は維持
+ *   - CSS: ds-card-title 13→14、ds-legend 12→13
+ *   - warm accent: hint ボックスを terracotta soft 背景に
+ *     (skewed の warning 色は §2.3 例外として意味色を維持、ヒント 1 箇所のみ温度感色)
  */
 
 export function DistributionShapeVisual() {
@@ -78,14 +84,15 @@ export function DistributionShapeVisual() {
       </div>
 
       <div style={{
-        marginTop: 12,
-        padding: '8px 10px',
-        background: 'var(--warning-soft)',
+        marginTop: 14,
+        padding: '10px 12px',
+        background: 'var(--visual-warm-primary-soft)',
         borderRadius: 8,
-        fontSize: 11,
+        fontSize: 13,
         fontWeight: 600,
-        color: '#92400E',
+        color: 'var(--visual-warm-primary-deep)',
         textAlign: 'center',
+        lineHeight: 1.45,
       }}>
         ⚠ 年収・売上などは右に歪んでいる。平均だけ見ると実態を誤る
       </div>

--- a/src/visuals/ExponentialCurveVisual.tsx
+++ b/src/visuals/ExponentialCurveVisual.tsx
@@ -6,6 +6,12 @@ import './visuals-phase3c.css'
  *
  * 構図: 折れ線グラフ (時間軸 / Y軸) で線形 vs 指数(年率10%複利) を重ねる
  * 下に 3 つのスポット (Year 5 / 10 / 20) で差を数値で示す
+ *
+ * A 案 Phase 3 適用済 (2026-05-24, §3.1 §2.4 準拠):
+ *   - inline hint 11→13, padding/lineHeight 拡大
+ *   - CSS: ec-point .yr 11→12, .val 15→16, .vs 11→12
+ *   - warm accent: SVG 内 "×6.7倍" ラベルを terracotta に
+ *     (指数増加の最終インパクト = 「複利が爆発する」動きの主役 = 1 visual 内 1 箇所)
  */
 
 export function ExponentialCurveVisual() {
@@ -70,7 +76,9 @@ export function ExponentialCurveVisual() {
 
             {/* ラベル */}
             <text x={sx(20) - 4} y={sy(100 + 20 * 10) + 12} fontSize="7" fill="var(--text-muted)" textAnchor="end" fontWeight="700">+300</text>
-            <text x={sx(20) - 4} y={sy(100 * Math.pow(1.1, 20)) - 4} fontSize="8" fill="var(--brand)" textAnchor="end" fontWeight="700">×6.7倍</text>
+            {/* warm accent (A 案 Phase 3): 指数の最終インパクト ×6.7 倍を terracotta
+             * (複利が爆発する瞬間 = 1 visual 内 1 箇所) */}
+            <text x={sx(20) - 4} y={sy(100 * Math.pow(1.1, 20)) - 4} fontSize="9" fill="var(--visual-warm-primary)" textAnchor="end" fontWeight="700">×6.7倍</text>
           </svg>
         </div>
 
@@ -95,14 +103,15 @@ export function ExponentialCurveVisual() {
       </div>
 
       <div style={{
-        marginTop: 12,
-        padding: '8px 10px',
+        marginTop: 14,
+        padding: '10px 12px',
         background: 'var(--brand-soft)',
         borderRadius: 8,
-        fontSize: 11,
+        fontSize: 13,
         fontWeight: 600,
         color: 'var(--brand)',
         textAlign: 'center',
+        lineHeight: 1.45,
       }}>
         💡 序盤は差がなくても、時間が複利の効果を爆発させる
       </div>

--- a/src/visuals/FallacyGridVisual.tsx
+++ b/src/visuals/FallacyGridVisual.tsx
@@ -5,6 +5,12 @@ import './visuals-phase3c.css'
  * lesson-41 step.visual='FallacyGridDiagram'
  *
  * 構図: 縦並びカード 5 枚、各カードに記号アイコン + 名称 + 1 行説明
+ *
+ * A 案 Phase 3 適用済 (2026-05-24, §3.1 §2.4 準拠):
+ *   - inline hint 11→13, padding/lineHeight 拡大、warning-deep token 化
+ *   - CSS: fg-name 14px / fg-desc 13px は既に底上げ済 (調整不要)
+ *   - warm accent: hint ボックスを terracotta soft 背景に
+ *     (5 カード全部 rose 系で警告色統一、注意喚起 1 箇所のみ温度感色)
  */
 
 type Fallacy = {
@@ -61,14 +67,15 @@ export function FallacyGridVisual() {
       </div>
 
       <div style={{
-        marginTop: 12,
-        padding: '8px 10px',
-        background: 'var(--warning-soft)',
+        marginTop: 14,
+        padding: '10px 12px',
+        background: 'var(--visual-warm-primary-soft)',
         borderRadius: 8,
-        fontSize: 11,
+        fontSize: 13,
         fontWeight: 600,
-        color: '#92400E',
+        color: 'var(--visual-warm-primary-deep)',
         textAlign: 'center',
+        lineHeight: 1.45,
       }}>
         ⚠ 自分が使ってしまっていないかも合わせて点検する
       </div>

--- a/src/visuals/FermiBaseDataVisual.tsx
+++ b/src/visuals/FermiBaseDataVisual.tsx
@@ -17,6 +17,11 @@ import './visuals-fermi.css'
  * design rationale:
  *   - 数字暗記モノは「読みやすさ > 派手さ」。フォントは大きめ・行間は広く
  *   - カテゴリは color-coded だがいずれもブランド系トーン内（accent カラーは使用しない）
+ *
+ * A 案 Phase 3 適用済 (2026-05-24, §3.1 §2.4 準拠):
+ *   - CSS: cat-summary 11→12, unit 11→12, label 12→13, note 10→12, hint 11→13
+ *   - warm accent: vz-fermi-bd-hint を terracotta soft 背景に
+ *     (6 カテゴリは tone color-coded で各自意味あり、暗記の動機付け 1 箇所のみ温度感色)
  */
 
 type Entry = {

--- a/src/visuals/FermiStepsVisual.tsx
+++ b/src/visuals/FermiStepsVisual.tsx
@@ -7,6 +7,12 @@ import { useStepReveal } from './hooks/useStepReveal'
  *
  * 構図: Stack（順序フロー）4 段、最終ステップ（統合検算）を結論カラーで強調
  * 段階開示: Step 1..4 — ステップを 1 つずつ表示
+ *
+ * A 案 Phase 3 適用済 (2026-05-24, §3.1 §2.4 準拠):
+ *   - inline hint 11→13, padding/lineHeight 拡大
+ *   - CSS: vz-fs-label 11→12, vz-fs-title 15→16
+ *   - warm accent: vz-fs-arrow ↓ を terracotta (step を進める動き)
+ *     (.final は brand-cta-grad 維持、矢印が唯一の動き起点 = 1 visual 内 1 箇所)
  */
 
 type Step = {
@@ -76,14 +82,15 @@ export function FermiStepsVisual({ revealMode = 'interactive' }: Props = {}) {
       {isLast && (
         <div
           style={{
-            marginTop: 12,
-            padding: '8px 10px',
+            marginTop: 14,
+            padding: '10px 12px',
             background: 'var(--brand-soft)',
             borderRadius: 8,
-            fontSize: 11,
+            fontSize: 13,
             fontWeight: 600,
             color: 'var(--brand)',
             textAlign: 'center',
+            lineHeight: 1.45,
           }}
         >
           💡 STEP 4 の検算がフェルミ推定の質を決める。一発回答で終わらせない。

--- a/src/visuals/MentalMathDecisionTreeVisual.tsx
+++ b/src/visuals/MentalMathDecisionTreeVisual.tsx
@@ -5,6 +5,12 @@ import './visuals-phase3c.css'
  * lesson-400 step.9 visual='MentalMathDecisionTreeDiagram'
  *
  * 構図: ルート 1 → 第 1 階層 3 分岐（×100 系 / 近似 / 分解）
+ *
+ * A 案 Phase 3 適用済 (2026-05-24, §3.1 §2.4 準拠):
+ *   - inline hint 11→13, padding/lineHeight 拡大
+ *   - CSS: mmd-cond 12px / mmd-tech 14px / mmd-ex 12px / mmd-root 14px は既に底上げ済
+ *   - warm accent: vz-mmd-row-label ↓ を terracotta deep に格上げ
+ *     (ルート → 3 分岐を結ぶ「判別の動き」 = 1 visual 内 1 箇所)
  */
 
 type Branch = {
@@ -57,14 +63,15 @@ export function MentalMathDecisionTreeVisual() {
       </div>
 
       <div style={{
-        marginTop: 12,
-        padding: '8px 10px',
+        marginTop: 14,
+        padding: '10px 12px',
         background: 'var(--brand-soft)',
         borderRadius: 8,
-        fontSize: 11,
+        fontSize: 13,
         fontWeight: 600,
         color: 'var(--brand)',
         textAlign: 'center',
+        lineHeight: 1.45,
       }}>
         💡 最初に形を判別する習慣をつけると、計算速度が一段上がる
       </div>

--- a/src/visuals/WhyWhyEvidenceVisual.tsx
+++ b/src/visuals/WhyWhyEvidenceVisual.tsx
@@ -22,6 +22,12 @@ type Props = {
 /**
  * なぜなぜ各層の裏付け — 層ごとに「事実の検証手段」を併記
  * lesson-345 step.visual='WhyWhyEvidenceDiagram'
+ *
+ * A 案 Phase 3 適用済 (2026-05-24, §3.1 §2.4 準拠):
+ *   - inline hint 11→13, padding/lineHeight 拡大、warning token 化済
+ *   - CSS: vz-ww-evidence-method-tag 11→12, method-text 13.5→14, layer 13→14
+ *   - warm accent: vz-ww-evidence-arrow ↔ を terracotta
+ *     (層と検証手段を結ぶ「裏付け」の動きを示す矢印 = 1 visual 内 1 箇所)
  */
 export function WhyWhyEvidenceVisual({ revealMode = 'interactive' }: Props = {}) {
   const { step, isLast, controls } = useStepReveal({ totalSteps: rows.length, mode: revealMode })
@@ -50,14 +56,15 @@ export function WhyWhyEvidenceVisual({ revealMode = 'interactive' }: Props = {})
       {isLast && (
         <div
           style={{
-            marginTop: 12,
-            padding: '8px 10px',
+            marginTop: 14,
+            padding: '10px 12px',
             background: 'var(--warning-soft)',
             borderRadius: 8,
-            fontSize: 11,
+            fontSize: 13,
             fontWeight: 600,
             color: 'var(--warning)',
             textAlign: 'center',
+            lineHeight: 1.45,
           }}
         >
           ⚠ 空欄の層は「仮説のまま」 — 打ち手の前に裏付けを取る

--- a/src/visuals/WhyWhyParallelVisual.tsx
+++ b/src/visuals/WhyWhyParallelVisual.tsx
@@ -15,6 +15,12 @@ const branches: Branch[] = [
 /**
  * なぜなぜ並行ループ — 1階層に複数の枝
  * lesson-344 step.visual='WhyWhyParallelDiagram'
+ *
+ * A 案 Phase 3 適用済 (2026-05-24, §3.1 §2.4 準拠):
+ *   - inline hint 11→13, padding/lineHeight 拡大
+ *   - CSS: branch-label 12→13, branch-sub 11→12, branch-deeper 11→12
+ *   - warm accent: vz-ww-parallel-svg の分岐ライン 4 本を terracotta
+ *     (1 → 4 への「分岐の動き」を示す矢印的要素 = 1 visual 内 1 箇所)
  */
 export function WhyWhyParallelVisual() {
   return (
@@ -33,10 +39,12 @@ export function WhyWhyParallelVisual() {
             preserveAspectRatio="none"
             aria-hidden="true"
           >
-            <line x1="160" y1="0" x2="40"  y2="24" stroke="var(--text-muted)" strokeWidth="1.4" />
-            <line x1="160" y1="0" x2="120" y2="24" stroke="var(--text-muted)" strokeWidth="1.4" />
-            <line x1="160" y1="0" x2="200" y2="24" stroke="var(--text-muted)" strokeWidth="1.4" />
-            <line x1="160" y1="0" x2="280" y2="24" stroke="var(--text-muted)" strokeWidth="1.4" />
+            {/* warm accent (A 案 Phase 3): 分岐ラインを terracotta に。
+             * 「ルートから 4 枝へ分岐する動き」が 1 visual の主役 = 1 箇所限定 */}
+            <line x1="160" y1="0" x2="40"  y2="24" stroke="var(--visual-warm-primary)" strokeWidth="1.4" />
+            <line x1="160" y1="0" x2="120" y2="24" stroke="var(--visual-warm-primary)" strokeWidth="1.4" />
+            <line x1="160" y1="0" x2="200" y2="24" stroke="var(--visual-warm-primary)" strokeWidth="1.4" />
+            <line x1="160" y1="0" x2="280" y2="24" stroke="var(--visual-warm-primary)" strokeWidth="1.4" />
           </svg>
         </div>
 
@@ -53,14 +61,15 @@ export function WhyWhyParallelVisual() {
 
       <div
         style={{
-          marginTop: 12,
-          padding: '8px 10px',
+          marginTop: 14,
+          padding: '10px 12px',
           background: 'var(--brand-soft)',
           borderRadius: 8,
-          fontSize: 11,
+          fontSize: 13,
           fontWeight: 600,
           color: 'var(--brand)',
           textAlign: 'center',
+          lineHeight: 1.45,
         }}
       >
         💡 各枝を独立に深掘り、インパクト × 実現可能性で優先順位

--- a/src/visuals/WhyWhyPitfallsVisual.tsx
+++ b/src/visuals/WhyWhyPitfallsVisual.tsx
@@ -35,6 +35,12 @@ const pitfalls: Pitfall[] = [
 /**
  * なぜなぜ分析の3つの落とし穴
  * lesson-343 step.visual='WhyWhyPitfallsDiagram'
+ *
+ * A 案 Phase 3 適用済 (2026-05-24, §3.1 §2.4 準拠):
+ *   - inline hint 11→13, padding/lineHeight 拡大
+ *   - CSS: pitfall は既に 13/14px で底上げ済、調整なし
+ *   - warm accent: vz-ww-pitfall-icon (head アイコン) を terracotta に
+ *     (落とし穴の象徴アイコン = 注意喚起の動き起点 = 1 visual 内 1 箇所)
  */
 export function WhyWhyPitfallsVisual() {
   return (
@@ -68,14 +74,15 @@ export function WhyWhyPitfallsVisual() {
 
       <div
         style={{
-          marginTop: 12,
-          padding: '8px 10px',
+          marginTop: 14,
+          padding: '10px 12px',
           background: 'var(--brand-soft)',
           borderRadius: 8,
-          fontSize: 11,
+          fontSize: 13,
           fontWeight: 600,
           color: 'var(--brand)',
           textAlign: 'center',
+          lineHeight: 1.45,
         }}
       >
         💡 人ではなく仕組み、飛躍させず1段ずつ、具体的に

--- a/src/visuals/WhyWhyStopRuleVisual.tsx
+++ b/src/visuals/WhyWhyStopRuleVisual.tsx
@@ -4,6 +4,12 @@ import { XIcon, CheckIcon, LightbulbIcon } from '../icons'
 /**
  * なぜなぜの止めどき — 浅すぎ / 適切 / 深すぎ
  * lesson-342 step.visual='WhyWhyStopRuleDiagram'
+ *
+ * A 案 Phase 3 適用済 (2026-05-24, §3.1 §2.4 準拠):
+ *   - inline hint 11→13, padding/lineHeight 拡大
+ *   - CSS: stop-tag/result 12px、stop-ex 13px、stop-label 14px は既に底上げ済
+ *   - warm accent: hint ボックスを terracotta soft 背景に
+ *     (3 ゾーンの danger/success/warning 意味色は §2.3 例外として維持)
  */
 export function WhyWhyStopRuleVisual() {
   return (
@@ -55,14 +61,15 @@ export function WhyWhyStopRuleVisual() {
 
       <div
         style={{
-          marginTop: 12,
-          padding: '8px 10px',
-          background: 'var(--brand-soft)',
+          marginTop: 14,
+          padding: '10px 12px',
+          background: 'var(--visual-warm-primary-soft)',
           borderRadius: 8,
-          fontSize: 11,
+          fontSize: 13,
           fontWeight: 600,
-          color: 'var(--brand)',
+          color: 'var(--visual-warm-primary-deep)',
           textAlign: 'center',
+          lineHeight: 1.45,
         }}
       >
         💡 「自分たちで打ち手が打てる層」で止める

--- a/src/visuals/WhyWhySymptomVsRootVisual.tsx
+++ b/src/visuals/WhyWhySymptomVsRootVisual.tsx
@@ -4,6 +4,12 @@ import { BandageIcon, SearchIcon } from '../icons'
 /**
  * 対症療法 vs 根本治療 — なぜなぜ分析の対立軸
  * lesson-340 step.visual='WhyWhySymptomVsRootDiagram'
+ *
+ * A 案 Phase 3 適用済 (2026-05-24, §3.1 §2.4 準拠):
+ *   - inline hint 11→13, padding/lineHeight 拡大
+ *   - CSS: sr-text strong 14px / sr-text span 13px / sr-result 13px は既に底上げ済
+ *   - warm accent: hint ボックスを terracotta soft 背景に
+ *     (bad/good の danger/success 意味色は §2.3 例外として維持)
  */
 export function WhyWhySymptomVsRootVisual() {
   return (
@@ -42,14 +48,15 @@ export function WhyWhySymptomVsRootVisual() {
 
       <div
         style={{
-          marginTop: 12,
-          padding: '8px 10px',
-          background: 'var(--brand-soft)',
+          marginTop: 14,
+          padding: '10px 12px',
+          background: 'var(--visual-warm-primary-soft)',
           borderRadius: 8,
-          fontSize: 11,
+          fontSize: 13,
           fontWeight: 600,
-          color: 'var(--brand)',
+          color: 'var(--visual-warm-primary-deep)',
           textAlign: 'center',
+          lineHeight: 1.45,
         }}
       >
         💡 「なぜ？」を重ねて根本原因まで降りる

--- a/src/visuals/WhyWhyVsLogicTreeVisual.tsx
+++ b/src/visuals/WhyWhyVsLogicTreeVisual.tsx
@@ -3,6 +3,12 @@ import './visuals-whywhy.css'
 /**
  * なぜなぜ（縦に深く）vs Why ツリー（横に広く）
  * lesson-340 step.visual='WhyWhyVsLogicTreeDiagram'
+ *
+ * A 案 Phase 3 適用済 (2026-05-24, §3.1 §2.4 準拠):
+ *   - inline hint 11→13, padding/lineHeight 拡大
+ *   - CSS: vbox 13→14, hroot 13→14, hleaf 12→13
+ *   - warm accent: vbox.root (左カラム = 根本原因 = なぜなぜの到達点) を terracotta gradient
+ *     (縦深掘りの到達ゴールを 1 visual 内 1 箇所だけ温度感色で示す)
  */
 export function WhyWhyVsLogicTreeVisual() {
   return (
@@ -54,14 +60,15 @@ export function WhyWhyVsLogicTreeVisual() {
 
       <div
         style={{
-          marginTop: 12,
-          padding: '8px 10px',
+          marginTop: 14,
+          padding: '10px 12px',
           background: 'var(--brand-soft)',
           borderRadius: 8,
-          fontSize: 11,
+          fontSize: 13,
           fontWeight: 600,
           color: 'var(--brand)',
           textAlign: 'center',
+          lineHeight: 1.45,
         }}
       >
         💡 深掘りは「なぜなぜ」、網羅は「Why ツリー」

--- a/src/visuals/visuals-fermi.css
+++ b/src/visuals/visuals-fermi.css
@@ -127,7 +127,7 @@
   letter-spacing: 0.03em;
 }
 .vz-fermi-bd-cat-summary {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
   color: var(--text-muted);
   letter-spacing: 0.02em;
@@ -163,32 +163,34 @@
   letter-spacing: -0.01em;
 }
 .vz-fermi-bd-unit {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 700;
   color: var(--vz-tone);
   opacity: 0.85;
 }
 .vz-fermi-bd-label {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 700;
   color: var(--text-primary);
   line-height: 1.35;
 }
 .vz-fermi-bd-note {
-  font-size: 10px;
+  font-size: 12px;
   font-weight: 500;
   color: var(--text-muted);
   line-height: 1.35;
 }
 
+/* warm accent (A 案 Phase 3): hint ボックスを terracotta soft 背景に。
+ * 6 カテゴリは tone color-coded で意味色を維持、暗記の動機付け 1 箇所のみ温度感色 */
 .vz-fermi-bd-hint {
   margin-top: 4px;
-  padding: 8px 10px;
-  background: var(--brand-soft);
+  padding: 10px 12px;
+  background: var(--visual-warm-primary-soft);
   border-radius: 8px;
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 600;
-  color: var(--brand);
+  color: var(--visual-warm-primary-deep);
   text-align: center;
   line-height: 1.45;
 }

--- a/src/visuals/visuals-phase3c.css
+++ b/src/visuals/visuals-phase3c.css
@@ -68,7 +68,7 @@
 }
 
 .vz-fs-label {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 700;
   color: var(--brand);
   letter-spacing: 0.08em;
@@ -81,7 +81,7 @@
 }
 
 .vz-fs-title {
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 700;
   color: var(--text-primary);
   line-height: 1.3;
@@ -99,10 +99,12 @@
 
 .vz-fs-step.final .vz-fs-desc { color: #fff; opacity: 0.92; }
 
+/* warm accent (A 案 Phase 3): step を進める ↓ 矢印を terracotta に。
+ * final step は brand-cta-grad 維持、矢印が唯一の動き起点 = 1 visual 内 1 箇所 */
 .vz-fs-arrow {
   text-align: center;
-  font-size: 14px;
-  color: var(--brand);
+  font-size: 16px;
+  color: var(--visual-warm-primary);
   font-weight: 700;
   line-height: 1;
   margin: -2px 0;
@@ -173,10 +175,12 @@
   border-radius: 6px;
 }
 
+/* warm accent (A 案 Phase 3): ルート → 3 分岐を結ぶ「↓ パターン別の最適な技」を terracotta deep。
+ * 判別の動きを 1 visual 内 1 箇所だけ温度感色で示す */
 .vz-mmd-row-label {
   font-size: 12px;
   font-weight: 700;
-  color: var(--text-muted);
+  color: var(--visual-warm-primary-deep);
   text-align: center;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -200,7 +204,7 @@
 }
 
 .vz-ds-card-title {
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 700;
   color: var(--brand);
   text-align: center;
@@ -219,7 +223,7 @@
   display: flex;
   flex-direction: column;
   gap: 3px;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
 }
 
@@ -304,7 +308,7 @@
 }
 
 .vz-ec-point .yr {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 700;
   color: var(--text-muted);
   letter-spacing: 0.06em;
@@ -312,14 +316,14 @@
 }
 
 .vz-ec-point .val {
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 700;
   color: var(--brand);
   line-height: 1.1;
 }
 
 .vz-ec-point .vs {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
   color: var(--text-muted);
   line-height: 1.2;
@@ -341,7 +345,7 @@
 }
 
 .vz-avr-fact-label {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 700;
   color: var(--text-muted);
   letter-spacing: 0.08em;
@@ -349,7 +353,7 @@
 }
 
 .vz-avr-fact-text {
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 700;
   color: var(--text-primary);
   margin-top: 2px;
@@ -378,7 +382,7 @@
 }
 
 .vz-avr-card-tag {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -404,7 +408,7 @@
 .vz-avr-card.relative .vz-avr-card-number { color: var(--rose); }
 
 .vz-avr-card-impression {
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--text-secondary);
   line-height: 1.4;

--- a/src/visuals/visuals-whywhy.css
+++ b/src/visuals/visuals-whywhy.css
@@ -230,7 +230,7 @@
   color: var(--brand);
   border-radius: 8px;
   padding: 4px 10px;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 700;
   min-width: 80px;
   text-align: center;
@@ -240,11 +240,13 @@
   background: var(--brand-soft);
 }
 
+/* warm accent (A 案 Phase 3): 縦深掘りの到達ゴール (根本原因) のみ terracotta gradient。
+ * 右側 hroot は brand-pop のまま維持して 1 visual 内 warm 1 箇所を厳守 */
 .vz-ww-vs-vbox.root {
-  background: var(--brand-cta-grad);
+  background: linear-gradient(135deg, var(--visual-warm-primary) 0%, var(--visual-warm-primary-deep) 100%);
   color: #fff;
   border: none;
-  box-shadow: 0 4px 12px rgba(108, 142, 245, 0.28);
+  box-shadow: 0 4px 12px rgba(196, 117, 58, 0.28);
 }
 
 .vz-ww-vs-arrow {
@@ -267,7 +269,7 @@
   color: #fff;
   border-radius: 8px;
   padding: 4px 10px;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 700;
   box-shadow: 0 4px 12px rgba(124, 58, 237, 0.25);
 }
@@ -291,7 +293,7 @@
   color: var(--brand-pop);
   border-radius: 6px;
   padding: 3px 4px;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 700;
   text-align: center;
 }
@@ -451,8 +453,10 @@
   border-bottom: 1px solid var(--border-light);
 }
 
+/* warm accent (A 案 Phase 3): 各落とし穴の象徴アイコンを terracotta に。
+ * 「注意して見る」動きを 1 visual 内 1 箇所だけ温度感色で示す */
 .vz-ww-pitfall-icon {
-  color: var(--brand);
+  color: var(--visual-warm-primary);
 }
 
 .vz-ww-pitfall-title {
@@ -544,7 +548,7 @@
 .vz-ww-parallel-branch.tone-d { border-color: var(--brand); }
 
 .vz-ww-parallel-branch-label {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 700;
   text-align: center;
   line-height: 1.3;
@@ -556,7 +560,7 @@
 .vz-ww-parallel-branch.tone-d .vz-ww-parallel-branch-label { color: var(--brand); }
 
 .vz-ww-parallel-branch-sub {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
   color: var(--text-muted);
   letter-spacing: 0.04em;
@@ -566,7 +570,7 @@
   background: var(--bg-secondary);
   border-radius: 4px;
   padding: 2px 6px;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
 }
@@ -592,7 +596,7 @@
 }
 
 .vz-ww-evidence-layer {
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 700;
   padding: 4px 8px;
   border-radius: 6px;
@@ -613,9 +617,11 @@
 .vz-ww-evidence-row.t-4 .vz-ww-evidence-layer { border-color: var(--brand-hover); color: var(--brand-hover); }
 .vz-ww-evidence-row.t-5 .vz-ww-evidence-layer { border-color: var(--brand-hover); color: var(--brand-hover); }
 
+/* warm accent (A 案 Phase 3): 層 ↔ 検証手段を結ぶ矢印を terracotta に。
+ * 「裏付けを取る」という動きの主役を 1 visual 内 1 箇所だけ温度感色で示す */
 .vz-ww-evidence-arrow {
-  color: var(--text-muted);
-  font-size: 14px;
+  color: var(--visual-warm-primary);
+  font-size: 16px;
   font-weight: 700;
 }
 
@@ -626,7 +632,7 @@
 }
 
 .vz-ww-evidence-method-tag {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.06em;
   color: var(--text-muted);
@@ -634,7 +640,7 @@
 }
 
 .vz-ww-evidence-method-text {
-  font-size: 13.5px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--text-primary);
 }

--- a/src/whyWhyLessonsEn.ts
+++ b/src/whyWhyLessonsEn.ts
@@ -17,6 +17,8 @@ const whyWhyIntro: LessonData = {
       content:
         'You have a recurring headache. Two options:\n\nSymptom relief: take a painkiller (silence the pain temporarily)\nRoot-cause cure: find why the headache keeps coming back and remove the cause (sleep? posture? eyesight?)\n\nBusiness works the same way.\nJump on surface symptoms and they keep returning.\nReach the root cause and you can stop the recurrence.\n\n5 Whys is the most fundamental technique for getting from a surface symptom to its true cause.',
       visual: 'WhyWhySymptomVsRootDiagram',
+      outro:
+        'Telling symptoms apart from root causes is where 5 Whys begins. Every time a problem lands on your desk, pause and ask yourself: is this a painkiller or an actual cure? That single habit alone keeps a surprising share of recurring issues from coming back.',
     },
     {
       type: 'quiz',
@@ -36,6 +38,8 @@ const whyWhyIntro: LessonData = {
       content:
         '5 Whys uses "five" as a rough target, not a magic number. It is a heuristic.\n\n• 1–2 whys: you usually only restate the symptom\n• 3 whys: you reach the immediate cause\n• 4–5 whys: you reach the structural / system level\n• 6+ whys: often beyond your team\'s control (economy, society)\n\n"5" is a rough indicator that you have reached a layer where you can actually act.\nThe goal is not to hit five mechanically — it is to stop where your team has the authority to fix the structure.',
       visual: 'WhyWhyChainDiagram',
+      outro:
+        'Five is a signal that you have reached the structural layer, not a quota. If a real fix appears at the third why, stop there. If the sixth why drops you into external forces, step back up one. Judge by the quality of the layer, not the count.',
     },
     {
       type: 'quiz',
@@ -55,6 +59,8 @@ const whyWhyIntro: LessonData = {
       content:
         'They look similar but serve different goals.\n\n【5 Whys】\nDrill down a single phenomenon vertically.\nWhy → Why → Why in a single chain.\nGoal: pin down one root cause.\n\n【Why-tree (logic tree)】\nFan out a single phenomenon horizontally.\nList possible causes MECE-style.\nGoal: enumerate candidate causes and prioritize.\n\nIn practice you combine the two.\nFirst expand the Why-tree to surface candidates, then drill the most likely one with 5 Whys.',
       visual: 'WhyWhyVsLogicTreeDiagram',
+      outro:
+        '5 Whys digs vertically, the Why-tree spreads horizontally. Fan out the candidates first, then drill only the most likely branch. Skip the fan-out step and your deep dive can easily end up on the wrong cause entirely.',
     },
     {
       type: 'quiz',
@@ -89,6 +95,8 @@ const whyWhyToyota: LessonData = {
       content:
         'Ohno\'s most famous example:\n\nQ1: Why did the machine stop?\nA1: A fuse blew because of an overload.\n\nQ2: Why was there an overload?\nA2: The bearing was not lubricated enough.\n\nQ3: Why wasn\'t it lubricated enough?\nA3: The lubrication pump wasn\'t pumping enough oil.\n\nQ4: Why wasn\'t the pump pumping enough?\nA4: The pump shaft was worn and rattling.\n\nQ5: Why was the shaft worn?\nA5: There was no strainer attached, so metal scraps got in.\n\n→ Real fix: install a strainer.',
       visual: 'WhyWhyToyotaDiagram',
+      outro:
+        'Stopping at Q1 and replacing the fuse means the same failure returns within a week. Only when you reach Q5 — the missing strainer — does the recurrence end. Make "would the same failure happen again?" the acceptance test for your fix and you naturally stop at the right depth.',
     },
     {
       type: 'quiz',
@@ -171,6 +179,8 @@ const whyWhyBasicSteps: LessonData = {
       content:
         'Drilling too deep or too shallow both fail.\n\nStopping rule:\n• Have we reached a layer where our team has authority to act?\n• Are we hitting external factors ("the economy is bad," "population is shrinking")? — too deep\n\nExample: "Repeat rate dropped"\n→ Our product lost appeal (✓ actionable)\n→ Customers\' disposable income shrank (✗ external)\n\nWhen you hit external factors, accept them as a precondition and step back to the actionable layer.\n\nToo shallow:\n"Mr. A made a mistake" → unless you ask "why was there no system to catch it," it recurs.',
       visual: 'WhyWhyStopRuleDiagram',
+      outro:
+        'Stopping at a person blocks any real fix, while drilling into external forces is equally unactionable. The "system layer" your team can change is the right place to land. Keep that single rule in mind and depth questions usually answer themselves.',
     },
     {
       type: 'quiz',
@@ -199,6 +209,8 @@ const whyWhyPitfalls: LessonData = {
       content:
         'The most common failure: ending at "Mr. A was careless" or "the operator missed a check."\n\nWhen people are the cause:\n• It becomes blame, not prevention\n• Replace the person → the same issue returns\n• Future abnormalities go unreported because reporters get blamed\n\nFix: translate "a person did it" into "the system was missing X."\n\n× "Operator B mistyped a value"\n○ "There was no auto-validation on the input field"\n○ "There was no double-check process"\n○ "The manual was outdated and never updated"\n\nAsk the system, not the person. This is the iron rule of 5 Whys.',
       visual: 'WhyWhyPitfallsDiagram',
+      outro:
+        'Blaming a person, jumping a step, and abstracting too far are the three traps that gut a 5 Whys analysis. Once you have written an answer, take a moment to check which of the three you might have fallen into. That single self-check is what turns analysis into something that actually prevents recurrence.',
     },
     {
       type: 'quiz',
@@ -269,6 +281,8 @@ const whyWhyParallel: LessonData = {
       content:
         'At Why1, list candidate causes in parallel.\n\nRepeat rate ↓\n├ Product appeal ↓\n├ Delivery delays\n├ Support quality ↓\n└ Competitor pricing\n\nDrill each branch independently.\n\nHow to focus:\n• Rank branches by impact × feasibility\n• Factor in verification difficulty (how fast can you get evidence?)\n• You do not have to drill all branches 5 layers deep — start with the strongest\n\n5 Whys is a tree, not a line.',
       visual: 'WhyWhyParallelDiagram',
+      outro:
+        '5 Whys is a tree, not a straight line. List several candidates in parallel at Why 1, then pick the branch worth drilling based on impact and how easy it is to verify. Insist on a single chain and the true cause can quietly hide on a branch you never looked at.',
     },
     {
       type: 'quiz',
@@ -327,6 +341,8 @@ const whyWhyEvidence: LessonData = {
       content:
         'Even if Q→A repeats logically 5 times, every step might still be conjecture.\n\nExample: "Because the bearing was not lubricated enough."\n→ Did anyone actually verify the lubrication state? With what?\n\nEach layer is a hypothesis, not a fact.\nActing on unverified hypotheses risks burning time and money on the wrong fix.\n\nThe work of "backing each layer with evidence" is verification.\n5 Whys and hypothesis verification come as a pair.',
       visual: 'WhyWhyEvidenceDiagram',
+      outro:
+        'Without evidence, each layer is just an "elegant hypothesis." Refuse to commit a fix on any layer whose evidence column is still blank. Noting the source — data, observation, or interview — beside every answer is the simplest way to keep your countermeasures from missing the mark.',
     },
     {
       type: 'quiz',

--- a/src/wrongAnswerStore.ts
+++ b/src/wrongAnswerStore.ts
@@ -5,6 +5,9 @@
  * 独立したレコードとして localStorage に保存する。
  * 構造は将来 Supabase に同期できる粒度（id / lessonId / question / wrongAt …）で持たせる。
  */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getSupabaseClient } from './db/index'
+
 const STORAGE_KEY = 'logic-wrong-answers'
 
 export type WrongAnswerOption = { label: string; correct: boolean }
@@ -144,4 +147,198 @@ export function filterWrongAnswers(filter: WrongAnswerFilter = {}): WrongAnswer[
   if (lessonId != null) items = items.filter((i) => i.lessonId === lessonId)
   // 直近の誤答を上に
   return items.sort((a, b) => (a.wrongAt < b.wrongAt ? 1 : -1))
+}
+
+// =============================================
+// Supabase 同期 (Phase 1: Device Sync)
+// =============================================
+
+type WrongAnswerRow = {
+  lesson_id: number
+  lesson_title: string | null
+  category: string | null
+  question: string
+  correct_answer: string
+  selected_answer: string | null
+  explanation: string | null
+  options: WrongAnswerOption[] | null
+  wrong_at: string
+  resolved_at: string | null
+  retry_count: number
+  retry_correct_count: number
+}
+
+function rowToWrongAnswer(row: WrongAnswerRow): WrongAnswer {
+  return {
+    id: `${row.lesson_id}:${row.question}`,
+    lessonId: row.lesson_id,
+    lessonTitle: row.lesson_title ?? '',
+    category: row.category ?? '',
+    question: row.question,
+    correctAnswer: row.correct_answer,
+    selectedAnswer: row.selected_answer ?? '',
+    explanation: row.explanation ?? '',
+    options: row.options ?? undefined,
+    wrongAt: row.wrong_at,
+    resolvedAt: row.resolved_at,
+    retryCount: row.retry_count,
+    retryCorrectCount: row.retry_correct_count,
+  }
+}
+
+function wrongAnswerToRow(userId: string, w: WrongAnswer): Record<string, unknown> {
+  return {
+    user_id: userId,
+    lesson_id: w.lessonId,
+    lesson_title: w.lessonTitle,
+    category: w.category,
+    question: w.question,
+    correct_answer: w.correctAnswer,
+    selected_answer: w.selectedAnswer,
+    explanation: w.explanation,
+    options: w.options ?? null,
+    wrong_at: w.wrongAt,
+    resolved_at: w.resolvedAt,
+    retry_count: w.retryCount,
+    retry_correct_count: w.retryCorrectCount,
+    updated_at: new Date().toISOString(),
+  }
+}
+
+async function fetchWrongAnswersFromDB(userId: string): Promise<WrongAnswer[] | null> {
+  const db = getSupabaseClient()
+  if (!db) return null
+  try {
+    const { data, error } = await (db as any)
+      .from('user_wrong_answers')
+      .select('lesson_id, lesson_title, category, question, correct_answer, selected_answer, explanation, options, wrong_at, resolved_at, retry_count, retry_correct_count')
+      .eq('user_id', userId)
+    if (error) {
+      console.warn('[wrongAnswerStore] fetchWrongAnswersFromDB error:', error.message)
+      return null
+    }
+    return (data || []).map((r: WrongAnswerRow) => rowToWrongAnswer(r))
+  } catch (e) {
+    console.warn('[wrongAnswerStore] fetchWrongAnswersFromDB exception:', e)
+    return null
+  }
+}
+
+/** 1 件 push */
+export async function pushWrongAnswerToDB(userId: string, w: WrongAnswer): Promise<void> {
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const { error } = await (db as any)
+      .from('user_wrong_answers')
+      .upsert([wrongAnswerToRow(userId, w)], { onConflict: 'user_id,lesson_id,question' })
+    if (error) console.warn('[wrongAnswerStore] pushWrongAnswerToDB error:', error.message)
+  } catch (e) {
+    console.warn('[wrongAnswerStore] pushWrongAnswerToDB exception:', e)
+  }
+}
+
+async function pushWrongAnswersToDB(userId: string, items: WrongAnswer[]): Promise<void> {
+  if (items.length === 0) return
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const rows = items.map((w) => wrongAnswerToRow(userId, w))
+    const CHUNK = 500
+    for (let i = 0; i < rows.length; i += CHUNK) {
+      const chunk = rows.slice(i, i + CHUNK)
+      const { error } = await (db as any)
+        .from('user_wrong_answers')
+        .upsert(chunk, { onConflict: 'user_id,lesson_id,question' })
+      if (error) {
+        console.warn('[wrongAnswerStore] pushWrongAnswersToDB error:', error.message)
+        return
+      }
+    }
+  } catch (e) {
+    console.warn('[wrongAnswerStore] pushWrongAnswersToDB exception:', e)
+  }
+}
+
+/** ローカル + DB から削除 */
+export async function deleteWrongAnswerForUser(userId: string, w: WrongAnswer): Promise<void> {
+  deleteWrongAnswer(w.id)
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const { error } = await (db as any)
+      .from('user_wrong_answers')
+      .delete()
+      .eq('user_id', userId)
+      .eq('lesson_id', w.lessonId)
+      .eq('question', w.question)
+    if (error) console.warn('[wrongAnswerStore] deleteWrongAnswerForUser error:', error.message)
+  } catch (e) {
+    console.warn('[wrongAnswerStore] deleteWrongAnswerForUser exception:', e)
+  }
+}
+
+/**
+ * ログイン時の同期。
+ * 戦略: Union + 衝突時は resolved_at の新しい方を採用。
+ */
+export async function syncWrongAnswers(userId: string): Promise<void> {
+  const db = getSupabaseClient()
+  if (!db) return
+  try {
+    const remote = await fetchWrongAnswersFromDB(userId)
+    if (remote == null) return
+    const local = loadWrongAnswers()
+
+    const keyOf = (w: WrongAnswer) => `${w.lessonId}:${w.question}`
+    const remoteByKey = new Map(remote.map((r) => [keyOf(r), r]))
+    const merged = new Map<string, WrongAnswer>()
+    const toPush: WrongAnswer[] = []
+
+    for (const r of remote) merged.set(keyOf(r), r)
+
+    for (const l of local) {
+      const k = keyOf(l)
+      const r = remoteByKey.get(k)
+      if (!r) {
+        merged.set(k, l)
+        toPush.push(l)
+        continue
+      }
+      let chosen: WrongAnswer = r
+      if (l.resolvedAt && r.resolvedAt) {
+        chosen = l.resolvedAt > r.resolvedAt ? l : r
+      } else if (l.resolvedAt && !r.resolvedAt) {
+        chosen = l
+      } else if (!l.resolvedAt && r.resolvedAt) {
+        chosen = r
+      } else {
+        chosen = l.wrongAt > r.wrongAt ? l : r
+      }
+      chosen = {
+        ...chosen,
+        retryCount: Math.max(l.retryCount, r.retryCount),
+        retryCorrectCount: Math.max(l.retryCorrectCount, r.retryCorrectCount),
+        options: chosen.options ?? l.options ?? r.options,
+      }
+      merged.set(k, chosen)
+      if (chosen !== r) toPush.push(chosen)
+    }
+
+    const mergedArr = [...merged.values()]
+    saveWrongAnswers(mergedArr)
+    await pushWrongAnswersToDB(userId, toPush)
+
+    if (import.meta.env.DEV) {
+      console.log(
+        '[wrongAnswerStore] syncWrongAnswers complete:',
+        `remote=${remote.length}`,
+        `local=${local.length}`,
+        `merged=${mergedArr.length}`,
+        `pushed=${toPush.length}`,
+      )
+    }
+  } catch (e) {
+    console.warn('[wrongAnswerStore] syncWrongAnswers failed:', e)
+  }
 }

--- a/supabase/migrations/022_user_flashcards.sql
+++ b/supabase/migrations/022_user_flashcards.sql
@@ -1,0 +1,50 @@
+-- Logic App: SRS フラッシュカード本体を Supabase に保持する
+-- Phase: Device Sync Phase 1
+-- 端末をまたいで SM-2 状態 (interval / ease / next_review) を共有する
+
+create table if not exists public.user_flashcards (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid references auth.users(id) on delete cascade not null,
+
+  -- 既存 client-side id をそのまま使うキー
+  -- "${ts}-${rand}" など loadCards() で発行された id
+  card_key text not null,
+
+  -- カード本体
+  source text not null,             -- "lesson-21" / "ai-weak" 等
+  category text not null,
+  front text not null,
+  back text not null,
+
+  -- SM-2 state
+  interval_days integer not null default 0,
+  ease real not null default 2.5,
+  next_review date not null,
+  correct_count integer not null default 0,
+  wrong_count integer not null default 0,
+
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  unique(user_id, card_key)
+);
+
+create index if not exists user_flashcards_user_due_idx
+  on public.user_flashcards (user_id, next_review);
+
+create index if not exists user_flashcards_user_updated_idx
+  on public.user_flashcards (user_id, updated_at desc);
+
+alter table public.user_flashcards enable row level security;
+
+drop policy if exists "user_flashcards: self only" on public.user_flashcards;
+create policy "user_flashcards: self only"
+  on public.user_flashcards for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- ロールバック手順 (手動):
+--   drop policy if exists "user_flashcards: self only" on public.user_flashcards;
+--   drop index if exists user_flashcards_user_due_idx;
+--   drop index if exists user_flashcards_user_updated_idx;
+--   drop table if exists public.user_flashcards;

--- a/supabase/migrations/023_user_wrong_answers.sql
+++ b/supabase/migrations/023_user_wrong_answers.sql
@@ -1,0 +1,49 @@
+-- Logic App: 誤答リストを Supabase に保持する
+-- Phase: Device Sync Phase 1
+-- 「弱点復習」機能の入口データを端末間で共有する
+
+create table if not exists public.user_wrong_answers (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid references auth.users(id) on delete cascade not null,
+
+  lesson_id integer not null,
+  lesson_title text,
+  category text,
+  question text not null,
+  correct_answer text not null,
+  selected_answer text,
+  explanation text,
+
+  -- 4択再出題用 options (WrongAnswerOption[])
+  options jsonb,
+
+  wrong_at timestamptz not null default now(),
+  resolved_at timestamptz,
+  retry_count integer not null default 0,
+  retry_correct_count integer not null default 0,
+
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  unique(user_id, lesson_id, question)
+);
+
+create index if not exists user_wrong_answers_user_idx
+  on public.user_wrong_answers (user_id, resolved_at, wrong_at desc);
+
+create index if not exists user_wrong_answers_user_updated_idx
+  on public.user_wrong_answers (user_id, updated_at desc);
+
+alter table public.user_wrong_answers enable row level security;
+
+drop policy if exists "user_wrong_answers: self only" on public.user_wrong_answers;
+create policy "user_wrong_answers: self only"
+  on public.user_wrong_answers for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- ロールバック手順 (手動):
+--   drop policy if exists "user_wrong_answers: self only" on public.user_wrong_answers;
+--   drop index if exists user_wrong_answers_user_idx;
+--   drop index if exists user_wrong_answers_user_updated_idx;
+--   drop table if exists public.user_wrong_answers;

--- a/supabase/migrations/024_user_saved_items.sql
+++ b/supabase/migrations/024_user_saved_items.sql
@@ -1,0 +1,40 @@
+-- Logic App: ブックマーク (saved items) を Supabase に保持する
+-- Phase: Device Sync Phase 1
+-- レッスン/コース/AI問題/Fermi のブックマークを端末間で共有する
+
+create table if not exists public.user_saved_items (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid references auth.users(id) on delete cascade not null,
+
+  -- 'lesson' | 'course' | 'lesson-step' | 'ai-problem' | 'fermi'
+  item_type text not null,
+  ref_id text not null,
+
+  title text not null,
+  subtitle text,
+  image text,
+  step_index integer,
+  parent_lesson_id integer,
+
+  saved_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  unique(user_id, item_type, ref_id)
+);
+
+create index if not exists user_saved_items_user_idx
+  on public.user_saved_items (user_id, saved_at desc);
+
+alter table public.user_saved_items enable row level security;
+
+drop policy if exists "user_saved_items: self only" on public.user_saved_items;
+create policy "user_saved_items: self only"
+  on public.user_saved_items for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- ロールバック手順 (手動):
+--   drop policy if exists "user_saved_items: self only" on public.user_saved_items;
+--   drop index if exists user_saved_items_user_idx;
+--   drop table if exists public.user_saved_items;

--- a/supabase/migrations/025_notebooks_journal_columns.sql
+++ b/supabase/migrations/025_notebooks_journal_columns.sql
@@ -1,0 +1,33 @@
+-- Logic App: notebooks テーブルにジャーナル用カラムを追加
+-- Phase: Device Sync Phase 1
+--
+-- 既存 notebooks テーブルは content jsonb 単一カラムだった (001_initial_schema.sql)。
+-- 実装側 (src/db/notebookDb.ts) は date / ai_summary / user_memo を前提にしているため、
+-- カラム追加 + unique(user_id, date) を張って実装と整合させる。
+-- 既存 content カラムは将来削除可能だが、生本番データ消失防止のため当面残す。
+--
+-- 注意: 既存 RLS ポリシー "notebooks: self only" (001_initial_schema.sql:94) はそのまま有効。
+
+alter table public.notebooks
+  add column if not exists date date,
+  add column if not exists ai_summary text default '',
+  add column if not exists user_memo text default '',
+  add column if not exists created_at timestamptz default now();
+
+-- (user_id, date) で upsert できるよう unique 制約を張る
+-- date が null の旧 row があると失敗するので NOT NULL は付けず unique のみ
+create unique index if not exists notebooks_user_date_uniq
+  on public.notebooks (user_id, date)
+  where date is not null;
+
+create index if not exists notebooks_user_updated_idx
+  on public.notebooks (user_id, updated_at desc);
+
+-- ロールバック手順 (手動):
+--   drop index if exists notebooks_user_date_uniq;
+--   drop index if exists notebooks_user_updated_idx;
+--   alter table public.notebooks
+--     drop column if exists date,
+--     drop column if exists ai_summary,
+--     drop column if exists user_memo,
+--     drop column if exists created_at;

--- a/supabase/migrations/026_user_roadmap_goals.sql
+++ b/supabase/migrations/026_user_roadmap_goals.sql
@@ -1,0 +1,38 @@
+-- Logic App: roadmap goals 用の新テーブル
+-- Phase: Device Sync Phase 1
+--
+-- 既存 roadmap_progress (001_initial_schema.sql) は node_id + status の単純 K-V で、
+-- 現在の GoalEntry (targetDate / dailyMinutes / completedSteps[]) 構造に合わない。
+-- 旧テーブルは deprecated として残置し、新テーブルに移行する。
+
+create table if not exists public.user_roadmap_goals (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid references auth.users(id) on delete cascade not null,
+
+  goal_id text not null,
+  target_date date,
+  daily_minutes integer not null default 15,
+  completed_steps jsonb not null default '[]'::jsonb,
+  setup_done boolean not null default true,
+
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  unique(user_id, goal_id)
+);
+
+create index if not exists user_roadmap_goals_user_idx
+  on public.user_roadmap_goals (user_id, updated_at desc);
+
+alter table public.user_roadmap_goals enable row level security;
+
+drop policy if exists "user_roadmap_goals: self only" on public.user_roadmap_goals;
+create policy "user_roadmap_goals: self only"
+  on public.user_roadmap_goals for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- ロールバック手順 (手動):
+--   drop policy if exists "user_roadmap_goals: self only" on public.user_roadmap_goals;
+--   drop index if exists user_roadmap_goals_user_idx;
+--   drop table if exists public.user_roadmap_goals;

--- a/supabase/migrations/027_user_progress_category.sql
+++ b/supabase/migrations/027_user_progress_category.sql
@@ -1,0 +1,12 @@
+-- Logic App: カテゴリ別マスタリー (logic-progress) を user_progress に同期するための列追加
+-- Phase: Device Sync Phase 1
+--
+-- 既存 user_progress (005_user_progress_sync.sql) は logic-stats を保持。
+-- カテゴリ別 progress は別概念だが、user_progress に JSONB で相乗りさせる方が
+-- ラウンドトリップが減る (1 リクエストで両方取れる)。
+
+alter table public.user_progress
+  add column if not exists category_progress jsonb not null default '{}'::jsonb;
+
+-- ロールバック手順 (手動):
+--   alter table public.user_progress drop column if exists category_progress;


### PR DESCRIPTION
## Summary

別端末で同じアカウントにログインしても SRS フラッシュカード・誤答リスト・ジャーナル・roadmap goals・カテゴリ別 progress・saved items が引き継がれない問題を解消する **Phase 1** 実装。Phase 1 では feature flag OFF (`VITE_ENABLE_DEVICE_SYNC=false`) を維持するため、ユーザー体験への影響はゼロ。

- DB migration 6 本を本番 Supabase に MCP 経由で適用済
- 各 store に DB 同期関数 (sync/push/delete) を実装
- `syncOnLogin` を拡張し、Phase 1 ON 時に 6 系統を Promise.allSettled で並列同期
- `featureFlags.ts` を新設し、Phase 2 以降のサーバー配信 API へのスケーラビリティを確保

## DB schema (本番反映済)

| migration | 内容 |
|---|---|
| 022 | `user_flashcards` — SM-2 state 含む SRS 本体 |
| 023 | `user_wrong_answers` — 誤答 + retry 状態 + 4択 options |
| 024 | `user_saved_items` — ブックマーク横断 |
| 025 | `notebooks` — `date / ai_summary / user_memo` カラム追加 + `unique(user_id, date)` |
| 026 | `user_roadmap_goals` — GoalEntry 構造に合わせた新テーブル (旧 `roadmap_progress` deprecated 据え置き) |
| 027 | `user_progress.category_progress` jsonb 追加 |

移行対象は 7 ユーザー、`notebooks` / `roadmap_progress` は既存データ 0 件のため破壊リスクなし。

## Conflict resolution 戦略

| データ | 戦略 |
|---|---|
| flashcards | `correctCount + interval` (進捗指標) が大きい方を採用 |
| wrong_answers | union + 衝突時は `resolved_at` 新しい方 |
| saved_items | union + 衝突時は `savedAt` 新しい方 |
| notebook | per-date 単位、`aiSummary + userMemo` の文字数が多い方 |
| roadmap | `completedSteps` を union、metadata は createdAt 新しい方 |
| category_progress | `Math.max` (単調増加) |

## Feature flag

- `VITE_ENABLE_DEVICE_SYNC=false` がデフォルト
- Phase 1 段階では Render env vars 未設定で全 main 反映可能
- Phase 2 (内部テスター ON) は env vars に `VITE_ENABLE_DEVICE_SYNC=true` を追加 → redeploy

## Phase 2 への引き継ぎ

1. Render dashboard で `VITE_ENABLE_DEVICE_SYNC=true` を `logic-u5wn` service に追加
2. `gh workflow run deploy-production.yml -f confirm=yes` で redeploy
3. 内部テスター (Keita 含む) が 7 日間 dry-run、Supabase ダッシュボードで件数・エラー確認
4. エラー率 < 1% を確認したら Phase 3 段階公開 (25%/50%/100%、2 週間ペース)

## スコープ外 (別フェーズ)

- Sentry 連携 (`src/sentry.ts` no-op スタブのまま、console.warn 止まり)
- Capacitor オフライン retry queue
- UI 上の進捗インジケータ (silent migration)
- Phase 3 段階公開用のサーバー側 `/api/feature-flags` エンドポイント

## Test plan

- [x] `node node_modules/.bin/tsc -b --noEmit` clean
- [x] `node node_modules/.bin/eslint <変更ファイル群>` clean
- [x] `node node_modules/.bin/vite build` 成功 (3.18s)
- [x] Supabase に migration 022-027 が適用済 (本番側 `list_migrations` で確認)
- [x] 全テーブルに RLS `self only` ポリシー (auth.uid() = user_id) 適用済
- [ ] Phase 2 で内部テスター向け ON 切替 + 7 日 dry-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)