### PR TITLE
fix(AF-05 P0): 再ログインでXP/プロフィールが消えるデータ消失を修正【Keita承認待ち: migration DDL + 設計判断】

### DIFF
--- a/docs/TASK_TRACKER.md
+++ b/docs/TASK_TRACKER.md
@@ -45,6 +45,8 @@ Keita から 2026-06-01 に直接報告された不具合・改善依頼3件を�
 | ID | タイトル | 優先度 | ステータス | 担当案 | 由来 |
 |----|---------|--------|-----------|--------|------|
 | AF-05 | 再ログイン後にプロフィール情報とレベル/XP が引き継がれない（データ消失） | P0 | IN_PROGRESS | dev-logic（根因調査→修正）+ test-functional（永続化E2E） | Keita 実機報告 2026-06-01 |
+| AF-07 | ストリークフリーズ在庫（logic-streak-freeze）がログアウトで消失（KEEP_KEYS 漏れ） | P2 | TODO | dev-logic | AF-05 隣接検出（dev-logic 2026-06-01） |
+| AF-08 | UI設定（font-scale / tts-autoplay / tts-rate）がログアウトで初期値に戻る（KEEP_KEYS 漏れ） | P3 | TODO | dev-logic | AF-05 隣接検出（dev-logic 2026-06-01） |
 | UI-30 | ライトテーマで「今日の1位問」のチャレンジするボタンが見にくい | P1 | TODO | dev-logic（コンポーネント特定→統一）+ test-functional（両テーマ視認性） | Keita 実機報告 2026-06-01 |
 | AF-06 | アプリDLサイズ300MB削減：レッスンアセットをオンデマンド読込に | P1 | TODO | dev-logic（計測→設計案）+ designer（アセット最適化調査） | Keita 実機報告 2026-06-01 |
 
@@ -61,6 +63,37 @@ Keita から 2026-06-01 に直接報告された不具合・改善依頼3件を�
   - **回帰**: ゲスト→ログインの移行時にローカルデータを Supabase にマージする経路（`guestUser.ts`）に波及しないか確認。匿名ユーザーの進捗が引き継がれる導線を壊さない。
   - **永続化**: 表示だけでなく user_id 紐付けの保存・再ログイン後の再フェッチまでがスコープ。localStorage キャッシュとリモートの整合（どちらを正にするか）を設計判断として明示。
   - **データ損失の調査優先**: 既存ユーザーの XP が「消えた」のか「フェッチできてないだけ（リモートには在る）」のかを最初に切り分ける。後者なら再フェッチ修正で復旧、前者なら保存が走っていない＝より深刻。
+- 更新日: 2026-06-01
+
+#### AF-07 — ストリークフリーズ在庫（logic-streak-freeze）がログアウトで消失
+- 優先度: P2 / ステータス: TODO / 担当案: dev-logic
+- 由来: **AF-05（再ログインデータ消失）の修正実装中に dev-logic が隣接で検出**（2026-06-01）。同根＝`syncService` の `syncOnLogout` で `KEEP_KEYS` に含まれないキーがログアウト時にクリアされる問題。ただし AF-05（XP/プロフィール）とは別スコープ。
+- 詳細: `logic-streak-freeze`（ストリークフリーズの在庫）が Supabase 同期されておらず、かつ `KEEP_KEYS` 外のため、ログアウト→再ログインで在庫が消える。フリーズは無料配布アイテムで再付与され得るので AF-05 ほど深刻ではないが、購入相当の在庫が消える＝軽微なデータ消失。
+- 想定修正方針（候補・要設計）: (a) `KEEP_KEYS` に `logic-streak-freeze` を追加（端末ローカル保持）、または (b) Supabase 同期化（`profiles` か `user_stats` のどちらに持たせるかは要設計）。在庫＝アカウントに紐づく資産なら (b) が筋だが、フリーズ仕様（無料配布・端末ローカルで十分か）次第。dev-logic が FB-06（ストリークフリーズ実装、`915e622`）の設計と突き合わせて方針確定する。
+- 受け入れ条件(DoD): ログアウト→再ログイン跨ぎでストリークフリーズ在庫が保持される。tsc / eslint . / vitest green。
+- 関連ファイル: `syncService`（`syncOnLogout` / `KEEP_KEYS` 定義箇所）、`src/stats.ts`（ストリーク・フリーズ在庫の保持先）、FB-06 で追加したフリーズ実装箇所、`supabase/migrations/`（(b) 採用時 profiles / user_stats）。
+- 依存: なし（AF-05 と同根だが独立修正可。AF-05 の `KEEP_KEYS` 修正コミットを参照して同じパターンで対応できる）
+- 提言・抜けもれ:
+  - **設計判断**: (a) KEEP 追加で十分か (b) Supabase 同期まで要るかは「フリーズ在庫をアカウント資産として扱うか・端末ローカルで許容か」の仕様判断。dev-logic が方針案を出し、同期化に倒すなら Keita 確認（DB スキーマ追加を伴うため）。
+  - **回帰**: FB-06 のフリーズ付与・消費ロジックに波及しないか確認。
+  - **両OS**: iOS / Android 両方でログアウト挙動を確認（[[project-logic-mobile-only]]）。
+  - **永続化**: 表示だけでなく在庫値の保存・再ログイン後の再表示まで。
+- 注記: AF-05 の修正コミット（branch `fix/af-05-xp-profile-sync`、`69b76de`）では、関連する `logic-journal-xp` / `logic-xp-log` を `KEEP_KEYS` に追加する隣接修正を dev-logic が能動的に実施済み（二重XP付与防止）。本件 AF-07 はそれとは別の未対応分。
+- 更新日: 2026-06-01
+
+#### AF-08 — UI設定（font-scale / tts-autoplay / tts-rate）がログアウトで初期値に戻る
+- 優先度: P3 / ステータス: TODO / 担当案: dev-logic
+- 由来: **AF-05 の修正実装中に dev-logic が隣接で検出**（2026-06-01）。同根＝`syncService` の `syncOnLogout` の `KEEP_KEYS` 漏れ。AF-05 とは別スコープ。
+- 詳細: `logic-font-scale` / `logic-tts-autoplay` / `logic-tts-rate` の3つの端末ローカル UI 設定が `KEEP_KEYS` 漏れのため、ログアウト→再ログインで初期値に戻る。`logic-locale` / `logic-theme` は KEEP されているのに、これらが漏れていて一貫性を欠く。軽微だが UX 改善。
+- 想定修正方針: `KEEP_KEYS` に上記3キーを追加（端末ローカル設定なので Supabase 同期は不要、KEEP で十分）。
+- 受け入れ条件(DoD): ログアウト→再ログイン跨ぎでフォントサイズ・TTS 設定（autoplay / rate）が保持される。tsc / eslint . / vitest green。
+- 関連ファイル: `syncService`（`KEEP_KEYS` 定義箇所。既存 `logic-locale` / `logic-theme` の隣に3キー追加）。
+- 依存: なし（AF-05 と同根。AF-05 の `KEEP_KEYS` 修正と同じ箇所・同じパターン）
+- 提言・抜けもれ:
+  - **一貫性**: `logic-locale` / `logic-theme` が KEEP 済みなのに同種の端末ローカル UI 設定が漏れている＝KEEP_KEYS の網羅性が崩れている。この機会に「端末ローカルで保持すべき UI 設定キー」を棚卸しして漏れがないか全 `logic-*` キーを確認するのを推奨（他にも漏れがあり得る）。
+  - **回帰**: KEEP_KEYS 追加はクリア対象を減らすだけなので副作用は小さいが、ログアウト時に「意図的にクリアしたい」キーを誤って残さないことだけ確認。
+  - **両OS**: iOS / Android 両方で確認（[[project-logic-mobile-only]]）。
+- 注記: AF-05 修正コミット（`69b76de`）で `logic-journal-xp` / `logic-xp-log` の KEEP 追加は実施済み。本件はそれとは別の未対応分。AF-07 と合わせて KEEP_KEYS 漏れの是正バッチとして1コミットにまとめても可（dev-logic 判断）。
 - 更新日: 2026-06-01
 
 #### UI-30 — ライトテーマで「今日の1位問」のチャレンジするボタンが見にくい

--- a/src/__tests__/stats.test.ts
+++ b/src/__tests__/stats.test.ts
@@ -3,10 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // stats.ts は syncService を import するが、syncService は Supabase + flashcards 等
 // 大量の依存を芋づる的に持ち込む。unit test では同期処理を無効化して純粋な
 // localStorage 計算ロジックだけを検証する。
+const mockGetSyncUser = vi.fn<() => string | null>(() => null)
+const mockPushXp = vi.fn<(xp: number) => Promise<void>>(async () => undefined)
+
 vi.mock('../syncService', () => ({
   pushProgress: vi.fn(),
   pushDisplayName: vi.fn(async () => undefined),
-  getSyncUser: () => null,
+  pushXp: (xp: number) => mockPushXp(xp),
+  getSyncUser: () => mockGetSyncUser(),
 }))
 
 // completionCountDb は Supabase 同期側も持つので、localStorage 部分のみ実コードを
@@ -15,6 +19,8 @@ vi.mock('../syncService', () => ({
 describe('stats.ts', () => {
   beforeEach(() => {
     localStorage.clear()
+    mockGetSyncUser.mockReturnValue(null)
+    mockPushXp.mockClear()
   })
 
   afterEach(() => {
@@ -297,6 +303,46 @@ describe('stats.ts', () => {
       // 同じ 25 日にもう 1 レッスン完了しても節目は跨がない
       recordCompletion('lesson-25b')
       expect(getStreakFreezeCount()).toBe(1)
+    })
+  })
+
+  // AF-05: XP の加算・クランプと、Supabase push 結線の回帰テスト。
+  describe('XP (addXp / addXP)', () => {
+    it('accumulates event XP and persists to localStorage', async () => {
+      const { addXp, getXp } = await import('../stats')
+      addXp('lesson') // +50
+      addXp('streak') // +10
+      expect(getXp()).toBe(60)
+      expect(localStorage.getItem('logic-xp')).toBe('60')
+    })
+
+    it('clamps XP at STATS_MAX_XP (50399)', async () => {
+      const { addXP, getXp } = await import('../stats')
+      addXP(99999)
+      expect(getXp()).toBe(50399)
+    })
+
+    it('does NOT push to server when logged out (getSyncUser null)', async () => {
+      mockGetSyncUser.mockReturnValue(null)
+      const { addXp } = await import('../stats')
+      addXp('lesson')
+      expect(mockPushXp).not.toHaveBeenCalled()
+    })
+
+    it('pushes the new cumulative XP to profiles.xp when logged in (AF-05)', async () => {
+      mockGetSyncUser.mockReturnValue('user-uuid-123')
+      const { addXp } = await import('../stats')
+      addXp('lesson') // +50
+      addXp('fermi')  // +30 → cumulative 80
+      expect(mockPushXp).toHaveBeenCalledTimes(2)
+      expect(mockPushXp).toHaveBeenLastCalledWith(80)
+    })
+
+    it('addXP (custom amount) also pushes cumulative XP when logged in', async () => {
+      mockGetSyncUser.mockReturnValue('user-uuid-123')
+      const { addXP } = await import('../stats')
+      addXP(15)
+      expect(mockPushXp).toHaveBeenLastCalledWith(15)
     })
   })
 })

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,4 +1,4 @@
-import { pushProgress, pushDisplayName, getSyncUser } from './syncService'
+import { pushProgress, pushDisplayName, getSyncUser, pushXp } from './syncService'
 import { incrementCompletionCount } from './db/completionCountDb'
 
 const STORAGE_KEY = 'logic-stats'
@@ -417,11 +417,21 @@ export function getXp(): number {
   } catch { return 0 }
 }
 
+/**
+ * 累積 XP を Supabase profiles.xp へ push する (AF-05)。
+ * - 認証済みのときだけ実行 (getSyncUser() あり)
+ * - fire-and-forget。失敗しても UX を止めない (pushXp 側で握り潰す)
+ */
+function syncXpToServer(xp: number): void {
+  if (getSyncUser()) void pushXp(xp)
+}
+
 export function addXp(event: XpEvent): number {
   const gained = XP_REWARDS[event]
   const newXp = Math.min(getXp() + gained, STATS_MAX_XP)
   localStorage.setItem(XP_KEY, String(newXp))
   appendXpLog(event, gained)
+  syncXpToServer(newXp)
   return newXp
 }
 
@@ -429,6 +439,7 @@ export function addXp(event: XpEvent): number {
 export function addXP(amount: number): number {
   const newXp = Math.min(getXp() + amount, STATS_MAX_XP)
   localStorage.setItem(XP_KEY, String(newXp))
+  syncXpToServer(newXp)
   try {
     const log: XpLogEntry[] = JSON.parse(localStorage.getItem(XP_LOG_KEY) || '[]')
     log.push({ ts: Date.now(), event: 'lesson' as XpEvent, xp: amount })

--- a/src/syncService.ts
+++ b/src/syncService.ts
@@ -292,6 +292,52 @@ export async function pullOccupation(): Promise<string | null> {
   }
 }
 
+// ---- XP (profiles.xp) 同期 ----
+
+/**
+ * 累積 XP を Supabase profiles.xp へ upsert する。
+ * - 未ログインや Supabase 未設定時は no-op
+ * - migration 036 未適用環境では列が無いため失敗するが UX を止めない
+ *   ("column xp does not exist" は握り潰す)
+ * - 負値は送らない (0 でクランプ)
+ */
+export async function pushXp(xp: number): Promise<void> {
+  if (!isReady()) return
+  const safeXp = Number.isFinite(xp) ? Math.max(0, Math.floor(xp)) : 0
+  try {
+    const { error } = await supabase!.from('profiles').upsert({
+      id: _currentUserId,
+      xp: safeXp,
+      updated_at: new Date().toISOString(),
+    }, { onConflict: 'id' })
+    if (error) {
+      // migration 036 未適用環境の "column xp does not exist" は無視
+      if (!/\bxp\b/i.test(error.message)) {
+        console.warn('[sync] pushXp failed:', error.message)
+      }
+    }
+  } catch (e) {
+    console.warn('[sync] pushXp failed:', e)
+  }
+}
+
+export async function pullXp(): Promise<number | null> {
+  if (!isReady()) return null
+  try {
+    const { data, error } = await supabase!
+      .from('profiles')
+      .select('xp')
+      .eq('id', _currentUserId)
+      .maybeSingle()
+    if (error || !data) return null
+    const raw = (data.xp as number | null) ?? null
+    if (raw == null || !Number.isFinite(raw)) return null
+    return Math.max(0, Math.floor(raw))
+  } catch {
+    return null
+  }
+}
+
 // ---- 汎用 profile フィールド (birth_year / goal / nickname) 同期 ----
 
 export interface ProfileFieldPatch {
@@ -517,6 +563,55 @@ export async function syncOnLogin(userId: string): Promise<void> {
       }))
     }
 
+    // XP (profiles.xp): local と remote の Math.max マージ (オフライン加算を消さない安全側)。
+    // AF-05: 以前は XP の pull/push が無く、ログアウトで logic-xp を消していたため
+    // 再ログインで XP/レベルが完全消失していた。
+    try {
+      const localXp = parseInt(localStorage.getItem('logic-xp') ?? '0', 10) || 0
+      const remoteXp = await pullXp()
+      const mergedXp = remoteXp != null ? Math.max(localXp, remoteXp) : localXp
+      localStorage.setItem('logic-xp', String(mergedXp))
+      // マージ結果をリモートにも反映 (remote が無かった/古かった場合に揃える)
+      if (remoteXp == null || mergedXp !== remoteXp) {
+        await pushXp(mergedXp)
+      }
+    } catch (e) {
+      console.warn('[sync] XP merge failed:', e)
+    }
+
+    // プロフィール属性 (birth_year / goal / occupation / nickname) を pull して
+    // logic-user-profile / logic-display-name へ書き戻す。
+    // AF-05: 以前は pull が結線されておらず、リモートに保存済みでも再ログインで
+    // 職業・生まれ年・目的が復元されなかった。
+    // リモート優先 (プロフィール編集は明示更新なので、別端末の最新を尊重する)。
+    try {
+      const remoteProfile = await pullProfileFields()
+      if (remoteProfile) {
+        const profileRaw = localStorage.getItem('logic-user-profile')
+        let profile: Record<string, unknown> = {}
+        try {
+          const parsed = profileRaw ? JSON.parse(profileRaw) : {}
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            profile = parsed as Record<string, unknown>
+          }
+        } catch { /* 破損時は空から再構築 */ }
+
+        if (remoteProfile.birthYear != null) profile.birthYear = remoteProfile.birthYear
+        if (remoteProfile.goal != null) profile.goal = remoteProfile.goal
+        if (remoteProfile.occupation != null) profile.occupation = remoteProfile.occupation
+        if (remoteProfile.nickname != null) profile.displayName = remoteProfile.nickname
+
+        localStorage.setItem('logic-user-profile', JSON.stringify(profile))
+
+        // nickname は logic-display-name とも整合させる (上の表示名同期と同じ正本)
+        if (remoteProfile.nickname) {
+          localStorage.setItem('logic-display-name', remoteProfile.nickname)
+        }
+      }
+    } catch (e) {
+      console.warn('[sync] profile fields pull failed:', e)
+    }
+
     if (import.meta.env.DEV) {
       console.log('[sync] Login sync complete. Lessons:', merged.completedLessons.length)
     }
@@ -620,6 +715,16 @@ export async function syncOnLogout(): Promise<void> {
     'logic-guest-id',
     'logic-flashcards',
     'logic-wrong-answers',
+    // XP / レベルはログアウト時に消すと再ログインで完全消失する (AF-05 P0)。
+    // syncOnLogin で profiles.xp と Math.max マージするまでローカルを保持する。
+    // 関連: logic-xp-log (履歴) / logic-journal-xp (朝夜付与フラグ) も
+    // ローカル専用のため保持し、累積 XP との不整合を防ぐ。
+    'logic-xp',
+    'logic-xp-log',
+    'logic-journal-xp',
+    // プロフィール属性 (生まれ年 / 性別 / 職業 / 目的)。profiles へ push 済みだが
+    // pull 復元が確実に効くまでの安全側保持 (AF-05)。
+    'logic-user-profile',
     // 通知設定キーは保持する。OS スケジュールはログアウト後も残るため、
     // pref を消すと UI 上 OFF 表示なのに通知だけ来る不整合になる
     // (REVIEW_REPORT_20260524 高#1)。

--- a/supabase/migrations/036_profile_xp.sql
+++ b/supabase/migrations/036_profile_xp.sql
@@ -1,0 +1,32 @@
+-- 036_profile_xp.sql
+--
+-- AF-05 (P0): 再ログインで XP / レベルが完全消失するデータ消失バグの修正。
+--
+-- 背景:
+--   XP は localStorage `logic-xp` 専用で、Supabase 側に保存先が無かった。
+--   syncOnLogout が logic-xp を消し、syncOnLogin にも pull が無いため、
+--   再ログインで端末からもリモートからも XP が完全消失していた。
+--
+-- 変更内容:
+--   profiles.xp integer カラムを追加 (NOT NULL, default 0)。
+--   level は XP から算出 (getCurrentLevel) するためカラムは不要。
+--
+-- 分離方針:
+--   ランキング用の user_stats (PK = guest_id, ゲスト系統) はそのまま維持し、
+--   profiles.xp とは別物として扱う。profiles.xp は auth user (UUID) に紐づく
+--   「その人の累積 XP」の正準ストア。guest_id 系の集計とは独立。
+--
+-- ロールバック (手動):
+--   alter table public.profiles drop column if exists xp;
+
+alter table public.profiles
+  add column if not exists xp integer not null default 0;
+
+alter table public.profiles
+  drop constraint if exists profiles_xp_nonneg;
+
+alter table public.profiles
+  add constraint profiles_xp_nonneg check (xp >= 0);
+
+comment on column public.profiles.xp is
+  '累積 XP (logic-xp の正準ストア)。level はこの値から算出。ゲスト系 user_stats.xp とは別物。';


### PR DESCRIPTION
## AF-05 (P0) 再ログインでXP/プロフィールが消えるデータ消失バグの修正

Keita 実機報告（2026-06-01）の P0 データ消失バグ。マジックリンク再ログインで XP/レベル・プロフィール属性が消える問題を修正。

### 根因
- XP は localStorage `logic-xp` 専用で Supabase に保存先が無かった
- `syncOnLogout` が `logic-xp` を削除し、`syncOnLogin` に pull が無いため、再ログインで端末からもリモートからも XP/レベルが完全消失
- プロフィール属性（職業/生まれ年/目的/ニックネーム）も profiles へ push 済みなのに pull 未結線で復元されず

### 修正内容
- `syncOnLogout` の KEEP_KEYS に `logic-xp` / `logic-xp-log` / `logic-journal-xp` / `logic-user-profile` を追加 → **同一端末での再ログインは migration 無しでも XP が保持される**（報告症状の根治）
- `syncService`: `pushXp`/`pullXp` 追加。`syncOnLogin` で `Math.max(local, remote)` マージ（オフライン加算を消さない安全側）。migration 未適用環境では graceful no-op（`column xp does not exist` を握り潰す）
- `syncOnLogin` に `pullProfileFields()` を結線しプロフィール復元（既存カラムのみ、migration 不要）
- `migration 036`: `profiles.xp` integer 追加（**本番DDL適用は未実施＝Keita 承認待ち**）
- `stats.test.ts`: XP 加算/クランプ/push 結線の回帰テスト追加

### 検証（green）
- tsc `-b --noEmit`: 0 errors
- eslint `.`（CI スコープ）: 0 errors（warning のみ）
- vitest run: 30 files / 499 passed / 0 fail

### ⚠ マージ前に Keita 承認が必要な2点（autonomous tick では進めない）
1. **migration 036 の本番DDL適用**（`profiles.xp` 追加＝破壊的操作）。これがクロス端末XP同期の前提。コードは graceful degradation 済みなので未適用でもクラッシュしない（同一端末の損失は KEEP_KEYS で既に根治、クロス端末は migration 適用後に有効化）
2. **source-of-truth 設計判断**: XP は `Math.max(local, remote)`、プロフィールはリモート優先。AF-05 提言で「どちらを正にするかを設計判断として明示」と挙げられた論点

### 推奨フォローアップ
- マージ時に test-functional で再ログイン跨ぎの永続化 E2E（DoD 要件）を実施