### PR TITLE
fix(samples): effect 内同期 setState を解消し main CI lint を緑化

### DIFF
--- a/docs/samples-src/src/pages/v2/SystemsFeedbackLoop.tsx
+++ b/docs/samples-src/src/pages/v2/SystemsFeedbackLoop.tsx
@@ -79,12 +79,12 @@ export function SystemsFeedbackLoop() {
   const maxTick = loop.trace[loop.nodes[0].id].length - 1
 
   useEffect(() => {
-    if (!playing) return
-    if (tick >= maxTick) {
-      setPlaying(false)
-      return
-    }
-    const t = setTimeout(() => setTick((s) => s + 1), 700)
+    if (!playing || tick >= maxTick) return
+    const t = setTimeout(() => {
+      // 終端到達時の停止は timeout コールバック内で行う（effect 本体での同期 setState を避ける）
+      if (tick + 1 >= maxTick) setPlaying(false)
+      setTick((s) => s + 1)
+    }, 700)
     return () => clearTimeout(t)
   }, [playing, tick, maxTick])
 


### PR DESCRIPTION
main の CI(build-and-lint) が docs/samples-src の react-hooks set-state-in-effect error で赤だったため修正。SystemsFeedbackLoop の停止処理を effect 本体の同期 setState から setTimeout コールバック内へ移動（挙動不変・ルール準拠）。docs/samples-src はドキュメント用サンプルの別パッケージで本番アプリと無関係。

検証: eslint .（worktree 除外）0 errors。

🤖 Generated with [Claude Code](https://claude.com/claude-code)