### PR TITLE
feat(fermi): 報告アイコン統一 + 電卓 万/億ボタン・万億表示

### DIFF
--- a/src/__tests__/fermiNumberFormat.test.ts
+++ b/src/__tests__/fermiNumberFormat.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import { roundTo1, formatJpUnit, formatResult, applyUnitMultiplier } from '../fermiNumberFormat'
+
+describe('roundTo1', () => {
+  it('1桁に丸めて末尾.0を落とす', () => {
+    expect(roundTo1(5)).toBe('5')
+    expect(roundTo1(5.0)).toBe('5')
+    expect(roundTo1(1.234)).toBe('1.2')
+    expect(roundTo1(1.25)).toBe('1.3') // 四捨五入
+    expect(roundTo1(12)).toBe('12')
+    expect(roundTo1(0)).toBe('0')
+  })
+})
+
+describe('formatJpUnit (ja)', () => {
+  it('万未満はそのまま区切り表示', () => {
+    expect(formatJpUnit(0)).toBe('0')
+    expect(formatJpUnit(5)).toBe('5')
+    expect(formatJpUnit(999)).toBe('999')
+    expect(formatJpUnit(1234)).toBe('1,234')
+    expect(formatJpUnit(9999)).toBe('9,999')
+  })
+
+  it('万単位（10^4〜）を1桁丸めで表示', () => {
+    expect(formatJpUnit(10000)).toBe('1万')
+    expect(formatJpUnit(50000)).toBe('5万')
+    expect(formatJpUnit(12345)).toBe('1.2万') // 端数1桁丸め
+    expect(formatJpUnit(125000)).toBe('12.5万')
+  })
+
+  it('億単位（10^8〜）', () => {
+    expect(formatJpUnit(1e8)).toBe('1億')
+    expect(formatJpUnit(1.2e8)).toBe('1.2億')
+    expect(formatJpUnit(350000000)).toBe('3.5億')
+  })
+
+  it('兆単位（10^12〜）', () => {
+    expect(formatJpUnit(1e12)).toBe('1兆')
+    expect(formatJpUnit(3.5e12)).toBe('3.5兆')
+    expect(formatJpUnit(1.2e15)).toBe('1200兆') // 兆を超えても兆で表示し続ける
+  })
+
+  it('境界値の扱い', () => {
+    expect(formatJpUnit(9999)).toBe('9,999') // 万未満
+    expect(formatJpUnit(10000)).toBe('1万') // ちょうど万
+    expect(formatJpUnit(99999999)).toBe('10000万') // 億直前は万で表示（< 1e8）
+    expect(formatJpUnit(1e8)).toBe('1億') // ちょうど億
+  })
+
+  it('負値', () => {
+    expect(formatJpUnit(-50000)).toBe('−5万')
+    expect(formatJpUnit(-1.2e8)).toBe('−1.2億')
+    expect(formatJpUnit(-500)).toBe('-500') // 万未満は toLocaleString のマイナス
+  })
+
+  it('小さい小数は単位化しない', () => {
+    expect(formatJpUnit(0.5)).toBe('0.5')
+    expect(formatJpUnit(0.001)).toBe('0.001')
+  })
+
+  it('非有限値はダッシュ', () => {
+    expect(formatJpUnit(NaN)).toBe('—')
+    expect(formatJpUnit(Infinity)).toBe('—')
+  })
+})
+
+describe('formatJpUnit (en)', () => {
+  it('K / M / B / T 表記（10進ベース）', () => {
+    expect(formatJpUnit(5000, 'en')).toBe('5K')
+    expect(formatJpUnit(50000, 'en')).toBe('50K')
+    expect(formatJpUnit(1.2e6, 'en')).toBe('1.2M')
+    expect(formatJpUnit(1.2e8, 'en')).toBe('120M')
+    expect(formatJpUnit(3.5e9, 'en')).toBe('3.5B')
+    expect(formatJpUnit(3.5e12, 'en')).toBe('3.5T')
+  })
+  it('千未満はそのまま', () => {
+    expect(formatJpUnit(123, 'en')).toBe('123')
+    expect(formatJpUnit(999, 'en')).toBe('999')
+  })
+  it('負値', () => {
+    expect(formatJpUnit(-50000, 'en')).toBe('−50K')
+  })
+})
+
+describe('formatResult', () => {
+  it('通常範囲はロケール区切り', () => {
+    expect(formatResult(50000)).toBe('50,000')
+    expect(formatResult(1234.5)).toBe('1,234.5')
+    expect(formatResult(0)).toBe('0')
+  })
+  it('極端な桁は指数表記', () => {
+    expect(formatResult(1e15)).toBe('1.000e+15')
+    expect(formatResult(0.00001)).toBe('1.000e-5')
+  })
+  it('非有限値はダッシュ', () => {
+    expect(formatResult(NaN)).toBe('—')
+  })
+})
+
+describe('applyUnitMultiplier', () => {
+  it('末尾の数値に万（1e4）を掛ける', () => {
+    expect(applyUnitMultiplier('5', 1e4)).toBe('50000')
+    expect(applyUnitMultiplier('1.5', 1e4)).toBe('15000')
+    expect(applyUnitMultiplier('12', 1e4)).toBe('120000')
+  })
+
+  it('末尾の数値に億（1e8）を掛ける', () => {
+    expect(applyUnitMultiplier('3', 1e8)).toBe('300000000')
+    expect(applyUnitMultiplier('1.2', 1e8)).toBe('120000000')
+  })
+
+  it('式の途中の末尾数値だけに掛ける', () => {
+    expect(applyUnitMultiplier('3*2', 1e8)).toBe('3*200000000')
+    expect(applyUnitMultiplier('100+5', 1e4)).toBe('100+50000')
+  })
+
+  it('小数点始まりの数値', () => {
+    expect(applyUnitMultiplier('.5', 1e4)).toBe('5000')
+  })
+
+  it('浮動小数誤差が出ないこと', () => {
+    expect(applyUnitMultiplier('1.1', 1e8)).toBe('110000000')
+    expect(applyUnitMultiplier('2.3', 1e4)).toBe('23000')
+  })
+
+  it('末尾が数値でなければ null', () => {
+    expect(applyUnitMultiplier('', 1e4)).toBeNull()
+    expect(applyUnitMultiplier('5+', 1e4)).toBeNull()
+    expect(applyUnitMultiplier('5*', 1e4)).toBeNull()
+    expect(applyUnitMultiplier('(', 1e4)).toBeNull()
+    expect(applyUnitMultiplier('5)', 1e4)).toBeNull()
+  })
+})

--- a/src/fermiNumberFormat.ts
+++ b/src/fermiNumberFormat.ts
@@ -1,0 +1,112 @@
+// フェルミ推定電卓の数値フォーマット純ロジック。
+// i18n / DOM に依存しないので単体テストしやすい形で切り出している。
+// 表示は「万 / 億 / 兆」単位（ja）または「K / M / T」（en）に丸めて読みやすくする。
+
+export type FermiLocale = 'ja' | 'en'
+
+// 単位境界（10^4 / 10^8 / 10^12）
+const MAN = 1e4 // 万
+const OKU = 1e8 // 億
+const CHO = 1e12 // 兆
+
+/**
+ * 小数を最大1桁に丸めて、末尾の `.0` を落とす。
+ * 例: 1.25 → "1.3"、5.0 → "5"、12.0 → "12"
+ */
+export function roundTo1(n: number): string {
+  // toFixed(1) で四捨五入 → 末尾 .0 を除去
+  const fixed = n.toFixed(1)
+  return fixed.endsWith('.0') ? fixed.slice(0, -2) : fixed
+}
+
+/**
+ * 数値を日本語の万/億/兆単位（ja）または K/M/T（en）に丸めて返す。
+ * - 万未満（|n| < 10000）はそのままロケール区切りで返す
+ * - 小数は1桁に丸める（例: 12345 → "1.2万"）
+ * - 0・負値・極端に小さい値も正しく扱う
+ * - 兆を超える巨大値は兆単位で表示し続ける（例: 3.5e12 → "3.5兆"、1.2e15 → "1200兆"）
+ *
+ * @param n      対象の数値
+ * @param locale 'ja' | 'en'
+ */
+export function formatJpUnit(n: number, locale: FermiLocale = 'ja'): string {
+  if (!Number.isFinite(n)) return '—'
+
+  const abs = Math.abs(n)
+  const sign = n < 0 ? '−' : '' // U+2212 マイナス記号（表示用）
+  const localeStr = locale === 'ja' ? 'ja-JP' : 'en-US'
+
+  // ja は 10^4(万)/10^8(億)/10^12(兆)、en は 10^3(K)/10^6(M)/10^9(B)/10^12(T)。
+  // 単位境界は言語で異なるので、ロケールごとにテーブルを分ける。
+  if (locale === 'ja') {
+    // 万未満（0 含む）はそのまま。小さな小数も無理に単位化しない。
+    if (abs < MAN) {
+      return n.toLocaleString(localeStr, { maximumFractionDigits: 4 })
+    }
+    const units: { threshold: number; label: string }[] = [
+      { threshold: CHO, label: '兆' },
+      { threshold: OKU, label: '億' },
+      { threshold: MAN, label: '万' },
+    ]
+    for (const u of units) {
+      if (abs >= u.threshold) {
+        return `${sign}${roundTo1(abs / u.threshold)}${u.label}`
+      }
+    }
+  } else {
+    // en: 千未満はそのまま
+    if (abs < 1e3) {
+      return n.toLocaleString(localeStr, { maximumFractionDigits: 4 })
+    }
+    const units: { threshold: number; label: string }[] = [
+      { threshold: 1e12, label: 'T' },
+      { threshold: 1e9, label: 'B' },
+      { threshold: 1e6, label: 'M' },
+      { threshold: 1e3, label: 'K' },
+    ]
+    for (const u of units) {
+      if (abs >= u.threshold) {
+        return `${sign}${roundTo1(abs / u.threshold)}${u.label}`
+      }
+    }
+  }
+
+  // ここには到達しないが保険
+  return n.toLocaleString(localeStr, { maximumFractionDigits: 4 })
+}
+
+/**
+ * 電卓の「= 結果」に出す生の数値表示。
+ * - 桁が極端（>= 10^15 または 0 でない |n| < 10^-4）は指数表記
+ * - それ以外はロケール区切り（小数最大6桁）
+ */
+export function formatResult(n: number, locale: FermiLocale = 'ja'): string {
+  if (!Number.isFinite(n)) return '—'
+  const abs = Math.abs(n)
+  if (abs !== 0 && (abs >= 1e15 || abs < 1e-4)) return n.toExponential(3)
+  const localeStr = locale === 'ja' ? 'ja-JP' : 'en-US'
+  return n.toLocaleString(localeStr, { maximumFractionDigits: 6 })
+}
+
+/**
+ * 電卓の入力式末尾の数値リテラルに単位倍率を掛ける。
+ * 例: applyUnitMultiplier("5", 1e4) → "50000"
+ *     applyUnitMultiplier("3*2", 1e8) → "3*200000000"
+ *     applyUnitMultiplier("1.5", 1e4) → "15000"
+ * 末尾が数値リテラルでない（演算子・括弧で終わる、空）場合は null を返し、呼び出し側で no-op にする。
+ *
+ * @param expr   現在の計算式文字列
+ * @param factor 掛ける倍率（万=1e4 / 億=1e8）
+ */
+export function applyUnitMultiplier(expr: string, factor: number): string | null {
+  // 末尾の数値リテラル（整数 or 小数）を取り出す
+  const m = expr.match(/(\d+\.?\d*|\.\d+)$/)
+  if (!m) return null
+  const literal = m[0]
+  const num = parseFloat(literal)
+  if (!Number.isFinite(num)) return null
+  const multiplied = num * factor
+  // 浮動小数誤差を抑えるため有効桁を丸めてから文字列化（例: 1.1*1e8 の誤差対策）
+  const replacement = String(Number(multiplied.toPrecision(15)))
+  return expr.slice(0, expr.length - literal.length) + replacement
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1695,6 +1695,10 @@ const STRINGS: Record<Locale, Strings> = {
     'dailyFermi.refData': '参考データ',
     'dailyFermi.calcClose': '電卓を閉じる',
     'dailyFermi.calcOpen': '電卓を使う',
+    'dailyFermi.calcUnitMan': '万',
+    'dailyFermi.calcUnitOku': '億',
+    'dailyFermi.calcUnitManAria': '入力中の数値を1万倍する',
+    'dailyFermi.calcUnitOkuAria': '入力中の数値を1億倍する',
     'dailyFermi.answerAria': 'フェルミ推定の解答',
     'dailyFermi.askHintBtn': 'ヒントを聞く',
     'dailyFermi.submit': '回答を提出する',
@@ -1711,9 +1715,6 @@ const STRINGS: Record<Locale, Strings> = {
     'dailyFermi.hintUsed': 'ヒント使用',
     'dailyFermi.aiFeedback': 'AIからのフィードバック',
     'dailyFermi.viewRanking': 'ランキングを見る',
-    'dailyFermi.aboutTrillion': '{sign}約{n}兆',
-    'dailyFermi.aboutHundredMil': '{sign}約{n}億',
-    'dailyFermi.aboutTenK': '{sign}約{n}万',
 
     // AI Problem Gen
     'aiGen.fallbackCategory': 'その他',
@@ -3490,6 +3491,10 @@ const STRINGS: Record<Locale, Strings> = {
     'dailyFermi.refData': 'Reference data',
     'dailyFermi.calcClose': 'Close calculator',
     'dailyFermi.calcOpen': 'Open calculator',
+    'dailyFermi.calcUnitMan': '10K',
+    'dailyFermi.calcUnitOku': '100M',
+    'dailyFermi.calcUnitManAria': 'Multiply the current number by 10,000',
+    'dailyFermi.calcUnitOkuAria': 'Multiply the current number by 100,000,000',
     'dailyFermi.answerAria': 'Fermi estimation answer',
     'dailyFermi.askHintBtn': 'Ask for a hint',
     'dailyFermi.submit': 'Submit answer',
@@ -3506,9 +3511,6 @@ const STRINGS: Record<Locale, Strings> = {
     'dailyFermi.hintUsed': 'Hint used',
     'dailyFermi.aiFeedback': 'AI feedback',
     'dailyFermi.viewRanking': 'View ranking',
-    'dailyFermi.aboutTrillion': '{sign}~{n}T',
-    'dailyFermi.aboutHundredMil': '{sign}~{n}00M',
-    'dailyFermi.aboutTenK': '{sign}~{n}0K',
 
     // AI Problem Gen
     'aiGen.fallbackCategory': 'Other',

--- a/src/screens/DailyFermiScreen.tsx
+++ b/src/screens/DailyFermiScreen.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useRef } from 'react'
-import { LightbulbIcon, BarChartIcon, MicIcon, BookmarkIcon, BookmarkFilledIcon } from '../icons'
+import { LightbulbIcon, BarChartIcon, MicIcon, BookmarkIcon, BookmarkFilledIcon, FlagIcon } from '../icons'
 import { Header } from '../components/platform/Header'
 import { Button } from '../components/Button'
 import { API_BASE } from './apiBase'
 import { getDailyFermiIndex, FERMI_POOL, getFermiStatsByIndex } from '../fermiData'
 import { t, getLocale } from '../i18n'
+import { formatJpUnit, formatResult, applyUnitMultiplier, type FermiLocale } from '../fermiNumberFormat'
 import { getGuestId } from '../guestId'
 import { getRankingUserId } from '../syncService'
 import { haptic } from '../platform/haptics'
@@ -101,23 +102,6 @@ function safeEval(expr: string): number | null {
   return null
 }
 
-function toJpUnit(n: number): string {
-  const abs = Math.abs(n)
-  const sign = n < 0 ? '−' : ''
-  const localeStr = getLocale() === 'ja' ? 'ja-JP' : 'en-US'
-  if (abs >= 1e12) return t('dailyFermi.aboutTrillion', { sign, n: (abs / 1e12).toFixed(2) })
-  if (abs >= 1e8)  return t('dailyFermi.aboutHundredMil', { sign, n: (abs / 1e8).toFixed(2) })
-  if (abs >= 1e4)  return t('dailyFermi.aboutTenK', { sign, n: (abs / 1e4).toFixed(2) })
-  return n.toLocaleString(localeStr, { maximumFractionDigits: 4 })
-}
-
-function formatResult(n: number): string {
-  const abs = Math.abs(n)
-  if (abs !== 0 && (abs >= 1e15 || abs < 1e-4)) return n.toExponential(3)
-  const localeStr = getLocale() === 'ja' ? 'ja-JP' : 'en-US'
-  return n.toLocaleString(localeStr, { maximumFractionDigits: 6 })
-}
-
 type CalcKeyKind = 'num' | 'op' | 'fn' | 'eq'
 
 const CALC_KEY_PALETTE: Record<CalcKeyKind, { bg: string; color: string; border: string }> = {
@@ -147,7 +131,7 @@ function CalcKey({ label, onClick, kind = 'num' }: { label: string; onClick: () 
   )
 }
 
-function FermiCalculator({ onInsert }: { onInsert: (text: string) => void }) {
+function FermiCalculator({ onInsert, locale }: { onInsert: (text: string) => void; locale: FermiLocale }) {
   const [expr, setExpr] = useState('')
   const result = safeEval(expr)
 
@@ -155,11 +139,17 @@ function FermiCalculator({ onInsert }: { onInsert: (text: string) => void }) {
   const clear = () => setExpr('')
   const back = () => setExpr(prev => prev.slice(0, -1))
   const equals = () => { if (result != null) setExpr(String(result)) }
+  // 単位ボタン（万=1e4 / 億=1e8）: 入力中の末尾数値にワンタップで倍率を掛ける
+  const applyUnit = (factor: number) => {
+    setExpr(prev => applyUnitMultiplier(prev, factor) ?? prev)
+  }
   const insert = () => {
     if (result == null) return
-    const formatted = formatResult(result)
+    const formatted = formatResult(result, locale)
     const display = expr.replace(/\*/g, '×').replace(/\//g, '÷').replace(/-/g, '−')
-    onInsert(`${display} = ${formatted}（${toJpUnit(result)}）`)
+    const opener = locale === 'ja' ? '（' : ' ('
+    const closer = locale === 'ja' ? '）' : ')'
+    onInsert(`${display} = ${formatted}${opener}${formatJpUnit(result, locale)}${closer}`)
   }
 
   return (
@@ -188,8 +178,8 @@ function FermiCalculator({ onInsert }: { onInsert: (text: string) => void }) {
         </div>
         {result != null && (
           <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginTop: 4 }}>
-            <span style={{ fontSize: 18, fontWeight: 800, color: 'var(--brand)', fontFamily: "'Inter Tight', monospace" }}>= {formatResult(result)}</span>
-            <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>{toJpUnit(result)}</span>
+            <span style={{ fontSize: 18, fontWeight: 800, color: 'var(--brand)', fontFamily: "'Inter Tight', monospace" }}>= {formatResult(result, locale)}</span>
+            <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>{formatJpUnit(result, locale)}</span>
           </div>
         )}
       </div>
@@ -220,6 +210,40 @@ function FermiCalculator({ onInsert }: { onInsert: (text: string) => void }) {
         <CalcKey label="." onClick={() => press('.')} />
         <CalcKey label="=" onClick={equals} kind="eq" />
         <CalcKey label="+" onClick={() => press('+')} kind="op" />
+      </div>
+
+      {/* 単位ボタン: 入力中の数値にワンタップで万(×10^4)・億(×10^8)を掛ける */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 6 }}>
+        <button
+          type="button"
+          onClick={() => applyUnit(1e4)}
+          aria-label={t('dailyFermi.calcUnitManAria')}
+          style={{
+            height: 40, borderRadius: 10,
+            background: CALC_KEY_PALETTE.op.bg,
+            border: `1px solid ${CALC_KEY_PALETTE.op.border}`,
+            color: CALC_KEY_PALETTE.op.color,
+            fontSize: 15, fontWeight: 800,
+            cursor: 'pointer', fontFamily: 'inherit',
+          }}
+        >
+          {t('dailyFermi.calcUnitMan')}
+        </button>
+        <button
+          type="button"
+          onClick={() => applyUnit(1e8)}
+          aria-label={t('dailyFermi.calcUnitOkuAria')}
+          style={{
+            height: 40, borderRadius: 10,
+            background: CALC_KEY_PALETTE.op.bg,
+            border: `1px solid ${CALC_KEY_PALETTE.op.border}`,
+            color: CALC_KEY_PALETTE.op.color,
+            fontSize: 15, fontWeight: 800,
+            cursor: 'pointer', fontFamily: 'inherit',
+          }}
+        >
+          {t('dailyFermi.calcUnitOku')}
+        </button>
       </div>
 
       <button
@@ -883,6 +907,7 @@ export function DailyFermiScreen({ onBack, onReport, onOpenRanking }: DailyFermi
 
               {showCalculator && (
                 <FermiCalculator
+                  locale={locale === 'ja' ? 'ja' : 'en'}
                   onInsert={(text) => {
                     setAnswer(prev => prev + (prev && !prev.endsWith('\n') ? '\n' : '') + text)
                     haptic.light()
@@ -1083,8 +1108,9 @@ export function DailyFermiScreen({ onBack, onReport, onOpenRanking }: DailyFermi
                   <div style={{ padding: '0 18px 14px' }}>
                     <button
                       onClick={() => onReport({ lessonTitle: t('report.dailyFermiTitle'), question })}
-                      style={{ fontSize: 13, color: 'var(--text-muted)', background: 'none', border: 'none', cursor: 'pointer', padding: 0, textDecoration: 'underline' }}
+                      style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, color: 'var(--text-muted)', background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontFamily: 'inherit' }}
                     >
+                      <FlagIcon width={14} height={14} aria-hidden="true" />
                       {t('report.linkText')}
                     </button>
                   </div>

--- a/src/screens/FermiScreen.tsx
+++ b/src/screens/FermiScreen.tsx
@@ -3,7 +3,7 @@ import { recordCompletion, addXp, getDisplayName } from '../stats'
 import { recordActivity } from '../activityLog'
 import { getGuestId } from '../guestId'
 import { getRankingUserId } from '../syncService'
-import { ArrowRightIcon, CheckIcon, LightbulbIcon } from '../icons'
+import { ArrowRightIcon, CheckIcon, LightbulbIcon, FlagIcon } from '../icons'
 import { Button } from '../components/Button'
 import { Header } from '../components/platform/Header'
 import { useIsDesktop } from '../hooks/useMediaQuery'
@@ -381,8 +381,9 @@ function FermiFeedbackBlock({
         {onReport && (
           <button
             onClick={onReport}
-            style={{ marginTop: 'var(--s-3)', fontSize: 14, color: 'var(--text-muted)', background: 'none', border: 'none', cursor: 'pointer', padding: 0, textDecoration: 'underline' }}
+            style={{ marginTop: 'var(--s-3)', display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 14, color: 'var(--text-muted)', background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontFamily: 'inherit' }}
           >
+            <FlagIcon width={14} height={14} aria-hidden="true" />
             {t('report.linkText')}
           </button>
         )}


### PR DESCRIPTION
Keita 依頼。reviewer approve。

- 報告ボタンを Fermi/DailyFermi 両画面とも FlagIcon＋ラベルに統一（既存 onReport 配線不変）
- 電卓に 万(×1e4)/億(×1e8) ボタン追加、結果を万/億/兆・小数1桁表示（5万/1.2万/1.2億）
- フォーマット純関数 fermiNumberFormat.ts ＋21テスト、i18n キー整理（orphan 無し）

検証: tsc 0 / eslint 0 / vitest 278 pass / Playwright 119 pass（残1は既存 onboarding flaky）

🤖 Generated with [Claude Code](https://claude.com/claude-code)